### PR TITLE
fix: TemporaryTokenGeneratedOutsideCanadaWarn alarm not using the right triggering metric

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -352,15 +352,20 @@ resource "aws_cloudwatch_metric_alarm" "route53_ddos" {
 #
 
 resource "aws_cloudwatch_metric_alarm" "temporary_token_generated_outside_canada_warn" {
-  alarm_name          = "TemporaryTokenGeneratedOutsideCandaWarn"
-  namespace           = "forms"
-  metric_name         = var.temporary_token_generated_outside_canada_metric_name
+  alarm_name          = "TemporaryTokenGeneratedOutsideCanadaWarn"
+  namespace           = "AWS/WAFV2"
+  metric_name         = "CountedRequests"
   statistic           = "SampleCount"
   period              = "300"
   comparison_operator = "GreaterThanThreshold"
   threshold           = "0"
   evaluation_periods  = "1"
   treat_missing_data  = "notBreaching"
+  dimensions = {
+    Region = "ca-central-1"
+    Rule   = "TemporaryTokenGeneratedOutsideCanada"
+    WebACL = "GCForms"
+  }
 
   alarm_description = "End User Forms Warning - A temporary token has been generated from outside Canada"
   alarm_actions     = [var.sns_topic_alert_warning_arn]

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -83,8 +83,3 @@ variable "sns_topic_alert_ok_us_east_arn" {
   description = "SNS topic ARN that ok alerts are sent to (US East)"
   type        = string
 }
-
-variable "temporary_token_generated_outside_canada_metric_name" {
-  description = "Metric tracking request made outside of Canada in order to generate a temporary token"
-  type        = string
-}

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -27,8 +27,3 @@ output "lb_target_group_2_name" {
   description = "Load balancer target group 2 name, used by CodeDeploy to alternate blue/green deployments"
   value       = aws_lb_target_group.form_viewer_2.name
 }
-
-output "temporary_token_generated_outside_canada_metric_name" {
-  description = "Metric tracking request made outside of Canada in order to generate a temporary token"
-  value       = one([for x in aws_wafv2_web_acl.forms_acl.rule : one(x.visibility_config.*.metric_name) if x.name == "TemporaryTokenGeneratedOutsideCanada"])
-}

--- a/env/production/alarms/terragrunt.hcl
+++ b/env/production/alarms/terragrunt.hcl
@@ -33,9 +33,8 @@ dependency "load_balancer" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    lb_arn                                               = ""
-    lb_arn_suffix                                        = ""
-    temporary_token_generated_outside_canada_metric_name = "tbd"
+    lb_arn        = ""
+    lb_arn_suffix = ""
   }
 }
 
@@ -86,9 +85,8 @@ inputs = {
   kms_key_cloudwatch_arn         = dependency.kms.outputs.kms_key_cloudwatch_arn
   kms_key_cloudwatch_us_east_arn = dependency.kms.outputs.kms_key_cloudwatch_us_east_arn
 
-  lb_arn                                               = dependency.load_balancer.outputs.lb_arn
-  lb_arn_suffix                                        = dependency.load_balancer.outputs.lb_arn_suffix
-  temporary_token_generated_outside_canada_metric_name = dependency.load_balancer.outputs.temporary_token_generated_outside_canada_metric_name
+  lb_arn        = dependency.load_balancer.outputs.lb_arn
+  lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 

--- a/env/staging/alarms/terragrunt.hcl
+++ b/env/staging/alarms/terragrunt.hcl
@@ -20,7 +20,7 @@ dependency "kms" {
   config_path = "../kms"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs_merge_with_state           = true  
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     kms_key_cloudwatch_arn         = ""
     kms_key_cloudwatch_us_east_arn = ""
@@ -33,9 +33,8 @@ dependency "load_balancer" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    lb_arn                                               = ""
-    lb_arn_suffix                                        = ""
-    temporary_token_generated_outside_canada_metric_name = "tbd"
+    lb_arn        = ""
+    lb_arn_suffix = ""
   }
 }
 
@@ -86,9 +85,8 @@ inputs = {
   kms_key_cloudwatch_arn         = dependency.kms.outputs.kms_key_cloudwatch_arn
   kms_key_cloudwatch_us_east_arn = dependency.kms.outputs.kms_key_cloudwatch_us_east_arn
 
-  lb_arn                                               = dependency.load_balancer.outputs.lb_arn
-  lb_arn_suffix                                        = dependency.load_balancer.outputs.lb_arn_suffix
-  temporary_token_generated_outside_canada_metric_name = dependency.load_balancer.outputs.temporary_token_generated_outside_canada_metric_name
+  lb_arn        = dependency.load_balancer.outputs.lb_arn
+  lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
 
   sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
 


### PR DESCRIPTION
# Summary | Résumé

- Fixed TemporaryTokenGeneratedOutsideCanadaWarn alarm not using the right triggering metric