### PR TITLE
Ensure detail from notify api error is captured and logged

### DIFF
--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -51,7 +51,27 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, mes
               reference: submissionID,
             });
         } catch (err) {
-          console.error(err);
+          if (err.response) {
+            /*
+             * The request was made and the server responded with a
+             * status code that falls out of the range of 2xx
+             */
+            const notifyErrors = Array.isArray(err.response.data.errors)
+              ? JSON.stringify(err.response.data.errors)
+              : err.response.data.errors;
+            const errorMessage = `Notify Errored with status code ${err.response.status} and returned the following detailed errors ${notifyErrors}`;
+            console.log(errorMessage);
+          } else if (err.request) {
+            /*
+             * The request was made but no response was received, `error.request`
+             * is an instance of XMLHttpRequest in the browser and an instance
+             * of http.ClientRequest in Node.js
+             */
+            console.log(err.request);
+          } else {
+            // Something happened in setting up the request and triggered an Error
+            console.log(err.message);
+          }
           throw new Error("Problem sending to Notify");
         }
       })


### PR DESCRIPTION
# Summary | Résumé
This PR ensures that when an error array object is returned from the Notify API that it is parsed and printed to the logs to ensure the detail of the issue is captured.

Current displayed error does not provide enough detail to identify the issue:
`data: { errors: [Array], status_code: 400 }`