### PR TITLE
fix: install Lambda dependencies for prod

### DIFF
--- a/env/production/app/terragrunt.hcl
+++ b/env/production/app/terragrunt.hcl
@@ -1,5 +1,8 @@
+# The source for this module is local since it requires that the `aws/app/lambda` dependencies are installed
+# before running `terraform plan/apply`.  If a remote Terraform module is used, this step can't happen.
+# TODO: switch to using Docker image based Lambdas that would not require the dependency install step.
 terraform {
-  source = "git::https://github.com/cds-snc/forms-terraform//aws/app?ref=${get_env("TARGET_VERSION")}"
+  source = "../../../aws//app"
 }
 
 dependencies {


### PR DESCRIPTION
# Summary
The source for this module must be local since it requires that the
`aws/app/lambda` dependencies are installed before running
`terraform plan/apply`.  If a remote Terraform module is used,
this step can't happen.

A future fix to this would be using Docker images to create
the Lambda functions so that no dependency install step
is required.

# Related
* #128  
