### PR TITLE
fix: sql parameters in wrong order and addition of retrieved attribute

### DIFF
--- a/aws/app/lambda/reliability/lib/dataLayer.js
+++ b/aws/app/lambda/reliability/lib/dataLayer.js
@@ -45,6 +45,7 @@ async function saveToVault(submissionID, formResponse, formID) {
       SubmissionID: { S: submissionID },
       FormID: { S: formIdentifier },
       FormSubmission: { S: formSubmission },
+      Retrieved: {N: "0"}
     },
   };
   //save data to DynamoDB

--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -114,7 +114,7 @@ exports.handler = async function (event) {
                 },
               },
             ]
-            : [formID, JSON.stringify(event.formConfig)];
+            : [JSON.stringify(event.formConfig), formID];
       } else {
         return { error: "Missing required Parameter" };
       }

--- a/env/common/local-provider.tf
+++ b/env/common/local-provider.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 1.0.11"
+  required_version = "= 1.0.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
# Summary | Résumé

Linked to issue https://github.com/cds-snc/platform-forms-client/issues/586

Summary of changes:
* Setting `Retrieval` to have a value of `0` when a record is first being inserted to the vault 
* Fixed a local only bug whereby sql parameters were in the wrong order for updating template record 
* Setting local environment terraform version to be the same as staging and production for consistency 


# Test instructions | Instructions pour tester la modification

Please see the following PR https://github.com/cds-snc/platform-forms-client/pull/694
