### PR TITLE
fix: error with DyanamoDB SubmissionTimestamp key

### DIFF
--- a/aws/app/lambda/submission/submission.js
+++ b/aws/app/lambda/submission/submission.js
@@ -12,12 +12,9 @@ const formatError = (err) => {
 
 // Store questions with responses
 exports.handler = async function (event) {
+  const submissionID = uuid.v4()
   try {
-    const formData = event;
-    const submissionID = uuid.v4();
- 
-    //-----------
-    await saveData(submissionID, formData)
+    await saveData(submissionID, event)
     const receiptID = await sendData(submissionID)
     // Update DB entry for receipt ID
     await saveReceipt(submissionID, receiptID);
@@ -66,7 +63,7 @@ const saveData = async (submissionID, formData) => {
       SendReceipt: { S: "unknown" },
       FormSubmissionLanguage: {S: formData.language},
       FormData: { S: formSubmission },
-      SubmissionTimestamp: { N: new Date().getTime() }
+      SubmissionTimestamp: { N: `${Date.now()}`}
     },
   };
   //save data to DynamoDB


### PR DESCRIPTION
# Summary | Résumé

* Fixed submissionID reference error due to catch block not having access to block scoped submissionID in the try block
* Fixed SubmissionTimestamp value needing to be a string 

# Test instructions | Instructions pour tester la modification

N/A
