### PR TITLE
feat: enable DLQ redrive and increase timeout for reliability lambda

### DIFF
--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -49,6 +49,7 @@ resource "aws_lambda_function" "reliability" {
   function_name = "Reliability"
   role          = aws_iam_role.lambda.arn
   handler       = "reliability.handler"
+  timeout       = 300
 
   source_code_hash = data.archive_file.reliability_main.output_base64sha256
 

--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -19,6 +19,11 @@ resource "aws_sqs_queue" "reliability_queue" {
     maxReceiveCount     = 5
   })
 
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = ["${aws_sqs_queue.deadletter_queue.arn}"]
+  })
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
@@ -58,6 +63,11 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.deadletter_queue.arn
     maxReceiveCount     = 5
+  })
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = ["${aws_sqs_queue.deadletter_queue.arn}"]
   })
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

closes #33 
closes #192 

This PR enables the redrive policy to allow queues to redrive messages from the DLQ as well as increases the timeout for the reliability lambda to 5 min

See hashicorp documentation on `redrive_allow_policy`

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#redrive_allow_policy

See AWS documentation on redrive 

https://aws.amazon.com/blogs/aws/enhanced-dlq-management-sqs/

