### PR TITLE
feat: add log metric filter on ECS Log group and associated alarm that will tell us when an expired bearer token has been used

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -371,3 +371,35 @@ resource "aws_cloudwatch_metric_alarm" "temporary_token_generated_outside_canada
     Terraform             = true
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "expired_bearer_token" {
+  name           = "ExpiredBearerToken"
+  pattern        = "expired bearer token"
+  log_group_name = var.ecs_cloudwatch_log_group_name
+  metric_transformation {
+    name      = "ExpiredBearerToken"
+    namespace = "forms"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "expired_bearer_token" {
+  alarm_name          = "ExpiredBearerToken"
+  namespace           = "forms"
+  metric_name         = aws_cloudwatch_log_metric_filter.expired_bearer_token.metric_transformation[0].name
+  statistic           = "SampleCount"
+  period              = "60"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "0"
+  evaluation_periods  = "1"
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "End User Forms Warning - An expired bearer token has been used"
+  alarm_actions     = [var.sns_topic_alert_warning_arn]
+  ok_actions        = [var.sns_topic_alert_ok_arn]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -209,5 +209,3 @@ resource "aws_iam_role_policy_attachment" "codedeploy" {
   role       = aws_iam_role.codedeploy.name
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
 }
-
-


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/617
linked to https://github.com/cds-snc/platform-forms-client/pull/635

- adds log metric filter on ECS log group to catch error when an expired bearer token has been used
- adds alarm to use new expired bearer token metric in order to send Slack warning