### PR TITLE
feat: add Open ID Connect roles

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -95,6 +95,9 @@ jobs:
             sqs:
               - 'aws/sqs/**'
               - 'env/staging/sqs/**'
+            oidc:
+              - 'aws/oidc/**'
+              - 'env/staging/oidc/**'
 
       # No dependencies
       - name: Terragrunt apply ecr
@@ -120,6 +123,11 @@ jobs:
       - name: Terragrunt apply sns
         if: ${{ steps.filter.outputs.sns == 'true' || steps.filter.outputs.common == 'true' }}
         working-directory: env/staging/sns
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply oidc
+        if: ${{ steps.filter.outputs.oidc == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/staging/oidc
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       # Depends on kms

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -103,6 +103,9 @@ jobs:
             sqs:
               - 'aws/sqs/**'
               - 'env/staging/sqs/**'
+            oidc:
+              - 'aws/oidc/**'
+              - 'env/staging/oidc/**'
 
       # No dependencies
       - name: Terragrunt plan ecr
@@ -255,3 +258,13 @@ jobs:
       - name: Remove Lambda load_testing deps
         if: ${{ steps.filter.outputs.load_testing == 'true' || steps.filter.outputs.common == 'true' }}
         run: ./aws/load_testing/lambda/deps.sh delete
+
+      - name: Terragrunt plan OIDC
+        if: ${{ steps.filter.outputs.oidc == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/staging/oidc"
+          comment-delete: "true"
+          comment-title: "Staging: OIDC"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/aws/oidc/oidc.tf
+++ b/aws/oidc/oidc.tf
@@ -5,19 +5,19 @@ locals {
 
 
 module "oidc" {
-  source = "github.com/cds-snc/terraform-modules?ref=v2.0.1//gh_oidc_role"
-  billing_tag_key = var.billing_tag_key
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.1//gh_oidc_role"
+  billing_tag_key   = var.billing_tag_key
   billing_tag_value = var.billing_tag_value
   roles = [
     {
       name : local.admin_name,
-      repo_name: "forms-terraform"
-      claim: "ref:refs/heads/main"
+      repo_name : "forms-terraform"
+      claim : "ref:refs/heads/main"
     },
     {
       name : local.plan_name,
-      repo_name: "forms-terraform"
-      claim: "*"
+      repo_name : "forms-terraform"
+      claim : "*"
     }
   ]
 
@@ -37,9 +37,9 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 ## Gives the plan role access to all secrets in the repo this is needed since ReadOnly doesn't provide that access
 ## This also gives the plan role the ability to the state bucket and the dynamodb lock table.
 module "attach_tf_plan_policy" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.1//attach_tf_plan_policy"
-  account_id        = var.account_id
-  role_name         = local.plan_name
+  source     = "github.com/cds-snc/terraform-modules?ref=v2.0.1//attach_tf_plan_policy"
+  account_id = var.account_id
+  role_name  = local.plan_name
   # This needs to match the data in the root terragrunt.hcl
   bucket_name       = "forms-terraform-{var.env}-tf"
   lock_table_name   = "tfstate-lock"

--- a/aws/oidc/oidc.tf
+++ b/aws/oidc/oidc.tf
@@ -44,7 +44,7 @@ module "attach_tf_plan_policy" {
   bucket_name       = "forms-terraform-{var.env}-tf"
   lock_table_name   = "tfstate-lock"
   billing_tag_key   = var.billing_tag_key
-  billing_tag_value = var.billing_code
+  billing_tag_value = var.billing_tag_value
 }
 
 data "aws_iam_policy" "admin" {

--- a/aws/oidc/oidc.tf
+++ b/aws/oidc/oidc.tf
@@ -1,0 +1,57 @@
+locals {
+  plan_name  = "gh_plan_role"
+  admin_name = "gh_admin_role"
+}
+
+
+module "oidc" {
+  source = "github.com/cds-snc/terraform-modules?ref=v2.0.1//gh_oidc_role"
+  billing_tag_key = var.billing_tag_key
+  billing_tag_value = var.billing_tag_value
+  roles = [
+    {
+      name : local.admin_name,
+      repo_name: "forms-terraform"
+      claim: "ref:refs/heads/main"
+    },
+    {
+      name : local.plan_name,
+      repo_name: "forms-terraform"
+      claim: "*"
+    }
+  ]
+
+}
+
+
+## Policy required for running TF Plans ReadOnly is needed along with some other policies.
+data "aws_iam_policy" "readonly" {
+  name = "ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly" {
+  role       = local.plan_name
+  policy_arn = data.aws_iam_policy.readonly.arn
+}
+
+## Gives the plan role access to all secrets in the repo this is needed since ReadOnly doesn't provide that access
+## This also gives the plan role the ability to the state bucket and the dynamodb lock table.
+module "attach_tf_plan_policy" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.1//attach_tf_plan_policy"
+  account_id        = var.account_id
+  role_name         = local.plan_name
+  # This needs to match the data in the root terragrunt.hcl
+  bucket_name       = "forms-terraform-{var.env}-tf"
+  lock_table_name   = "tfstate-lock"
+  billing_tag_key   = var.billing_tag_key
+  billing_tag_value = var.billing_code
+}
+
+data "aws_iam_policy" "admin" {
+  name = "AdministratorAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "admin" {
+  role       = local.admin_name
+  policy_arn = data.aws_iam_policy.admin.arn
+}

--- a/env/production/oidc/terragrunt.hcl
+++ b/env/production/oidc/terragrunt.hcl
@@ -1,5 +1,6 @@
 terraform {
   source = "../../../aws//oidc"
+  source = "git::https://github.com/cds-snc/forms-terraform//aws/oidc?ref=${get_env("TARGET_VERSION")}"
 }
 
 include {

--- a/env/production/oidc/terragrunt.hcl
+++ b/env/production/oidc/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//oidc"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/env/staging/oidc/terragrunt.hcl
+++ b/env/staging/oidc/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//oidc"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary | Résumé

Create the admin and plan role for the Open ID Connect, also creates an Identity Provider for Github OIDC.


Please note this is a first step to get OIDC enabled in your project,
this will create the required roles for planning and applying terraform
changes.

After this change is put in place we can switch the Github Workflows to
authenticate using those new roles and then finally delete the terraform
users and secrets.

I've also only updated the staging workflows as I want to make sure that
staging works before we apply changes in production
