### PR TITLE
fix: Change return value from boolean to actual value.

### DIFF
--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -203,8 +203,8 @@ const parseConfig = (records) => {
       formID = record[0].longValue;
       if (record.length > 1) {
         formConfig = JSON.parse(record[1].stringValue.trim(1, -1)) || undefined;
-        organization = record[2].isNull || undefined;
-        bearerToken = record[3].isNull || undefined;
+        organization = record[2] ? record[2] : undefined;
+        bearerToken = record[3] ? record[3] : undefined;
       }
     } else {
       formID = record.id;


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this fix.

**Problem:** This was returning a boolean value for `organization` and `bearerToken` instead of the actual value. It will continue to return `undefined` if the values for `record[2]` or `record[3]` are `null` or `undefined`. 

This only applies when not using the `process.env.AWS_SAM_LOCAL`.

# Test instructions | Instructions pour tester la modification

