### PR TITLE
feat: add log metric filter on ECS Log group and associated alarm that will tell us when we failed to generate temporary token too many times

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -403,3 +403,35 @@ resource "aws_cloudwatch_metric_alarm" "expired_bearer_token" {
     Terraform             = true
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "generate_temporary_token_api_failure" {
+  name           = "GenerateTemporaryTokenApiFailure"
+  pattern        = "Failed to generate temporary token"
+  log_group_name = var.ecs_cloudwatch_log_group_name
+  metric_transformation {
+    name      = "GenerateTemporaryTokenApiFailure"
+    namespace = "forms"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "generate_temporary_token_api_failure" {
+  alarm_name          = "GenerateTemporaryTokenApiFailure"
+  namespace           = "forms"
+  metric_name         = aws_cloudwatch_log_metric_filter.generate_temporary_token_api_failure.metric_transformation[0].name
+  statistic           = "SampleCount"
+  period              = "300"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "5"
+  evaluation_periods  = "1"
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "End User Forms Warning - Failed to generate temporary token too many times"
+  alarm_actions     = [var.sns_topic_alert_warning_arn]
+  ok_actions        = [var.sns_topic_alert_ok_arn]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/616
linked to https://github.com/cds-snc/platform-forms-client/pull/636

- adds log metric filter on ECS log group to catch error when we failed to generate a temporary token too many times
- adds alarm to use new "failed to generate a temporary token too many times" metric in order to send Slack warning