### PR TITLE
Feature/gc notify callback integration

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -22,6 +22,7 @@ env:
   TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
 jobs:
   # Check the VERSION file to get the target version to deploy and previously deployed version.

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -25,6 +25,7 @@ env:
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
+  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
 jobs:
   terragrunt-apply:

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -23,6 +23,7 @@ env:
   TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
 jobs:
   # Check the VERSION file to get the target version to deploy and previously deployed version.

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -24,6 +24,7 @@ env:
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
+  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
 jobs:
   terragrunt-plan:

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -23,25 +23,26 @@ data "template_file" "form_viewer_task" {
   template = file("ecs_task/form_viewer.json")
 
   vars = {
-    image                    = var.ecr_repository_url
-    awslogs-group            = aws_cloudwatch_log_group.forms.name
-    awslogs-region           = var.region
-    awslogs-stream-prefix    = "ecs-${var.ecs_form_viewer_name}"
-    metric_provider          = var.metric_provider
-    tracer_provider          = var.tracer_provider
-    notify_api_key           = aws_secretsmanager_secret_version.notify_api_key.arn
-    google_client_id         = aws_secretsmanager_secret_version.google_client_id.arn
-    google_client_secret     = aws_secretsmanager_secret_version.google_client_secret.arn
-    recaptcha_secret         = aws_secretsmanager_secret_version.recaptcha_secret.arn
-    recaptcha_public         = var.recaptcha_public
-    token_secret             = aws_secretsmanager_secret_version.token_secret.arn
-    database_url             = var.database_url_secret_arn
-    redis_url                = var.redis_url
-    nextauth_url             = "https://${var.domain}"
-    submission_api           = aws_lambda_function.submission.arn
-    templates_api            = aws_lambda_function.templates.arn
-    organizations_api        = aws_lambda_function.organizations.arn
-    reliability_file_storage = aws_s3_bucket.reliability_file_storage.id
+    image                           = var.ecr_repository_url
+    awslogs-group                   = aws_cloudwatch_log_group.forms.name
+    awslogs-region                  = var.region
+    awslogs-stream-prefix           = "ecs-${var.ecs_form_viewer_name}"
+    metric_provider                 = var.metric_provider
+    tracer_provider                 = var.tracer_provider
+    notify_api_key                  = aws_secretsmanager_secret_version.notify_api_key.arn
+    google_client_id                = aws_secretsmanager_secret_version.google_client_id.arn
+    google_client_secret            = aws_secretsmanager_secret_version.google_client_secret.arn
+    recaptcha_secret                = aws_secretsmanager_secret_version.recaptcha_secret.arn
+    recaptcha_public                = var.recaptcha_public
+    gc_notify_callback_bearer_token = aws_secretsmanager_secret_version.gc_notify_callback_bearer_token.arn
+    token_secret                    = aws_secretsmanager_secret_version.token_secret.arn
+    database_url                    = var.database_url_secret_arn
+    redis_url                       = var.redis_url
+    nextauth_url                    = "https://${var.domain}"
+    submission_api                  = aws_lambda_function.submission.arn
+    templates_api                   = aws_lambda_function.templates.arn
+    organizations_api               = aws_lambda_function.organizations.arn
+    reliability_file_storage        = aws_s3_bucket.reliability_file_storage.id
   }
 }
 

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -48,7 +48,8 @@ data "aws_iam_policy_document" "forms_secrets_manager" {
       aws_secretsmanager_secret_version.google_client_secret.arn,
       aws_secretsmanager_secret_version.recaptcha_secret.arn,
       aws_secretsmanager_secret_version.notify_api_key.arn,
-      aws_secretsmanager_secret_version.token_secret.arn
+      aws_secretsmanager_secret_version.token_secret.arn,
+      aws_secretsmanager_secret_version.gc_notify_callback_bearer_token.arn
     ]
   }
 }

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -107,6 +107,42 @@ resource "aws_iam_role_policy_attachment" "dynamodb_forms" {
   policy_arn = aws_iam_policy.forms_dynamodb.arn
 }
 
+resource "aws_iam_role_policy_attachment" "sqs_forms" {
+  role       = aws_iam_role.forms.name
+  policy_arn = aws_iam_policy.forms_sqs.arn
+}
+
+#
+# IAM - SQS
+#
+
+resource "aws_iam_policy" "forms_sqs" {
+  name        = "forms_sqs"
+  path        = "/"
+  description = "IAM policy to allow access to SQS for Forms ECS task"
+  policy      = data.aws_iam_policy_document.forms_sqs.json
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+data "aws_iam_policy_document" "forms_sqs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      var.sqs_reprocess_submission_queue_arn
+    ]
+  }
+}
+
 #
 # IAM - KMS (for encryption key access - needed for Dynamob DB)
 #

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -82,6 +82,10 @@
       {
         "name": "TOKEN_SECRET",
         "valueFrom": "${token_secret}"
+      },
+      {
+        "name": "GC_NOTIFY_CALLBACK_BEARER_TOKEN",
+        "valueFrom": "${gc_notify_callback_bearer_token}"
       }
     ]
   }

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -184,6 +184,11 @@ variable "sqs_reliability_queue_arn" {
   type        = string
 }
 
+variable "sqs_reprocess_submission_queue_arn" {
+  description = "SQS reprocess submission queue ARN"
+  type        = string
+}
+
 variable "tracer_provider" {
   description = "Tracer provider, used by the ECS task"
   type        = string

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -114,6 +114,12 @@ variable "recaptcha_public" {
   type        = string
 }
 
+variable "gc_notify_callback_bearer_token" {
+  description = "GC Notify callback bearer token which will be used as an authentication factor in GC Forms"
+  type        = string
+  sensitive   = true
+}
+
 variable "kms_key_cloudwatch_arn" {
   description = "CloudWatch KMS key ARN, used by the ECS task's CloudWatch log group"
   type        = string

--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -97,6 +97,13 @@ resource "aws_lambda_event_source_mapping" "reliability" {
   enabled          = true
 }
 
+resource "aws_lambda_event_source_mapping" "reprocess_submission" {
+  event_source_arn = var.sqs_reprocess_submission_queue_arn
+  function_name    = aws_lambda_function.reliability.arn
+  batch_size       = 1
+  enabled          = true
+}
+
 #
 # Form Submission API processing
 #

--- a/aws/app/lambda/reliability/lib/dataLayer.js
+++ b/aws/app/lambda/reliability/lib/dataLayer.js
@@ -20,18 +20,6 @@ async function getSubmission(message) {
   return await db.send(new GetItemCommand(DBParams));
 }
 
-async function removeSubmission(message) {
-  const db = new DynamoDBClient({ region: REGION, endpoint: process.env.AWS_SAM_LOCAL ? "http://host.docker.internal:4566": undefined });
-  const DBParams = {
-    TableName: "ReliabilityQueue",
-    Key: {
-      SubmissionID: { S: message.submissionID },
-    },
-  };
-  //remove data fron DynamoDB
-  return await db.send(new DeleteItemCommand(DBParams));
-}
-
 async function saveToVault(submissionID, formResponse, formID) {
   const db = new DynamoDBClient({ region: REGION, endpoint: process.env.AWS_SAM_LOCAL ? "http://host.docker.internal:4566": undefined });
   const formSubmission =
@@ -201,7 +189,6 @@ function formatError(err) {
 
 module.exports = {
   getSubmission,
-  removeSubmission,
   extractFileInputResponses,
   extractFormData,
   saveToVault,

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -1,10 +1,7 @@
 const { NotifyClient } = require("notifications-node-client");
 const convertMessage = require("markdown");
-const { removeSubmission, formatError, extractFileInputResponses } = require("dataLayer");
-const {
-  retrieveFilesFromReliabilityStorage,
-  removeFilesFromReliabilityStorage,
-} = require("s3FileInput");
+const { extractFileInputResponses } = require("dataLayer");
+const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 
 module.exports = async (submissionID, sendReceipt, formSubmission, language, message) => {
   const templateID = "92096ac6-1cc5-40ae-9052-fffdb8439a90";
@@ -78,21 +75,11 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, mes
       .catch((err) => {
         throw new Error(`Sending to Notify error: ${JSON.stringify(err)}`);
       })
-      .then(async () => await removeFilesFromReliabilityStorage(fileInputPaths))
       .then(async () => {
         console.log(
           `{"status": "success", "submissionID": "${submissionID}", "sqsMessage":"${sendReceipt}", "method":"notify"}`
         );
-        // Remove data
-        return await removeSubmission(message).catch((err) => {
-          // Not throwing an error back to SQS because the message was
-          // sucessfully processed by Notify.  Only cleanup required.
-          console.warn(
-            `{"status": "failed", "submissionID": "${submissionID}", "error": "Can not delete entry from reliability db.  Error:${formatError(
-              err
-            )}", "method":"notify"}`
-          );
-        });
+        return Promise.resolve();
       });
   } else {
     throw Error("Form can not be submitted due to missing Submission Parameters");

--- a/aws/app/lambda/reliability/lib/s3FileInput.js
+++ b/aws/app/lambda/reliability/lib/s3FileInput.js
@@ -75,19 +75,7 @@ async function copyFilesFromReliabilityToVaultStorage(filePaths) {
   }
 }
 
-async function removeFilesFromReliabilityStorage(filePaths) {
-  for (const filePath of filePaths) {
-    const commandInput = {
-      Bucket: reliabilityBucketName,
-      Key: filePath,
-    };
-
-    await s3Client.send(new DeleteObjectCommand(commandInput));
-  }
-}
-
 module.exports = {
   retrieveFilesFromReliabilityStorage,
   copyFilesFromReliabilityToVaultStorage,
-  removeFilesFromReliabilityStorage,
 };

--- a/aws/app/lambda/reliability/lib/vaultProcessing.js
+++ b/aws/app/lambda/reliability/lib/vaultProcessing.js
@@ -1,20 +1,9 @@
-const {
-  saveToVault,
-  removeSubmission,
-  formatError,
-  extractFileInputResponses,
-} = require("dataLayer");
-const {
-  copyFilesFromReliabilityToVaultStorage,
-  removeFilesFromReliabilityStorage,
-} = require("s3FileInput");
+const { saveToVault, extractFileInputResponses } = require("dataLayer");
+const { copyFilesFromReliabilityToVaultStorage } = require("s3FileInput");
 
 module.exports = async (submissionID, sendReceipt, formSubmission, formID, message) => {
   const fileInputPaths = extractFileInputResponses(formSubmission);
   return await copyFilesFromReliabilityToVaultStorage(fileInputPaths)
-    .then(async () => {
-      return await removeFilesFromReliabilityStorage(fileInputPaths);
-    })
     .then(async () => await saveToVault(submissionID, formSubmission.responses, formID))
     .catch((err) => {
       throw new Error(`Saving to Vault error: ${formatErr(err)}`);
@@ -23,15 +12,6 @@ module.exports = async (submissionID, sendReceipt, formSubmission, formID, messa
       console.log(
         `{"status": "success", "submissionID": "${submissionID}", "sqsMessage":"${sendReceipt}", "method":"vault"}`
       );
-      // Remove data
-      return await removeSubmission(message).catch((err) => {
-        // Not throwing an error back to SQS because the message was
-        // sucessfully processed by the vault.  Only cleanup required.
-        console.warn(
-          `{"status": "failed", "submissionID": "${submissionID}", "error": "Can not delete entry from reliability db.  Error:${formatError(
-            err
-          )}", "method":"vault" }`
-        );
-      });
+      return Promise.resolve();
     });
 };

--- a/aws/app/lambda/submission/submission.js
+++ b/aws/app/lambda/submission/submission.js
@@ -58,6 +58,8 @@ const sendData = async (submissionID) => {
 const saveData = async (submissionID, formData) => {
   const formSubmission = typeof formData === "string" ? formData : JSON.stringify(formData);
 
+  const expiringTime = (Math.floor(Date.now() / 1000) + 172800).toString(); // expire after 48 hours
+
   const DBParams = {
     TableName: "ReliabilityQueue",
     Item: {
@@ -66,6 +68,7 @@ const saveData = async (submissionID, formData) => {
       SendReceipt: { S: "unknown" },
       FormSubmissionLanguage: {S: formData.language},
       FormData: { S: formSubmission },
+      TTL: { N: expiringTime },
     },
   };
   //save data to DynamoDB

--- a/aws/app/s3.tf
+++ b/aws/app/s3.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "reliability_file_storage" {
     enabled = true
 
     expiration {
-      days = 5
+      days = 2
     }
   }
   server_side_encryption_configuration {

--- a/aws/app/secrets.tf
+++ b/aws/app/secrets.tf
@@ -75,3 +75,18 @@ resource "aws_secretsmanager_secret_version" "recaptcha_secret" {
   secret_id     = aws_secretsmanager_secret.recaptcha_secret.id
   secret_string = var.recaptcha_secret
 }
+
+resource "aws_secretsmanager_secret" "gc_notify_callback_bearer_token" {
+  name                    = "gc_notify_callback_bearer_token"
+  recovery_window_in_days = 0
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "gc_notify_callback_bearer_token" {
+  secret_id     = aws_secretsmanager_secret.gc_notify_callback_bearer_token.id
+  secret_string = var.gc_notify_callback_bearer_token
+}

--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -9,6 +9,11 @@ resource "aws_dynamodb_table" "reliability_queue" {
     type = "S"
   }
 
+  ttl {
+    enabled        = true
+    attribute_name = "TTL"
+  }
+
   server_side_encryption {
     enabled     = true
     kms_key_arn = var.kms_key_dynamodb_arn

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -8,6 +8,11 @@ output "sqs_reliability_queue_arn" {
   value       = aws_sqs_queue.reliability_queue.arn
 }
 
+output "sqs_reprocess_submission_queue_arn" {
+  description = "SQS reprocess submission queue ARN"
+  value       = aws_sqs_queue.reprocess_submission_queue.arn
+}
+
 output "sqs_deadletter_queue_arn" {
   description = "Reliability queue's dead-letter queue ARN"
   value       = aws_sqs_queue.deadletter_queue.name

--- a/env/local/app/terragrunt.hcl
+++ b/env/local/app/terragrunt.hcl
@@ -95,8 +95,9 @@ inputs = {
   database_secret_arn        = ""
   database_url_secret_arn    = ""
 
-  sqs_reliability_queue_arn = ""
-  sqs_reliability_queue_id  = ""
+  sqs_reliability_queue_arn          = ""
+  sqs_reliability_queue_id           = ""
+  sqs_reprocess_submission_queue_arn = ""
 }
 
 remote_state {

--- a/env/local/app/terragrunt.hcl
+++ b/env/local/app/terragrunt.hcl
@@ -66,6 +66,7 @@ inputs = {
   notify_api_key                              = "local"
   rds_db_password                             = "local"
   slack_webhook                               = "local"
+  gc_notify_callback_bearer_token             = "local"
 
   sns_topic_alert_critical_arn  = ""
 

--- a/env/production/app/terragrunt.hcl
+++ b/env/production/app/terragrunt.hcl
@@ -87,9 +87,11 @@ dependency "sqs" {
   config_path = "../sqs"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
-  sqs_reliability_queue_arn = "" 
-  sqs_reliability_queue_id  = ""
+    sqs_reliability_queue_arn          = "" 
+    sqs_reliability_queue_id           = ""
+    sqs_reprocess_submission_queue_arn = ""
   }
 }
 
@@ -144,8 +146,9 @@ inputs = {
   database_secret_arn        = dependency.rds.outputs.database_secret_arn
   database_url_secret_arn    = dependency.rds.outputs.database_url_secret_arn
 
-  sqs_reliability_queue_arn = dependency.sqs.outputs.sqs_reliability_queue_arn 
-  sqs_reliability_queue_id  = dependency.sqs.outputs.sqs_reliability_queue_id
+  sqs_reliability_queue_arn          = dependency.sqs.outputs.sqs_reliability_queue_arn 
+  sqs_reliability_queue_id           = dependency.sqs.outputs.sqs_reliability_queue_id
+  sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
 }

--- a/env/staging/app/terragrunt.hcl
+++ b/env/staging/app/terragrunt.hcl
@@ -84,9 +84,11 @@ dependency "sqs" {
   config_path = "../sqs"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
-  sqs_reliability_queue_arn = "" 
-  sqs_reliability_queue_id  = ""
+    sqs_reliability_queue_arn          = "" 
+    sqs_reliability_queue_id           = ""
+    sqs_reprocess_submission_queue_arn = ""
   }
 }
 
@@ -141,8 +143,9 @@ inputs = {
   database_secret_arn        = dependency.rds.outputs.database_secret_arn
   database_url_secret_arn    = dependency.rds.outputs.database_url_secret_arn
 
-  sqs_reliability_queue_arn = dependency.sqs.outputs.sqs_reliability_queue_arn 
-  sqs_reliability_queue_id  = dependency.sqs.outputs.sqs_reliability_queue_id
+  sqs_reliability_queue_arn          = dependency.sqs.outputs.sqs_reliability_queue_arn 
+  sqs_reliability_queue_id           = dependency.sqs.outputs.sqs_reliability_queue_id
+  sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
 }


### PR DESCRIPTION
# Summary | Résumé

linked to https://github.com/cds-snc/platform-forms-client/pull/672

- remove code that deletes submissions from DynamoDB table as well as files attached to form from temporary S3 bucket
- expire S3 items in reliability storage after 2 days instead of 5
- enable TTL feature on ReliabilityQueue DynamoDB table in order to delete entries after 48 hours
- allow ECS task to interact with SQS
- add reprocess submission queue to SQS