### PR TITLE
fix: remove redrive allow policy

### DIFF
--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -19,11 +19,6 @@ resource "aws_sqs_queue" "reliability_queue" {
     maxReceiveCount     = 5
   })
 
-  redrive_allow_policy = jsonencode({
-    redrivePermission = "byQueue",
-    sourceQueueArns   = ["${aws_sqs_queue.deadletter_queue.arn}"]
-  })
-
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
@@ -63,11 +58,6 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.deadletter_queue.arn
     maxReceiveCount     = 5
-  })
-
-  redrive_allow_policy = jsonencode({
-    redrivePermission = "byQueue",
-    sourceQueueArns   = ["${aws_sqs_queue.deadletter_queue.arn}"]
   })
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

remove redrive-allow-policy which doesn't work with SQS FIFO queues
