### PR TITLE
fix: make local lambdas use NodeJS 14 runtime instead of 12

### DIFF
--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -37,7 +37,7 @@ Parameters:
 
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs14.x
     Tags:
       Environment:
         Ref: Environment
@@ -88,7 +88,6 @@ Resources:
         Fn::Sub: ${Environment}-${AppName}-reliability
       CodeUri: ../reliability/
       Handler: reliability.handler
-      Runtime: nodejs14.x
       Timeout: 300
       Layers:
         - Ref: ReliabilityLayer


### PR DESCRIPTION
# Summary | Résumé

- Just a simple change to make sure our Lambdas are running on NodeJS 14 locally (instead of 12)