### PR TITLE
Add a second gc notify service

### DIFF
--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -23,8 +23,7 @@ env:
   TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
-  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
-  GC_NOTIFY_URL: https://api.notification.canada.ca
+  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }} 
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
   TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90
 

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -24,7 +24,7 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
-  TF_VAR_gc_notify_url: https://notification.canada.ca
+  GC_NOTIFY_URL: https://api.notification.canada.ca
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
   TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90
 

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -24,6 +24,9 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
+  TF_VAR_gc_notify_url: https://notification.canada.ca
+  TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
+  TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90
 
 jobs:
   # Check the VERSION file to get the target version to deploy and previously deployed version.

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -25,9 +25,9 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
-  TF_VAR_gc_notify_url: https://staging.notification.cdssandbox.xyz
-  TF_VAR_gc_temp_token_template_id: 7199f6c9-41de-4941-85be-6fa6919b05d9
-  TF_VAR_gc_template_id: 48e64069-3dd7-4aa4-830d-d70e76732ce4
+  TF_VAR_gc_notify_url: https://notification.canada.ca
+  TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
+  TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7
 
 jobs:
   terragrunt-plan:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -25,7 +25,7 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
-  TF_VAR_gc_notify_url: https://notification.canada.ca
+  GC_NOTIFY_URL: https://api.notification.canada.ca
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7
 

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -25,6 +25,9 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
+  TF_VAR_gc_notify_url: https://staging.notification.cdssandbox.xyz
+  TF_VAR_gc_temp_token_template_id: 7199f6c9-41de-4941-85be-6fa6919b05d9
+  TF_VAR_gc_template_id: 48e64069-3dd7-4aa4-830d-d70e76732ce4
 
 jobs:
   terragrunt-plan:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -25,7 +25,6 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
-  GC_NOTIFY_URL: https://api.notification.canada.ca
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7
 

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -43,7 +43,6 @@ data "template_file" "form_viewer_task" {
     templates_api                   = aws_lambda_function.templates.arn
     organizations_api               = aws_lambda_function.organizations.arn
     reliability_file_storage        = aws_s3_bucket.reliability_file_storage.id
-    gc_notify_url                   = var.gc_notify_url
     gc_temp_token_template_id       = var.gc_temp_token_template_id
     gc_template_id                  = var.gc_template_id
   }

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -43,6 +43,9 @@ data "template_file" "form_viewer_task" {
     templates_api                   = aws_lambda_function.templates.arn
     organizations_api               = aws_lambda_function.organizations.arn
     reliability_file_storage        = aws_s3_bucket.reliability_file_storage.id
+    gc_notify_url                   = var.gc_notify_url
+    gc_temp_token_template_id       = var.gc_temp_token_template_id
+    gc_template_id                  = var.gc_template_id
   }
 }
 

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -56,6 +56,18 @@
       {
         "name": "RECAPTCHA_V3_SITE_KEY",
         "value": "${recaptcha_public}"
+      },
+      {
+        "name": "GC_NOTIFY_URL",
+        "value": "${gc_notify_url}"
+      },
+      {
+        "name": "TEMPORAY_TOKEN_TEMPLATE_ID",
+        "value": "${gc_temp_token_template_id}"
+      },
+      {
+        "name": "TEMPLATE_ID",
+        "value": "${gc_template_id}"
       }
     ],
     "secrets": [

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -56,11 +56,7 @@
       {
         "name": "RECAPTCHA_V3_SITE_KEY",
         "value": "${recaptcha_public}"
-      },
-      {
-        "name": "GC_NOTIFY_URL",
-        "value": "${gc_notify_url}"
-      },
+      },     
       {
         "name": "TEMPORAY_TOKEN_TEMPLATE_ID",
         "value": "${gc_temp_token_template_id}"

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -58,7 +58,7 @@
         "value": "${recaptcha_public}"
       },     
       {
-        "name": "TEMPORAY_TOKEN_TEMPLATE_ID",
+        "name": "TEMPORARY_TOKEN_TEMPLATE_ID",
         "value": "${gc_temp_token_template_id}"
       },
       {

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -218,3 +218,19 @@ variable "dynamodb_vault_stream_arn" {
   description = "Vault DynamoDB stream ARN"
   type        = string
 }
+
+variable "gc_notify_url" {
+  description = "GC Notify URL"
+  type        = string
+}
+
+variable "gc_template_id" {
+  description = "GC Notify send a notification templateID"
+  type        = string
+}
+
+variable "gc_temp_token_template_id" {
+  description = "GC Notify temporary token templateID"
+  type        = string
+}
+

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -219,11 +219,6 @@ variable "dynamodb_vault_stream_arn" {
   type        = string
 }
 
-variable "gc_notify_url" {
-  description = "GC Notify URL"
-  type        = string
-}
-
 variable "gc_template_id" {
   description = "GC Notify send a notification templateID"
   type        = string

--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_function" "reliability" {
       ENVIRONMENT    = var.env
       REGION         = var.region
       NOTIFY_API_KEY = aws_secretsmanager_secret_version.notify_api_key.secret_string
+      TEMPLATE_ID    = var.gc_template_id
     }
   }
 

--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -28,6 +28,15 @@ Parameters:
   NOTIFY_API_KEY:
     Type: AWS::SSM::Parameter::Value<String>
     Default: "NOTIFY API KEY"
+  TEMPLATE_ID:
+    Type: String
+    Default: "8d597a1b-a1d6-4e3c-8421-042a2b4158b7"
+  GC_NOTIFY_URL:
+    Type: String
+    Default: "https://notification.canada.ca"
+  TEMPORAY_TOKEN_TEMPLATE_ID:
+    Type: String
+    Default: "b6885d06-d10a-422a-973f-05e274d9aa86"
 
 Globals:
   Function:

--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -31,7 +31,7 @@ Parameters:
   TEMPLATE_ID:
     Type: String
     Default: "8d597a1b-a1d6-4e3c-8421-042a2b4158b7"
-  TEMPORAY_TOKEN_TEMPLATE_ID:
+  TEMPORARY_TOKEN_TEMPLATE_ID:
     Type: String
     Default: "b6885d06-d10a-422a-973f-05e274d9aa86"
 

--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -31,9 +31,6 @@ Parameters:
   TEMPLATE_ID:
     Type: String
     Default: "8d597a1b-a1d6-4e3c-8421-042a2b4158b7"
-  GC_NOTIFY_URL:
-    Type: String
-    Default: " https://api.notification.canada.ca"
   TEMPORAY_TOKEN_TEMPLATE_ID:
     Type: String
     Default: "b6885d06-d10a-422a-973f-05e274d9aa86"

--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -33,7 +33,7 @@ Parameters:
     Default: "8d597a1b-a1d6-4e3c-8421-042a2b4158b7"
   GC_NOTIFY_URL:
     Type: String
-    Default: "https://notification.canada.ca"
+    Default: " https://api.notification.canada.ca"
   TEMPORAY_TOKEN_TEMPLATE_ID:
     Type: String
     Default: "b6885d06-d10a-422a-973f-05e274d9aa86"

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -5,7 +5,7 @@ const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 
 module.exports = async (submissionID, sendReceipt, formSubmission, language, createdAt) => {
   const templateID = process.env.TEMPLATE_ID;
-  const notify = new NotifyClient(process.env.GC_NOTIFY_URL, process.env.NOTIFY_API_KEY);
+  const notify = new NotifyClient("https://api.notification.canada.ca", process.env.NOTIFY_API_KEY);
   const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
   const messageSubject =
     language === "fr"

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -4,8 +4,8 @@ const { extractFileInputResponses } = require("dataLayer");
 const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 
 module.exports = async (submissionID, sendReceipt, formSubmission, language, createdAt) => {
-  const templateID = "92096ac6-1cc5-40ae-9052-fffdb8439a90";
-  const notify = new NotifyClient("https://api.notification.canada.ca", process.env.NOTIFY_API_KEY);
+  const templateID = process.env.TEMPLATE_ID;
+  const notify = new NotifyClient(process.env.GC_NOTIFY_URL, process.env.NOTIFY_API_KEY);
   const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
   const messageSubject =
     language === "fr"


### PR DESCRIPTION
# Summary | Résumé
This PR aims to enable the support of notify's Callback function  per GC forms environment. 
 [Card](https://github.com/cds-snc/platform-forms-client/issues/696) 

These environment variables were added to support the new GC Notify service for Staging. 

- GC_NOTIFY_URL 
- TEMPLATE_ID
- TEMPORAY_TOKEN_TEMPLATE_ID 

