### PR TITLE
Alarm for error in Reliaiblity Queue processing

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -119,6 +119,39 @@ resource "aws_cloudwatch_metric_alarm" "application_error_warn" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "reliability_error" {
+  name           = "ReliabilityQueueError"
+  pattern        = "Error"
+  log_group_name = var.lambda_reliability_log_group_name
+
+  metric_transformation {
+    name          = "ReliabilityQueueError"
+    namespace     = "forms"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "reliability_error_warn" {
+  alarm_name          = "ReliabilityErrorWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.reliability_error.name
+  namespace           = "forms"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "End User Forms Warning - An error message was detected in the Reliability Queue"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 #
 # Submissions in Dead Letter Queue
 #

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -3,6 +3,11 @@ variable "ecs_cloudwatch_log_group_name" {
   type        = string
 }
 
+variable "lambda_reliability_log_group_name" {
+  description = "Lambda Reliability Queue CloudWatch log group name, used by lambda error metric alarms"
+  type        = string
+}
+
 variable "ecs_cluster_name" {
   description = "ECS cluster name, used by CPU/memory threshold alarms"
   type        = string

--- a/env/production/alarms/terragrunt.hcl
+++ b/env/production/alarms/terragrunt.hcl
@@ -54,9 +54,10 @@ dependency "app" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    ecs_cloudwatch_log_group_name = ""
-    ecs_cluster_name              = ""
-    ecs_service_name              = "" 
+    ecs_cloudwatch_log_group_name     = ""
+    ecs_cluster_name                  = ""
+    ecs_service_name                  = ""
+    lambda_reliability_log_group_name = ""
   }
 }
 
@@ -89,9 +90,10 @@ inputs = {
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 
-  ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
-  ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name
-  ecs_service_name              = dependency.app.outputs.ecs_service_name
+  ecs_cloudwatch_log_group_name     = dependency.app.outputs.ecs_cloudwatch_log_group_name
+  ecs_cluster_name                  = dependency.app.outputs.ecs_cluster_name
+  ecs_service_name                  = dependency.app.outputs.ecs_service_name
+  lambda_reliability_log_group_name = dependency.app.outputs.lambda_reliability_log_group_name
 
   sns_topic_alert_critical_arn        = dependency.sns.outputs.sns_topic_alert_critical_arn
   sns_topic_alert_warning_arn         = dependency.sns.outputs.sns_topic_alert_warning_arn

--- a/env/staging/alarms/terragrunt.hcl
+++ b/env/staging/alarms/terragrunt.hcl
@@ -54,9 +54,10 @@ dependency "app" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    ecs_cloudwatch_log_group_name = ""
-    ecs_cluster_name              = ""
-    ecs_service_name              = "" 
+    ecs_cloudwatch_log_group_name     = ""
+    ecs_cluster_name                  = ""
+    ecs_service_name                  = ""
+    lambda_reliability_log_group_name = ""
   }
 }
 
@@ -89,9 +90,10 @@ inputs = {
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 
-  ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
-  ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name
-  ecs_service_name              = dependency.app.outputs.ecs_service_name
+  ecs_cloudwatch_log_group_name     = dependency.app.outputs.ecs_cloudwatch_log_group_name
+  ecs_cluster_name                  = dependency.app.outputs.ecs_cluster_name
+  ecs_service_name                  = dependency.app.outputs.ecs_service_name
+  lambda_reliability_log_group_name = dependency.app.outputs.lambda_reliability_log_group_name
 
   sns_topic_alert_critical_arn        = dependency.sns.outputs.sns_topic_alert_critical_arn
   sns_topic_alert_warning_arn         = dependency.sns.outputs.sns_topic_alert_warning_arn


### PR DESCRIPTION
# Summary | Résumé

This PR creates an alarm at the warning level when an Error is detected processing form responses in the reliability queue.  This is a first warning sign alarm that should be followed by another warning alarm that a response has been sent to the dead letter queue.

