### PR TITLE
fix: add SNS topic permission to invoke Slack Lambda

### DIFF
--- a/aws/alarms/lambda.tf
+++ b/aws/alarms/lambda.tf
@@ -54,6 +54,22 @@ resource "aws_lambda_permission" "notify_slack_ok" {
   source_arn    = aws_sns_topic.alert_ok.arn
 }
 
+resource "aws_lambda_permission" "notify_slack_warning_us_east" {
+  statement_id  = "AllowExecutionFromSNSWarningAlertUSEast"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notify_slack_sns.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.alert_warning_us_east.arn
+}
+
+resource "aws_lambda_permission" "notify_slack_ok_us_east" {
+  statement_id  = "AllowExecutionFromSNSOkAlertUSEast"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notify_slack_sns.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.alert_ok_us_east.arn
+}
+
 #
 # IAM: Notify Slack Lambda
 #


### PR DESCRIPTION
# Summary
Add the Lambda permission required that allows the `us-east-1`
SNS topics to invoke the Slack notify Lambda used by CloudWatch
alarms.

# Related
* #150 
* #130 