### PR TITLE
feat: alarm 5xx errors

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -101,18 +101,16 @@ resource "aws_cloudwatch_log_metric_filter" "application_error" {
 
 resource "aws_cloudwatch_metric_alarm" "5xx_error_warn" {
   alarm_name          = "HTTPCode_ELB_5XX_Count"
+  alarm_description   = "ELB Warning - 5xx Error exceed threshold."  
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_ELB_5XX_Count"
   namespace           = "forms"
-  period              = "60"
+  period              = "300"
   statistic           = "Sum"
-  threshold           = "0"
+  threshold           = "10"
   treat_missing_data  = "notBreaching"
-  alarm_description   = "ELB Warning - 5xx Error exceed threshold."
-
-  alarm_actions = [var.sns_topic_alert_warning_arn]
-
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -99,6 +99,26 @@ resource "aws_cloudwatch_log_metric_filter" "application_error" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "5xx_error_warn" {
+  alarm_name          = "HTTPCode_ELB_5XX_Count"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = HTTPCode_ELB_5XX_Count
+  namespace           = "forms"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ELB Warning - 5xx Error exceed threshold."
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "application_error_warn" {
   alarm_name          = "ApplicationErrorWarn"
   comparison_operator = "GreaterThanThreshold"

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_log_metric_filter" "application_error" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "5xx_error_warn" {
+resource "aws_cloudwatch_metric_alarm" "ELB_5xx_error_warn" {
   alarm_name          = "HTTPCode_ELB_5XX_Count"
   alarm_description   = "ELB Warning - 5xx Error exceed threshold."  
   comparison_operator = "GreaterThanThreshold"

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -105,10 +105,10 @@ resource "aws_cloudwatch_metric_alarm" "5xx_error_warn" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_ELB_5XX_Count"
-  namespace           = "forms"
+  namespace           = "AWS/ApplicationELB"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "10"
+  threshold           = "1"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
   tags = {

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_metric_alarm" "5xx_error_warn" {
   alarm_name          = "HTTPCode_ELB_5XX_Count"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = HTTPCode_ELB_5XX_Count
+  metric_name         = "HTTPCode_ELB_5XX_Count"
   namespace           = "forms"
   period              = "60"
   statistic           = "Sum"

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_log_metric_filter" "application_error" {
 
 resource "aws_cloudwatch_metric_alarm" "ELB_5xx_error_warn" {
   alarm_name          = "HTTPCode_ELB_5XX_Count"
-  alarm_description   = "ELB Warning - 5xx Error exceed threshold."  
+  alarm_description   = "ELB Warning - 5xx Error exceed threshold."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_ELB_5XX_Count"


### PR DESCRIPTION
# Summary | Résumé

API call failure rates (500 http errors)

Closes #618
https://github.com/cds-snc/platform-forms-client/issues/618

# Test instructions | Instructions pour tester la modification

This will need to be deployed to **Staging**, and then some 500 errors will need to be triggered to test that the alarm goes off.
