### PR TITLE
Fix/placeholder_lang_on_email

### DIFF
--- a/aws/app/lambda/reliability/lib/dataLayer.js
+++ b/aws/app/lambda/reliability/lib/dataLayer.js
@@ -108,7 +108,7 @@ function extractFormData(submission, language) {
 function handleType(question, response, language, collector) {
   const qTitle = language === "fr" ? question.properties.titleFr : question.properties.titleEn;
   const qRowLabel =
-    language === "fr" ? question.properties.placeholderFr : question.properties.placeholderFr;
+    language === "fr" ? question.properties.placeholderFr : question.properties.placeholderEn;
   switch (question.type) {
     case "textField":
     case "textArea":


### PR DESCRIPTION
# Summary | Résumé
The placeholder on the dynamic row would always return the french version.
It will now return the proper version depending on the email language.

