### PR TITLE
feat: production Terragrunt config and workflows

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -1,0 +1,163 @@
+name: "Terragrunt apply PRODUCTION"
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+  TERRAFORM_VERSION: 1.0.10
+  TERRAGRUNT_VERSION: 0.35.6
+  TF_INPUT: false
+  TF_VAR_ecs_secret_token_secret: ${{ secrets.PRODUCTION_TOKEN_SECRET }}
+  TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID}}
+  TF_VAR_google_client_secret: ${{secrets.PRODUCTION_GOOGLE_CLIENT_SECRET}}
+  TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
+  TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
+  TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+
+jobs:
+
+  # Check the VERSION file to get the target version to deploy and previously deployed version.
+  # These are used to determine which Terraform modules need to have `terraform apply` run.
+  version-manifest:
+    uses: cds-snc/forms-terraform/.github/workflows/version-manifest.yml@main
+
+  terragrunt-apply:
+    needs: version-manifest
+    runs-on: ubuntu-latest
+    env:
+      TARGET_VERSION: v${{ needs.version-manifest.outputs.current }}
+      PREVIOUS_VERSION: v${{ needs.version-manifest.outputs.previous }} 
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - uses: cds-snc/paths-filter@v2.10.3
+        id: filter
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+          base: ${{ env.PREVIOUS_VERSION }}
+          filters: |
+            alarms:
+              - 'aws/alarms/**'
+              - 'env/production/alarms/**'
+            app:
+              - 'aws/app/**'
+              - 'env/production/app/**'
+            common:
+              - '.github/workflows/terragrunt-apply-production.yml'
+              - 'env/common/**'
+              - 'env/terragrunt.hcl'
+              - 'env/production/env_vars.hcl'
+            dynamodb:
+              - 'aws/dynamodb/**'
+              - 'env/production/dynamodb/**'
+            ecr:
+              - 'aws/ecr/**'
+              - 'env/production/ecr/**'
+            hosted_zone:
+              - 'aws/hosted_zone/**'
+              - 'env/production/hosted_zone/**'
+            kms:
+              - 'aws/kms/**'
+              - 'env/production/kms/**'
+            load_balancer:
+              - 'aws/load_balancer/**'
+              - 'env/production/load_balancer/**'
+            network:
+              - 'aws/network/**'
+              - 'env/production/network/**'
+            rds:
+              - 'aws/rds/**'
+              - 'env/production/rds/**'
+            redis:
+              - 'aws/redis/**'
+              - 'env/production/redis/**'
+            sqs:
+              - 'aws/sqs/**'
+              - 'env/production/sqs/**'
+
+      # No dependencies
+      - name: Terragrunt apply ecr
+        if: ${{ steps.filter.outputs.ecr == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/ecr
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/hosted_zone
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply kms
+        if: ${{ steps.filter.outputs.kms == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/kms
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply sqs
+        if: ${{ steps.filter.outputs.sqs == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/sqs
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      # Depends on kms
+      - name: Terragrunt apply network
+        if: ${{ steps.filter.outputs.network == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/network
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply dynamodb
+        if: ${{ steps.filter.outputs.dynamodb == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/dynamodb
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      # Depends on network
+      - name: Terragrunt apply load_balancer
+        if: ${{ steps.filter.outputs.load_balancer == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/load_balancer
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply redis
+        if: ${{ steps.filter.outputs.redis == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/redis
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply rds
+        if: ${{ steps.filter.outputs.rds == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/rds
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      # Depends on everything
+      - name: Install Lambda deps
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        run: ./aws/app/lambda/deps.sh install
+
+      - name: Terragrunt apply app
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/app
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Remove Lambda deps
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        run: ./aws/app/lambda/deps.sh delete
+
+      - name: Terragrunt apply alarms
+        if: ${{ steps.filter.outputs.alarms == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/production/alarms
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve     

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -1,0 +1,236 @@
+name: "Terragrunt plan PRODUCTION"
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.0.10
+  TERRAGRUNT_VERSION: 0.35.6
+  TF_INPUT: false
+  TF_VAR_ecs_secret_token_secret: ${{ secrets.PRODUCTION_TOKEN_SECRET }}
+  TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID}}
+  TF_VAR_google_client_secret: ${{secrets.PRODUCTION_GOOGLE_CLIENT_SECRET}}
+  TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
+  TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
+  TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+
+jobs:
+
+  # Check the VERSION file to get the target version to deploy and previously deployed version.
+  # These are used to determine which Terraform modules need to have `terraform plan` run.
+  version-manifest:
+    uses: cds-snc/forms-terraform/.github/workflows/version-manifest.yml@main
+
+  # Create a comment with a link showing the diff between versions
+  diff-comment:
+    needs: version-manifest
+    uses: cds-snc/forms-terraform/.github/workflows/diff-comment.yml@main
+    with:
+      ref: v${{ needs.version-manifest.outputs.current }}
+      base: v${{ needs.version-manifest.outputs.previous }}
+
+  terragrunt-plan:
+    needs: version-manifest
+    runs-on: ubuntu-latest
+    env:
+      TARGET_VERSION: v${{ needs.version-manifest.outputs.current }}
+      PREVIOUS_VERSION: v${{ needs.version-manifest.outputs.previous }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Install Conftest
+        run: |
+          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
+          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
+          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
+          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
+          && mv conftest /usr/local/bin \
+          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+
+      - uses: cds-snc/paths-filter@v2.10.3
+        id: filter
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+          base: ${{ env.PREVIOUS_VERSION }}
+          filters: |
+            alarms:
+              - 'aws/alarms/**'
+              - 'env/production/alarms/**'
+            app:
+              - 'aws/app/**'
+              - 'env/production/app/**'
+            common:
+              - '.github/workflows/terragrunt-plan-production.yml'
+              - 'env/common/**'
+              - 'env/terragrunt.hcl'
+              - 'env/production/env_vars.hcl'
+            dynamodb:
+              - 'aws/dynamodb/**'
+              - 'env/production/dynamodb/**'
+            ecr:
+              - 'aws/ecr/**'
+              - 'env/production/ecr/**'
+            hosted_zone:
+              - 'aws/hosted_zone/**'
+              - 'env/production/hosted_zone/**'
+            kms:
+              - 'aws/kms/**'
+              - 'env/production/kms/**'
+            load_balancer:
+              - 'aws/load_balancer/**'
+              - 'env/production/load_balancer/**'
+            network:
+              - 'aws/network/**'
+              - 'env/production/network/**'
+            rds:
+              - 'aws/rds/**'
+              - 'env/production/rds/**'
+            redis:
+              - 'aws/redis/**'
+              - 'env/production/redis/**'
+            sqs:
+              - 'aws/sqs/**'
+              - 'env/production/sqs/**'
+
+      # No dependencies
+      - name: Terragrunt plan ecr
+        if: ${{ steps.filter.outputs.ecr == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/ecr"
+          comment-delete: "true"
+          comment-title: "Production: ecr"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/hosted_zone"
+          comment-delete: "true"
+          comment-title: "Production: hosted_zone"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan kms
+        if: ${{ steps.filter.outputs.kms == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/kms"
+          comment-delete: "true"
+          comment-title: "Production: kms"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan sqs
+        if: ${{ steps.filter.outputs.sqs == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/sqs"
+          comment-delete: "true"
+          comment-title: "Production: sqs"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      # Depends on kms
+      - name: Terragrunt plan network
+        if: ${{ steps.filter.outputs.network == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/network"
+          comment-delete: "true"
+          comment-title: "Production: network"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan dynamodb
+        if: ${{ steps.filter.outputs.dynamodb == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/dynamodb"
+          comment-delete: "true"
+          comment-title: "Production: dynamodb"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      # Depends on network
+      - name: Terragrunt plan load_balancer
+        if: ${{ steps.filter.outputs.load_balancer == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/load_balancer"
+          comment-delete: "true"
+          comment-title: "Production: load_balancer"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan redis
+        if: ${{ steps.filter.outputs.redis == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/redis"
+          comment-delete: "true"
+          comment-title: "Production: redis"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan rds
+        if: ${{ steps.filter.outputs.rds == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/rds"
+          comment-delete: "true"
+          comment-title: "Production: rds"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      # Depends on everything
+      - name: Install Lambda deps
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        run: ./aws/app/lambda/deps.sh install
+
+      - name: Terragrunt plan app
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/app"
+          comment-delete: "true"
+          comment-title: "Production: app"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Remove Lambda deps
+        if: ${{ steps.filter.outputs.app == 'true' || steps.filter.outputs.common == 'true' }}
+        run: ./aws/app/lambda/deps.sh delete
+
+      - name: Terragrunt plan alarms
+        if: ${{ steps.filter.outputs.alarms == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/production/alarms"
+          comment-delete: "true"
+          comment-title: "Production: alarms"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# forms-staging-terraform
+# Forms Terraform
 
-Infrastructure as Code for GC Forms Staging environment
+Infrastructure as Code for the GC Forms environment.
 
 ## Running Lambdas and DBs locally
 
 Pre-requisites:
-- Docker  
-- Homebrew  
-- AWS CLI (*configure with staging credentials and “ca-central-1”*)  
+- Docker
+- Homebrew
+- AWS CLI (*configure with staging credentials and “ca-central-1”*)
 - Postgres and PGAdmin
 
 Install AWS SAM-CLI
@@ -23,10 +23,10 @@ In directory:
 Install Lambda dependencies and start local lambda service
 In directory: `./aws/app/lambda/` run the script `./start_local_lambdas.sh`
 
-If you want to invoke a lambda specifically, here’s the example command:  
-`aws lambda invoke --function-name "Templates" --endpoint-url "http://127.0.0.1:3001" --no-verify-ssl --payload fileb://./file.json out.txt`  
-**NOTE:** *`fileb://` allows a JSON file that uses UTF-8 encoding for the payload.*   
-  
+If you want to invoke a lambda specifically, here’s the example command:
+`aws lambda invoke --function-name "Templates" --endpoint-url "http://127.0.0.1:3001" --no-verify-ssl --payload fileb://./file.json out.txt`
+**NOTE:** *`fileb://` allows a JSON file that uses UTF-8 encoding for the payload.*
+
 Otherwise, in the platform-forms-client, you just modify the ‘endpoint’ parameter of the LambdaClient to hit `http://127.0.0.1:3001` . I’ve done this through an environment variable:
 `LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001`
 
@@ -37,4 +37,14 @@ if you get connection errors: postgresql.conf listen address “\*”
 Notes:
 When running locally using AWS SAM, the env var `AWS_SAM_LOCAL = true` is set automatically - so I hook into this for local testing
 
-todo: environment variables
+## Terraform secrets
+Terraform will require the following variables to plan and apply:
+```hcl
+ecs_secret_token_secret # JSON Web Token signing secret
+google_client_id        # Google OAuth client ID (used for authentication)
+google_client_secret:   # Google OAuth client secret (used for authentication)
+notify_api_key          # Notify API key to send messages
+rds_db_password         # Database password
+slack_webhook           # Slack webhook to send CloudWatch notifications
+```
+

--- a/env/production/alarms/terragrunt.hcl
+++ b/env/production/alarms/terragrunt.hcl
@@ -1,0 +1,78 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/alarms?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../hosted_zone", "../kms", "../load_balancer", "../sqs", "../app"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    hosted_zone_id = ""
+  }
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_cloudwatch_arn = ""
+  }
+}
+
+dependency "load_balancer" {
+  config_path = "../load_balancer"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    lb_arn        = ""
+    lb_arn_suffix = ""
+  }
+}
+
+dependency "sqs" {
+  config_path = "../sqs"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    sqs_deadletter_queue_arn = ""
+  }
+}
+
+dependency "app" {
+  config_path = "../app"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    ecs_cloudwatch_log_group_name = ""
+    ecs_cluster_name              = ""
+    ecs_service_name              = "" 
+  }
+}
+
+inputs = {
+  threshold_ecs_cpu_utilization_high    = "50"
+  threshold_ecs_memory_utilization_high = "50"
+  threshold_lb_response_time            = "1"
+
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+
+  kms_key_cloudwatch_arn = dependency.kms.outputs.kms_key_cloudwatch_arn
+
+  lb_arn        = dependency.load_balancer.outputs.lb_arn
+  lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
+
+  sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
+
+  ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
+  ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name
+  ecs_service_name              = dependency.app.outputs.ecs_service_name
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/app/terragrunt.hcl
+++ b/env/production/app/terragrunt.hcl
@@ -1,0 +1,135 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/app?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../kms", "../network", "../dynamodb", "../rds", "../redis", "../sqs", "../load_balancer", "../ecr"]
+}
+
+dependency "dynamodb" {
+  config_path = "../dynamodb"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    dynamodb_relability_queue_arn = ""
+    dynamodb_vault_arn            = ""
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    ecr_repository_url = ""
+  }
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_cloudwatch_arn = ""
+    kms_key_dynamodb_arn   = ""
+  }
+}
+
+dependency "load_balancer" {
+  config_path = "../load_balancer"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    lb_https_listener_arn  = ""
+    lb_target_group_1_arn  = ""
+    lb_target_group_1_name = ""
+    lb_target_group_2_name = ""
+  }
+}
+
+dependency "network" {
+  config_path = "../network"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    private_subnet_ids    = [""]
+  }
+}
+
+dependency "rds" {
+  config_path = "../rds"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    rds_cluster_arn         = ""
+    rds_db_name             = ""
+    database_url_secret_arn = ""
+    database_secret_arn     = ""
+  }
+}
+
+dependency "redis" {
+  config_path = "../redis"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    redis_url = ""
+  }
+}
+
+dependency "sqs" {
+  config_path = "../sqs"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+  sqs_reliability_queue_arn = "" 
+  sqs_reliability_queue_id  = ""
+  }
+}
+
+inputs = {
+  codedeploy_manual_deploy_enabled            = false
+  codedeploy_termination_wait_time_in_minutes = 1
+  ecs_autoscale_enabled                       = true
+  ecs_form_viewer_name                        = "form-viewer"
+  ecs_name                                    = "Forms"
+  ecs_min_tasks                               = 1
+  ecs_max_tasks                               = 2
+  ecs_scale_cpu_threshold                     = 60
+  ecs_scale_memory_threshold                  = 60
+  ecs_scale_in_cooldown                       = 60
+  ecs_scale_out_cooldown                      = 60
+  metric_provider                             = "stdout"
+  tracer_provider                             = "stdout"
+
+  dynamodb_relability_queue_arn = dependency.dynamodb.outputs.dynamodb_relability_queue_arn
+  dynamodb_vault_arn            = dependency.dynamodb.outputs.dynamodb_vault_arn
+
+  ecr_repository_url = dependency.ecr.outputs.ecr_repository_url
+
+  kms_key_cloudwatch_arn = dependency.kms.outputs.kms_key_cloudwatch_arn
+  kms_key_dynamodb_arn   = dependency.kms.outputs.kms_key_dynamodb_arn
+
+  lb_https_listener_arn  = dependency.load_balancer.outputs.lb_https_listener_arn
+  lb_target_group_1_arn  = dependency.load_balancer.outputs.lb_target_group_1_arn
+  lb_target_group_1_name = dependency.load_balancer.outputs.lb_target_group_1_name
+  lb_target_group_2_name = dependency.load_balancer.outputs.lb_target_group_2_name 
+
+  ecs_security_group_id    = dependency.network.outputs.ecs_security_group_id
+  egress_security_group_id = dependency.network.outputs.egress_security_group_id
+  private_subnet_ids       = dependency.network.outputs.private_subnet_ids
+
+  redis_url = dependency.redis.outputs.redis_url
+
+  rds_cluster_arn            = dependency.rds.outputs.rds_cluster_arn
+  rds_db_name                = dependency.rds.outputs.rds_db_name
+  database_secret_arn        = dependency.rds.outputs.database_secret_arn
+  database_url_secret_arn    = dependency.rds.outputs.database_url_secret_arn
+
+  sqs_reliability_queue_arn = dependency.sqs.outputs.sqs_reliability_queue_arn 
+  sqs_reliability_queue_id  = dependency.sqs.outputs.sqs_reliability_queue_id
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/dynamodb/terragrunt.hcl
+++ b/env/production/dynamodb/terragrunt.hcl
@@ -1,0 +1,24 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/dynamodb?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../kms"]
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_dynamodb_arn = ""
+  }
+}
+
+inputs = {
+  kms_key_dynamodb_arn = dependency.kms.outputs.kms_key_dynamodb_arn
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/ecr/terragrunt.hcl
+++ b/env/production/ecr/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/ecr?ref=${get_env("TARGET_VERSION")}"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/env_vars.hcl
+++ b/env/production/env_vars.hcl
@@ -1,0 +1,5 @@
+inputs = {
+  account_id = "957818836222"
+  domain     = "forms-formulaires.alpha.canada.ca"
+  env        = "production"
+}

--- a/env/production/hosted_zone/terragrunt.hcl
+++ b/env/production/hosted_zone/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/hosted_zone?ref=${get_env("TARGET_VERSION")}"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/kms/terragrunt.hcl
+++ b/env/production/kms/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/kms?ref=${get_env("TARGET_VERSION")}"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/load_balancer/terragrunt.hcl
+++ b/env/production/load_balancer/terragrunt.hcl
@@ -1,0 +1,39 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/load_balancer?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../hosted_zone", "../network"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    hosted_zone_id = ""
+  }
+}
+
+dependency "network" {
+  config_path = "../network"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    alb_security_group_id = ""
+    public_subnet_ids     = [""]
+    vpc_id                = ""
+  }
+}
+
+inputs = {
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+
+  alb_security_group_id = dependency.network.outputs.alb_security_group_id
+  public_subnet_ids     = dependency.network.outputs.public_subnet_ids
+  vpc_id                = dependency.network.outputs.vpc_id
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/network/terragrunt.hcl
+++ b/env/production/network/terragrunt.hcl
@@ -1,0 +1,26 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/network?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../kms"]
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_cloudwatch_arn = ""
+  }
+}
+
+inputs = {
+  kms_key_cloudwatch_arn = dependency.kms.outputs.kms_key_cloudwatch_arn
+  vpc_cidr_block         = "172.16.0.0/16"
+  vpc_name               = "forms"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -1,0 +1,31 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/rds?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../network"]
+}
+
+dependency "network" {
+  config_path = "../network"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    private_subnet_ids    = [""]
+    rds_security_group_id = ""
+  }
+}
+
+inputs = {
+  private_subnet_ids    = dependency.network.outputs.private_subnet_ids
+  rds_security_group_id = dependency.network.outputs.rds_security_group_id
+  
+  rds_db_name              = "forms"
+  rds_db_subnet_group_name = "forms-db"
+  rds_db_user              = "postgres"
+  rds_name                 = "forms-db"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/redis/terragrunt.hcl
+++ b/env/production/redis/terragrunt.hcl
@@ -1,0 +1,26 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/redis?ref=${get_env("TARGET_VERSION")}"
+}
+
+dependencies {
+  paths = ["../network"]
+}
+
+dependency "network" {
+  config_path = "../network"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    private_subnet_ids      = [""]
+    redis_security_group_id = ""
+  }
+}
+
+inputs = {
+  private_subnet_ids      = dependency.network.outputs.private_subnet_ids
+  redis_security_group_id = dependency.network.outputs.redis_security_group_id
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/production/sqs/terragrunt.hcl
+++ b/env/production/sqs/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/sqs?ref=${get_env("TARGET_VERSION")}"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary 
Add the Terragrunt configuration that will be used to manage
the production environment.

Add the GitHub workflows that will run Terraform plan
and apply commands.

Update the main README to reflect that this repo is no
longer staging specific.

# Related
* #28 
* cds-snc/platform-sre-security-support#47