### PR TITLE
fix: mark secret app variables as sensitive

### DIFF
--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -176,7 +176,6 @@ variable "rds_db_name" {
 variable "redis_url" {
   description = "Redis URL used by the ECS task"
   type        = string
-  sensitive   = true
 }
 
 variable "sqs_reliability_queue_id" {

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -97,16 +97,19 @@ variable "egress_security_group_id" {
 variable "google_client_id" {
   description = "value"
   type        = string
+  sensitive   = true
 }
 
 variable "google_client_secret" {
   description = "value"
   type        = string
+  sensitive   = true
 }
 
 variable "recaptcha_secret" {
   description = "Secret Site Key for reCAPTCHA"
   type        = string
+  sensitive   = true
 }
 
 variable "recaptcha_public" {
@@ -152,6 +155,7 @@ variable "metric_provider" {
 variable "notify_api_key" {
   description = "The Notify API key used by the ECS task and Lambda"
   type        = string
+  sensitive   = true
 }
 
 variable "private_subnet_ids" {
@@ -172,6 +176,7 @@ variable "rds_db_name" {
 variable "redis_url" {
   description = "Redis URL used by the ECS task"
   type        = string
+  sensitive   = true
 }
 
 variable "sqs_reliability_queue_id" {


### PR DESCRIPTION
# Summary
Mark the secret app module variables as `sensitive` so that they are not
leaked by the Terraform Plan action comment.