### PR TITLE
fix: diff comment and version manifest workflows

### DIFF
--- a/.github/workflows/diff-comment.yml
+++ b/.github/workflows/diff-comment.yml
@@ -36,5 +36,5 @@ jobs:
             github.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
-              body: "## Version diff\n${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/compare/${{ inputs.base }}...${{ inputs.ref }}"
+              body: "## Version diff\nhttps://github.com/cds-snc/forms-terraform/compare/${{ inputs.base }}...${{ inputs.ref }}"
             })

--- a/.github/workflows/version-manifest.yml
+++ b/.github/workflows/version-manifest.yml
@@ -6,7 +6,13 @@ name: "Version manifest"
 
 on:
   workflow_call:
-  workflow_dispatch:
+    outputs:
+      previous:
+        description: "The previous contents of the VERSION manifest"
+        value: ${{ jobs.version-manifest.outputs.previous }}
+      current:
+        description: "The current contents of the VERSION manifest"
+        value: ${{ jobs.version-manifest.outputs.current }}
 
 jobs:
   version-manifest:
@@ -24,7 +30,7 @@ jobs:
         id: versions
         run: |
           PREV_SHA="$(git show -2 --pretty=format:"%h" --no-patch VERSION | tail -n 1)"
-          PREV_VERSION="$(git show ${CURRENT_SHA}:VERSION)"
+          PREV_VERSION="$(git show ${PREV_SHA}:VERSION)"
           CURR_VERSION="$(cat VERSION)"
           echo "PREV_SHA=${PREV_SHA}"
           echo "PREV_VERSION=${PREV_VERSION}"


### PR DESCRIPTION
# Summary
Fix diff comment as it does not have access to workflow
environment variables.

Fix version manifest to expose the job outputs and properly
references the previous commit SHA.

# Related
These were problems identified testing #128 