### PR TITLE
fix: archiver lambda index name value is wrong

### DIFF
--- a/aws/dynamodb/outputs.tf
+++ b/aws/dynamodb/outputs.tf
@@ -15,5 +15,5 @@ output "dynamodb_vault_table_name" {
 
 output "dynamodb_vault_retrieved_index_name" {
   description = "Vault DynamodDB Retrieved index name"
-  value       = aws_dynamodb_table.vault.global_secondary_index.*.name
+  value       = one(aws_dynamodb_table.vault.global_secondary_index.*.name)
 }


### PR DESCRIPTION
# Summary | Résumé

Fix for following error:

`
End User Forms Critical - Form responses archiver: Failed to retrieve consumed form responses. Reason: 1 validation error detected: Value '["retrieved-index"]' at 'indexName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+.
`