### PR TITLE
feat: Add submissionID and createdAt timestamp to email body

### DIFF
--- a/aws/app/lambda/reliability/lib/dataLayer.js
+++ b/aws/app/lambda/reliability/lib/dataLayer.js
@@ -14,13 +14,13 @@ async function getSubmission(message) {
     Key: {
       SubmissionID: { S: message.submissionID },
     },
-    ProjectExpression: "SubmissionID,FormID,SendReceipt,FormData,FormSubmissionLanguage",
+    ProjectExpression: "SubmissionID,FormID,SendReceipt,FormData,FormSubmissionLanguage,CreatedAt",
   };
   //save data to DynamoDB
   return await db.send(new GetItemCommand(DBParams));
 }
 
-async function saveToVault(submissionID, formResponse, formID) {
+async function saveToVault(submissionID, formResponse, formID, language, createdAt) {
   const db = new DynamoDBClient({ region: REGION, endpoint: process.env.AWS_SAM_LOCAL ? "http://host.docker.internal:4566": undefined });
   const formSubmission =
     typeof formResponse === "string" ? formResponse : JSON.stringify(formResponse);
@@ -33,6 +33,8 @@ async function saveToVault(submissionID, formResponse, formID) {
       SubmissionID: { S: submissionID },
       FormID: { S: formIdentifier },
       FormSubmission: { S: formSubmission },
+      FormSubmissionLanguage: {S: language},
+      CreatedAt: {N: `${createdAt}`},
       Retrieved: {N: "0"}
     },
   };

--- a/aws/app/lambda/reliability/lib/markdown.js
+++ b/aws/app/lambda/reliability/lib/markdown.js
@@ -1,7 +1,7 @@
 const json2md = require("json2md");
 const { extractFormData } = require("dataLayer");
 
-module.exports = (formResponse, language) => {
+module.exports = (formResponse, submissionID, language, createdAt) => {
 
   const title = `${language === "fr" ? (formResponse.form.emailSubjectFr
       ? formResponse.form.emailSubjectFr
@@ -14,10 +14,19 @@ module.exports = (formResponse, language) => {
     return { p: item };
   });
 
-  // use Notify lang attribute to denote the language https://notification.canada.ca/format
-  const emailBody = language === "fr" ?
-      "[[fr]]\n" + json2md([{ h1: title }, mdBody])+ "\n[[/fr]]":
-      "[[en]]\n" + json2md([{ h1: title }, mdBody])+ "\n[[/en]]";
+  let emailMarkdown = json2md([{ h1: title }, mdBody]);
+  const isoCreatedAtString = new Date(parseInt(createdAt)).toISOString();
 
-  return emailBody;
+
+  // Using language attribute tags https://notification.canada.ca/format
+  // This is done so screen readers can read in the correct voice
+  if (language === "fr"){
+    emailMarkdown =
+        `[[fr]]\n${emailMarkdown}\nDate de soumission: ${isoCreatedAtString}\nID: ${submissionID}\n[[/fr]]`;
+  }else{
+    emailMarkdown =
+        `[[en]]\n${emailMarkdown}\nSubmission Date: ${isoCreatedAtString}\nID: ${submissionID}\n[[/en]]`;
+  }
+
+  return emailMarkdown
 };

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -3,10 +3,10 @@ const convertMessage = require("markdown");
 const { extractFileInputResponses } = require("dataLayer");
 const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 
-module.exports = async (submissionID, sendReceipt, formSubmission, language, message) => {
+module.exports = async (submissionID, sendReceipt, formSubmission, language, createdAt) => {
   const templateID = "92096ac6-1cc5-40ae-9052-fffdb8439a90";
   const notify = new NotifyClient("https://api.notification.canada.ca", process.env.NOTIFY_API_KEY);
-  const emailBody = convertMessage(formSubmission, language);
+  const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
   const messageSubject =
     language === "fr"
       ? formSubmission.form.emailSubjectFr

--- a/aws/app/lambda/reliability/lib/vaultProcessing.js
+++ b/aws/app/lambda/reliability/lib/vaultProcessing.js
@@ -1,10 +1,10 @@
 const { saveToVault, extractFileInputResponses } = require("dataLayer");
 const { copyFilesFromReliabilityToVaultStorage } = require("s3FileInput");
 
-module.exports = async (submissionID, sendReceipt, formSubmission, formID, message) => {
+module.exports = async (submissionID, sendReceipt, formSubmission, formID, language, createdAt) => {
   const fileInputPaths = extractFileInputResponses(formSubmission);
   return await copyFilesFromReliabilityToVaultStorage(fileInputPaths)
-    .then(async () => await saveToVault(submissionID, formSubmission.responses, formID))
+    .then(async () => await saveToVault(submissionID, formSubmission.responses, formID, language, createdAt))
     .catch((err) => {
       throw new Error(`Saving to Vault error: ${formatErr(err)}`);
     })

--- a/aws/app/lambda/reliability/reliability.js
+++ b/aws/app/lambda/reliability/reliability.js
@@ -17,12 +17,13 @@ exports.handler = async function (event) {
       formID: messageData.Item?.FormID.S ?? null,
       sendReceipt: messageData.Item?.SendReceipt.S ?? null,
       language: messageData.Item?.FormSubmissionLanguage.S ?? "en",
+      createdAt: messageData.Item?.CreatedAt.N ?? null,
       formSubmission: messageData.Item?.FormData.S
           ? JSON.parse(messageData.Item?.FormData.S)
           : null,
     }
 
-    const {submissionID, formSubmission, formID, sendReceipt, language} = processedMessageData
+    const {submissionID, formSubmission, formID, sendReceipt, createdAt, language} = processedMessageData
     submissionIDPlaceholder = submissionID;
     // Check if form data exists or was already processed.
     if (formSubmission === null || typeof formSubmission === "undefined") {
@@ -39,9 +40,9 @@ exports.handler = async function (event) {
 
     /// process submission to vault or Notify
     if (formSubmission.submission.vault) {
-      return await sendToVault(submissionID, sendReceipt, formSubmission, formID, message);
+      return await sendToVault(submissionID, sendReceipt, formSubmission, formID, language, createdAt);
     } else {
-      return await sendToNotify(submissionID, sendReceipt, formSubmission, language,message);
+      return await sendToNotify(submissionID, sendReceipt, formSubmission, language, createdAt);
     }
   } catch(err) {
     console.error(
@@ -72,7 +73,7 @@ const getFormTemplate = async (formID) => {
       const decoder = new TextDecoder();
       const payload = decoder.decode(response.Payload);
       if (response.FunctionError) {
-        cosole.error("Lambda Template Client not successful");
+        console.error("Lambda Template Client not successful");
         return null;
       } else {
         console.info("Lambda Template Client successfully triggered");

--- a/aws/app/lambda/submission/submission.js
+++ b/aws/app/lambda/submission/submission.js
@@ -60,6 +60,7 @@ const saveData = async (submissionID, formData) => {
   const formSubmission = typeof formData === "string" ? formData : JSON.stringify(formData);
 
   const expiringTime = (Math.floor(Date.now() / 1000) + 172800).toString(); // expire after 48 hours
+  const timeStamp = Date.now().toString()
 
   const DBParams = {
     TableName: "ReliabilityQueue",
@@ -69,6 +70,7 @@ const saveData = async (submissionID, formData) => {
       SendReceipt: { S: "unknown" },
       FormSubmissionLanguage: {S: formData.language},
       FormData: { S: formSubmission },
+      CreatedAt: { N: timeStamp },
       TTL: { N: expiringTime },
     },
   };


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/687
closes https://github.com/cds-snc/platform-forms-client/issues/595

This PR mainly adds the submission ID and a timestamp to the end of the email body

In french:

![Screen Shot 2022-04-11 at 9 36 57 AM](https://user-images.githubusercontent.com/26819992/162751486-18baeb82-deb8-42f1-b6b2-b7d5bef1bdf7.png)

In english:

![Screen Shot 2022-04-11 at 9 37 27 AM](https://user-images.githubusercontent.com/26819992/162751582-9c4e9788-38ac-4913-8319-33c9219259e9.png)


I was not able to find a good way to shorten the UUID unfortunately. Taking the first 8 characters would mean a duplicate every 65000 IDs. Base64 encoding the ID based on its bytes did shorten the ID to 22 characters however it did not make much of a difference when it came to being read by a screenreader and in fact was even more confusing. Unfortunately there is not a really good solution for this other than a user controlling the reading speed of the screen reader. 

Also fixed a couple of issues:
* language attribute not included 
* misspelled console command 
