### PR TITLE
feat: alarm for tracking temporary token request made from outside of Canada

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -346,3 +346,28 @@ resource "aws_cloudwatch_metric_alarm" "route53_ddos" {
     ResourceArn = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}"
   }
 }
+
+#
+# Monitoring alarms
+#
+
+resource "aws_cloudwatch_metric_alarm" "temporary_token_generated_outside_canada_warn" {
+  alarm_name          = "TemporaryTokenGeneratedOutsideCandaWarn"
+  namespace           = "forms"
+  metric_name         = var.temporary_token_generated_outside_canada_metric_name
+  statistic           = "SampleCount"
+  period              = "300"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "0"
+  evaluation_periods  = "1"
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "End User Forms Warning - A temporary token has been generated from outside Canada"
+  alarm_actions     = [var.sns_topic_alert_warning_arn]
+  ok_actions        = [var.sns_topic_alert_ok_arn]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -83,3 +83,8 @@ variable "sns_topic_alert_ok_us_east_arn" {
   description = "SNS topic ARN that ok alerts are sent to (US East)"
   type        = string
 }
+
+variable "temporary_token_generated_outside_canada_metric_name" {
+  description = "Metric tracking request made outside of Canada in order to generate a temporary token"
+  type        = string
+}

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -27,3 +27,8 @@ output "lb_target_group_2_name" {
   description = "Load balancer target group 2 name, used by CodeDeploy to alternate blue/green deployments"
   value       = aws_lb_target_group.form_viewer_2.name
 }
+
+output "temporary_token_generated_outside_canada_metric_name" {
+  description = "Metric tracking request made outside of Canada in order to generate a temporary token"
+  value       = one([for x in aws_wafv2_web_acl.forms_acl.rule : one(x.visibility_config.*.metric_name) if x.name == "TemporaryTokenGeneratedOutsideCanada"])
+}

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -155,6 +155,59 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     }
   }
 
+  rule {
+    # make sure to update line 33 of output.tf if you change the name of the rule
+    name     = "TemporaryTokenGeneratedOutsideCanada"
+    priority = 5
+
+    action {
+      count {}
+    }
+
+    statement {
+
+      and_statement {
+        statement {
+          not_statement {
+            statement {
+              geo_match_statement {
+                country_codes = ["CA"]
+              }
+            }
+          }
+        }
+
+        statement {
+          byte_match_statement {
+
+            field_to_match {
+              uri_path {}
+            }
+
+            positional_constraint = "CONTAINS"
+            search_string         = "/api/token/temporary"
+
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      metric_name                = "TemporaryTokenGeneratedOutsideCanada"
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "forms_global_rule"

--- a/env/production/alarms/terragrunt.hcl
+++ b/env/production/alarms/terragrunt.hcl
@@ -33,8 +33,9 @@ dependency "load_balancer" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    lb_arn        = ""
-    lb_arn_suffix = ""
+    lb_arn                                               = ""
+    lb_arn_suffix                                        = ""
+    temporary_token_generated_outside_canada_metric_name = "tbd"
   }
 }
 
@@ -85,8 +86,9 @@ inputs = {
   kms_key_cloudwatch_arn         = dependency.kms.outputs.kms_key_cloudwatch_arn
   kms_key_cloudwatch_us_east_arn = dependency.kms.outputs.kms_key_cloudwatch_us_east_arn
 
-  lb_arn        = dependency.load_balancer.outputs.lb_arn
-  lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
+  lb_arn                                               = dependency.load_balancer.outputs.lb_arn
+  lb_arn_suffix                                        = dependency.load_balancer.outputs.lb_arn_suffix
+  temporary_token_generated_outside_canada_metric_name = dependency.load_balancer.outputs.temporary_token_generated_outside_canada_metric_name
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 

--- a/env/staging/alarms/terragrunt.hcl
+++ b/env/staging/alarms/terragrunt.hcl
@@ -33,8 +33,9 @@ dependency "load_balancer" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    lb_arn        = ""
-    lb_arn_suffix = ""
+    lb_arn                                               = ""
+    lb_arn_suffix                                        = ""
+    temporary_token_generated_outside_canada_metric_name = "tbd"
   }
 }
 
@@ -85,8 +86,9 @@ inputs = {
   kms_key_cloudwatch_arn         = dependency.kms.outputs.kms_key_cloudwatch_arn
   kms_key_cloudwatch_us_east_arn = dependency.kms.outputs.kms_key_cloudwatch_us_east_arn
 
-  lb_arn        = dependency.load_balancer.outputs.lb_arn
-  lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
+  lb_arn                                               = dependency.load_balancer.outputs.lb_arn
+  lb_arn_suffix                                        = dependency.load_balancer.outputs.lb_arn_suffix
+  temporary_token_generated_outside_canada_metric_name = dependency.load_balancer.outputs.temporary_token_generated_outside_canada_metric_name
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/615

Added alarm to track when a temporary token has been generated from outside of Canada