### PR TITLE
fix: Use `stringValue` for Aurora Postgres.

### DIFF
--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -203,8 +203,8 @@ const parseConfig = (records) => {
       formID = record[0].longValue;
       if (record.length > 1) {
         formConfig = JSON.parse(record[1].stringValue.trim(1, -1)) || undefined;
-        organization = record[2] ? record[2] : undefined;
-        bearerToken = record[3] ? record[3] : undefined;
+        organization = record[2].stringValue ? record[2].stringValue : null;
+        bearerToken = record[3].stringValue ? record[3].stringValue : null;
       }
     } else {
       formID = record.id;


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this fix.

**Problem:** This was returning a JSON object with either:
`{isNull: true}` or 
`{stringValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyFoo3JtSUQiOjIzBariaWF0IjoxNjFoOTI3BAR1LCJleHAiOfO0BaR2ODQ3NDV9.DNxKOAReVOLEXy6zA4BU4vCCL9vaEsiJ5ZbAFOOBAR-h8"}`

It was necessary to access the `.stringValue` property of the object, if it existed.

If there was no value, when returning `undefined`, the `bearerToken` was omitted from the results. Returning `null` solved that issue.

This only applies when not using the process.env.AWS_SAM_LOCAL, because of the differences between Aurora Postgres and Postgres used in development in Docker.

# Test instructions | Instructions pour tester la modification

This Lambda can only be tested after it's been deployed in the AWS Staging environment, since it needs to connect to the Aurora DB, which is not possible in the dev environment.