### PR TITLE
Attach dynamodb policy to ecs role

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -96,6 +96,11 @@ resource "aws_iam_role_policy_attachment" "s3_forms" {
   policy_arn = aws_iam_policy.forms_s3.arn
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_forms" {
+  role       = aws_iam_role.forms.name
+  policy_arn = aws_iam_policy.forms_dynamodb.arn
+}
+
 #
 # IAM - Dynamo DB
 #

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -96,7 +96,7 @@ resource "aws_iam_role_policy_attachment" "s3_forms" {
   policy_arn = aws_iam_policy.forms_s3.arn
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_task_execution_forms" {
+resource "aws_iam_role_policy_attachment" "dynamodb_forms" {
   role       = aws_iam_role.forms.name
   policy_arn = aws_iam_policy.forms_dynamodb.arn
 }


### PR DESCRIPTION
# Summary | Résumé

Attach the dynamodb policy to the ECS forms role.