### PR TITLE
feat: use latest localstack and run in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,33 +1,46 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:buster
 
 ARG USERNAME=vscode
-
-# Set these in devcontainer.json
-ARG TERRAFORM_VERSION
-ARG TERRAGRUNT_VERSION
+ARG AWS_SAM_VERSION
+ARG AWS_SAM_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends awscli build-essential ca-certificates curl git gnupg2 jq libffi-dev make nodejs npm openssh-client python3-dev python3-pip vim zsh \
+    && apt-get -y install --no-install-recommends build-essential ca-certificates curl git gnupg2 jq libffi-dev make nodejs npm openssh-client python3-dev python3-pip vim zsh \
     && apt-get autoremove -y && apt-get clean -y 
 
 # Install yarn
 RUN npm install -g yarn
 
-# Install Terraform
-RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/"${TERRAFORM_VERSION}"/terraform_"${TERRAFORM_VERSION}"_linux_"$(dpkg --print-architecture)".zip \
-    && unzip terraform.zip \
-    && mv terraform /usr/local/bin/ \
-    && rm terraform.zip
-
-# Install Terragrunt
-RUN curl -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v"${TERRAGRUNT_VERSION}"/terragrunt_linux_"$(dpkg --print-architecture)" \
-    && chmod +x terragrunt \
-    && mv terragrunt /usr/local/bin/
+# Install aws-sam
+ARG AWS_SAM_SRC=https://github.com/aws/aws-sam-cli/releases/download
+RUN curl -Lo aws-sam-cli.zip "${AWS_SAM_SRC}/v${AWS_SAM_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    && echo "${AWS_SAM_CHECKSUM} aws-sam-cli.zip" | sha256sum --check \
+    && unzip aws-sam-cli.zip -d sam-installation \
+    && ./sam-installation/install \
+    && rm -r aws-sam* \
+    && rm -r sam-installation*
 
 # Install Checkov
 RUN pip3 install --upgrade requests setuptools \
     && pip3 install --upgrade botocore checkov
+
+# Setup AWS Credentials
+RUN mkdir -p /home/vscode/.aws
+
+RUN echo "\n\
+[default]\n\
+aws_access_key_id=foo\n\
+aws_secret_access_key=bar\n\
+" >> /home/vscode/.aws/credentials
+
+RUN echo "\n\
+[default]\n\
+region=ca-central-1\n\
+output=json\n\
+" >> /home/vscode/.aws/config
+
+ENV SHELL /bin/zsh
 
 # Setup aliases and autocomplete
 RUN echo "\n\
@@ -36,4 +49,6 @@ complete -C /usr/local/bin/terraform terraform\n\
 complete -C /usr/local/bin/terraform terragrunt\n\
 alias tf='terraform'\n\
 alias tg='terragrunt'\n\
-alias ll='la -la'" >> /home/"${USERNAME}"/.zshrc
+alias ll='la -la' \n\
+alias laws='aws --endpoint-url=http://localstack:4566 --region=ca-central-1' \n\
+export PATH=$PATH:/usr/local/go/bin/" >> /home/vscode/.zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,27 @@
 {
 	"name": "Terraform",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": {
-			"TERRAFORM_VERSION": "1.0.10",
-			"TERRAGRUNT_VERSION": "0.35.6"
-		}
-	},
-
-	"containerEnv": {
-		"SHELL": "/bin/zsh"
-	},
-
+	"dockerComposeFile": "docker-compose.yml",
+  "service": "iac",
+  "workspaceFolder": "/workspace",
 	"settings": {
 		"[terraform]": {
 			"editor.formatOnSave": true
 		}
 	},
+  "features": {
+    "docker-from-docker": {
+      "version": "latest",
+      "moby": true
+    },
+    "terraform": {
+      "version": "1.0.10",
+      "tflint": "latest",
+      "terragrunt": "0.35.6"
+    },
+    "aws-cli": {
+      "version": "2.5.6"
+    }
+  },
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 {
-	"name": "Terraform",
-	"dockerComposeFile": "docker-compose.yml",
+  "name": "Terraform",
+  "dockerComposeFile": "docker-compose.yml",
   "service": "iac",
   "workspaceFolder": "/workspace",
-	"settings": {
-		"[terraform]": {
-			"editor.formatOnSave": true
-		}
-	},
+  "settings": {
+    "[terraform]": {
+      "editor.formatOnSave": true
+    }
+  },
   "features": {
     "docker-from-docker": {
       "version": "latest",
@@ -23,12 +23,12 @@
     }
   },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"hashicorp.terraform",
-		"redhat.vscode-yaml"
-	],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "hashicorp.terraform",
+    "redhat.vscode-yaml"
+  ],
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       DEVCONTAINER: "True"
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack@sha256:c6479ffb7fcb56899d9ead00af7fd5c64620bdea4ed303744cc33cb9361d2053
     hostname: localstack
     volumes:
       - "./data:/tmp/localstack"
@@ -27,7 +27,7 @@ services:
     ports:
       - 4566:4566
     environment:
-      - SERVICES=dynamodb,kms,sqs,s3,sns
+      - SERVICES=ec2,dynamodb,kms,sqs,s3,sns
       - DATA_DIR=/tmp/localstack/data
       - DOCKER_HOST=unix:///var/run/docker.sock`
       - DEBUG=1

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+  iac:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        AWS_SAM_VERSION: "1.50.0"
+        AWS_SAM_CHECKSUM: "093fc2cc40b098321dcc8635abe468642b72f8658821c9243a9357e400734207"
+        
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    environment:
+      AWS_LOCALSTACK: "True"
+      TF_VAR_region: "ca-central-1"
+      DEVCONTAINER: "True"
+
+  localstack:
+    image: localstack/localstack
+    hostname: localstack
+    volumes:
+      - "./data:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./scripts/init_localstack:/docker-entrypoint-initaws.d"
+    ports:
+      - 4566:4566
+    environment:
+      - SERVICES=dynamodb,kms,sqs,s3,sns
+      - DATA_DIR=/tmp/localstack/data
+      - DOCKER_HOST=unix:///var/run/docker.sock`
+      - DEBUG=1

--- a/.devcontainer/scripts/init_localstack/localstack-entrypoint.sh
+++ b/.devcontainer/scripts/init_localstack/localstack-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+printf "Configuring localstack components..."
+sleep 5;
+
+function laws {
+  aws --endpoint-url=http://localstack:4566 --region=ca-central-1 "$@"
+}
+
+set -x
+
+cwd=$(pwd)
+
+printf "Setting Connection Info..."
+laws configure set aws_access_key_id foo
+laws configure set aws_secret_access_key bar
+laws configure set region ca-central-1
+laws configure set output json
+
+set +x

--- a/.devcontainer/scripts/terraform_apply_localstack.sh
+++ b/.devcontainer/scripts/terraform_apply_localstack.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+printf "Configuring localstack components via terraform..."
+
+basedir=$(pwd)
+
+export TF_VAR_localstack_host="localstack"
+
+printf "Setting up local KMS..."
+cd $basedir/env/local/kms
+terragrunt apply --terragrunt-non-interactive -auto-approve
+
+printf "Creating SQS queue..."
+cd $basedir/env/local/sqs
+terragrunt apply --terragrunt-non-interactive -auto-approve
+
+printf "Creating SNS queue..."
+cd $basedir/env/local/sns
+rm -rf .terragrunt-cache
+terragrunt apply --terragrunt-non-interactive -auto-approve
+
+printf "Creating the DynamoDB database..."
+cd $basedir/env/local/dynamodb
+rm -rf .terragrunt-cache
+terragrunt apply --terragrunt-non-interactive -auto-approve
+
+printf "Creating the S3 buckets..."
+cd $basedir/env/local/app
+terragrunt apply --terragrunt-non-interactive -auto-approve
+
+printf "Installing lambda dependencies..."
+cd $basedir/aws/app/lambda
+find . -maxdepth 3 -name package.json -execdir yarn install \;

--- a/.devcontainer/scripts/terraform_apply_localstack.sh
+++ b/.devcontainer/scripts/terraform_apply_localstack.sh
@@ -28,7 +28,3 @@ terragrunt apply --terragrunt-non-interactive -auto-approve
 printf "Creating the S3 buckets...\n"
 cd $basedir/env/local/app
 terragrunt apply --terragrunt-non-interactive -auto-approve
-
-printf "Installing lambda dependencies...\n"
-cd $basedir/aws/app/lambda
-find . -maxdepth 3 -name package.json -execdir yarn install \;

--- a/.devcontainer/scripts/terraform_apply_localstack.sh
+++ b/.devcontainer/scripts/terraform_apply_localstack.sh
@@ -1,33 +1,34 @@
 #!/bin/bash
 
-printf "Configuring localstack components via terraform..."
-
+export TF_VAR_localstack_host="localstack"
 basedir=$(pwd)
 
-export TF_VAR_localstack_host="localstack"
+printf "Configuring localstack components via terraform...\n"
 
-printf "Setting up local KMS..."
+printf "Purging stale localstack related files\n"
+find $basedir/env/local -type d -name .terragrunt-cache -prune -exec rm -rf {} \;
+rm -rf $basedir/.devcontainer/data/data
+
+printf "Setting up local KMS...\n"
 cd $basedir/env/local/kms
 terragrunt apply --terragrunt-non-interactive -auto-approve
 
-printf "Creating SQS queue..."
+printf "Creating SQS queue...\n"
 cd $basedir/env/local/sqs
 terragrunt apply --terragrunt-non-interactive -auto-approve
 
-printf "Creating SNS queue..."
+printf "Creating SNS queue...\n"
 cd $basedir/env/local/sns
-rm -rf .terragrunt-cache
 terragrunt apply --terragrunt-non-interactive -auto-approve
 
-printf "Creating the DynamoDB database..."
+printf "Creating the DynamoDB database...\n"
 cd $basedir/env/local/dynamodb
-rm -rf .terragrunt-cache
 terragrunt apply --terragrunt-non-interactive -auto-approve
 
-printf "Creating the S3 buckets..."
+printf "Creating the S3 buckets...\n"
 cd $basedir/env/local/app
 terragrunt apply --terragrunt-non-interactive -auto-approve
 
-printf "Installing lambda dependencies..."
+printf "Installing lambda dependencies...\n"
 cd $basedir/aws/app/lambda
 find . -maxdepth 3 -name package.json -execdir yarn install \;

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tf.plan
 
 #Ignore Mac OS file types
 .DS_Store
+
+# Ignore local stack data file
+.devcontainer/data

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ validate: 	## Terragrunt validate all resources
 	cd env/scratch &&\
 	terragrunt run-all validate
 
+lambdas:
+	cd aws/app/lambda &&\
+	./start_local_lambdas.sh
+
 .PHONY: \
 	checkov \
 	default \

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,14 @@ validate: 	## Terragrunt validate all resources
 	cd env/scratch &&\
 	terragrunt run-all validate
 
-lambdas:
+terragrunt: ## Create localstack resources
+	./devcontainer/scripts/terraform_apply_localstack.sh
+
+lambdas: ## Start lambdas locally
 	cd aws/app/lambda &&\
 	./start_local_lambdas.sh
+
+local: terragrunt lambdas
 
 .PHONY: \
 	checkov \
@@ -28,4 +33,7 @@ lambdas:
 	fmt \
 	hclfmt \
 	help \
+	lambdas \
+	local \
+	terragrunt \
 	validate

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ Install AWS SAM-CLI
 
 ### Starting LocalStack and E2E testing from devcontainers
 
-```shell
-make terragrunt
-make lambdas
-```
-
+1. forms-terraform: **in** the devcontainer, run `.devcontainer/scripts/terraform_apply_localstack.sh`
+1. forms-terraform: while **not** in the devcontainer, run `make lambdas`
 1. platform-forms-client: **in** the devcontainer, cd /migrations; run `yarn install` and `node index.js`
 1. platform-forms-client: **in** the devcontainer, run `yarn install` and `yarn dev`
+
+**Note:** Due to how aws sam mounts volumes, you cannot run the lambda from the devcontainer. To launch the lambdas execute the `make lambdas` command
 
 ### Starting LocalStack 
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Install AWS SAM-CLI
 `brew tap aws/tap`
 `brew install aws-sam-cli`
 
-### Starting LocalStack from devcontainer
-```shell
-.devcontainer/scripts/terraform_apply_localstack.sh
-```
+### Starting LocalStack and E2E testing from devcontainers
+
+1. forms-terraform: **in** the devcontainer, run `.devcontainer/scripts/terraform_apply_localstack.sh`
+1. forms-terraform: while **not** in the devcontainer, run `make lambdas`
+1. platform-forms-client: **in** the devcontainer, cd /migrations; run `yarn install` and `node index.js`
+1. platform-forms-client: **in** the devcontainer, run `yarn install` and `yarn dev`
 
 **Note:** Due to how aws sam mounts volumes, you cannot run the lambda from the devcontainer. To launch the lambdas execute the `make lambdas` command
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make lambdas
 
 1. platform-forms-client: **in** the devcontainer:
 ```sh
-cd /migrations
+cd migrations
 yarn install
 node index.js
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Install AWS SAM-CLI
 `brew tap aws/tap`
 `brew install aws-sam-cli`
 
+### Starting LocalStack from devcontainer
+```shell
+.devcontainer/scripts/terraform_apply_localstack.sh
+```
+
+**Note:** Due to how aws sam mounts volumes, you cannot run the lambda from the devcontainer. To launch the lambdas execute the `make lambdas` command
 
 ### Starting LocalStack 
 
@@ -357,6 +363,7 @@ In directory:
 `template.yml` defines the local environment / project we will be running. Functions and environment variables can be defined here.
 
 Install Lambda dependencies and start local lambda service
+**NOTE:** if starting from inside the devcontainer add `/workspace` to from Docker -> Preferences... -> Resources -> File Sharing. 
 In directory: `./aws/app/lambda/` run the script `./start_local_lambdas.sh`
 
 If you want to invoke a lambda specifically, here’s the example command:

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ make lambdas
 
 1. platform-forms-client: **in** the devcontainer:
 ```sh
-make lambdas
-```
-
-1. platform-forms-client: **in** the devcontainer:
-```sh
 cd /migrations
 yarn install
 node index.js

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ Install AWS SAM-CLI
 
 ### Starting LocalStack and E2E testing from devcontainers
 
-1. forms-terraform: **in** the devcontainer, run `.devcontainer/scripts/terraform_apply_localstack.sh`
-1. forms-terraform: while **not** in the devcontainer, run `make lambdas`
+```shell
+make terragrunt
+make lambdas
+```
+
 1. platform-forms-client: **in** the devcontainer, cd /migrations; run `yarn install` and `node index.js`
 1. platform-forms-client: **in** the devcontainer, run `yarn install` and `yarn dev`
-
-**Note:** Due to how aws sam mounts volumes, you cannot run the lambda from the devcontainer. To launch the lambdas execute the `make lambdas` command
 
 ### Starting LocalStack 
 
@@ -365,7 +366,6 @@ In directory:
 `template.yml` defines the local environment / project we will be running. Functions and environment variables can be defined here.
 
 Install Lambda dependencies and start local lambda service
-**NOTE:** if starting from inside the devcontainer add `/workspace` to from Docker -> Preferences... -> Resources -> File Sharing. 
 In directory: `./aws/app/lambda/` run the script `./start_local_lambdas.sh`
 
 If you want to invoke a lambda specifically, here’s the example command:

--- a/README.md
+++ b/README.md
@@ -4,24 +4,37 @@ Infrastructure as Code for the GC Forms environment.
 
 ## Running Lambdas and DBs locally
 
-You will need to have the following installed on a MacOS machine. To install these pre-requisits a quick google search using the names of these dependencies should yield many tutorials on how to do so
+You will need to have the following installed on a MacOS machine.
 
 Pre-requisites:
-- Docker Hub
-- LocalStack
-- Homebrew
-- Terragrunt
-- AWS CLI
+- Docker Hub: https://docs.docker.com/desktop/mac/install/
+
+- Homebrew:
+    ```bash
+     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+     ```
+- LocalStack : `brew install localstack`
+- Terragrunt: 
+
+  1. `brew install warrensbox/tap/tfswitch`
+  1. `tfswitch 1.0.10`
+  1. `brew install warrensbox/tap/tgswitch`
+  1. `tgswitch 0.35.6`
+
+- Yarn: `brew install yarn`
+
+- AWS CLI: `brew install awscli`
+
 - AWS SAM CLI
+
+  Please run these commands to install the aws sam cli using homebrew. The AWS SAM CLI is what we use to run the lambda functions locally and invoke them.
+
+  1. `brew tap aws/tap`
+  1. `brew install aws-sam-cli`
+
 - Postgres and PGAdmin
-
-### Installing AWS SAM CLI
-
-Please run these commands to install the aws sam cli using homebrew. The AWS SAM CLI is what we use to run the lambda functions locally and invoke them.
-
-Install AWS SAM-CLI
-`brew tap aws/tap`
-`brew install aws-sam-cli`
+  1. `brew install postgresql`
+  1. `brew install --cask pgadmin4`
 
 ### Starting LocalStack and E2E testing from devcontainers
 
@@ -30,7 +43,7 @@ Install AWS SAM-CLI
 1. platform-forms-client: **in** the devcontainer, cd /migrations; run `yarn install` and `node index.js`
 1. platform-forms-client: **in** the devcontainer, run `yarn install` and `yarn dev`
 
-**Note:** Due to how aws sam mounts volumes, you cannot run the lambda from the devcontainer. To launch the lambdas execute the `make lambdas` command
+**Note:** Due to how aws sam mounts volumes, you start the lambdas from the devcontainer. To launch the lambdas execute the `make lambdas` command outside the devcontainer
 
 ### Starting LocalStack 
 
@@ -109,7 +122,7 @@ Add the following configurations to `~/.aws/config` and `~/.aws/credentials`
 `~/.aws/config`
 ```text
 [profile local]
-region = us-east-1
+region = ca-central-1
 output = yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,22 @@ Pre-requisites:
 
 ### Starting LocalStack and E2E testing from devcontainers
 
-1. forms-terraform: while **not** in the devcontainer:
+1. forms-terraform: while **in** the devcontainer:
 ```sh
 .devcontainer/scripts/terraform_apply_localstack.sh
 ```
 
-2. platform-forms-client: **in** the devcontainer:
+1. forms-terraform: while **not** in the devcontainer:
 ```sh
 make lambdas
 ```
 
-3. platform-forms-client: **in** the devcontainer:
+1. platform-forms-client: **in** the devcontainer:
+```sh
+make lambdas
+```
+
+1. platform-forms-client: **in** the devcontainer:
 ```sh
 cd /migrations
 yarn install

--- a/README.md
+++ b/README.md
@@ -38,10 +38,26 @@ Pre-requisites:
 
 ### Starting LocalStack and E2E testing from devcontainers
 
-1. forms-terraform: **in** the devcontainer, run `.devcontainer/scripts/terraform_apply_localstack.sh`
-1. forms-terraform: while **not** in the devcontainer, run `make lambdas`
-1. platform-forms-client: **in** the devcontainer, cd /migrations; run `yarn install` and `node index.js`
-1. platform-forms-client: **in** the devcontainer, run `yarn install` and `yarn dev`
+1. forms-terraform: while **not** in the devcontainer:
+```sh
+.devcontainer/scripts/terraform_apply_localstack.sh
+```
+
+2. platform-forms-client: **in** the devcontainer:
+```sh
+make lambdas
+```
+
+3. platform-forms-client: **in** the devcontainer:
+```sh
+cd /migrations
+yarn install
+node index.js
+
+cd ..
+yarn install
+yarn dev
+```
 
 **Note:** Due to how aws sam mounts volumes, you start the lambdas from the devcontainer. To launch the lambdas execute the `make lambdas` command outside the devcontainer
 

--- a/aws/app/lambda/start_local_lambdas.sh
+++ b/aws/app/lambda/start_local_lambdas.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-find . -maxdepth 3 -name package.json -execdir yarn install \;
-sam local start-lambda -t ./local_development/template.yml
+
+# Check if running locally or in the devcontainer
+if [[ -z "${DEVCONTAINER}" ]]; then
+  find . -maxdepth 3 -name package.json -execdir yarn install \;
+fi
+
+sam local start-lambda -t ./local_development/template.yml --host 0.0.0.0 --port 3001 --warm-containers EAGER

--- a/aws/app/lambda/start_local_lambdas.sh
+++ b/aws/app/lambda/start_local_lambdas.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+find . -maxdepth 3 -name package.json -execdir yarn install \;
+
 # Check if running locally or in the devcontainer
 if [[ -z "${DEVCONTAINER}" ]]; then
-  find . -maxdepth 3 -name package.json -execdir yarn install \;
+  sam local start-lambda -t ./local_development/template.yml --host 0.0.0.0 --port 3001 --warm-containers EAGER
+else
+  # devcontainer detected, set container host to host.docker.internal
+  sam local start-lambda -t ./local_development/template.yml --host 0.0.0.0 --port 3001 --warm-containers EAGER --container-host host.docker.internal
 fi
-
-sam local start-lambda -t ./local_development/template.yml --host 0.0.0.0 --port 3001 --warm-containers EAGER

--- a/env/common/local-provider.tf
+++ b/env/common/local-provider.tf
@@ -12,76 +12,117 @@ terraform {
   }
 }
 
+variable "localstack_host" {
+  type    = string
+  default = "localhost"
+}
+
 provider "aws" {
   access_key                  = "test"
   secret_key                  = "test"
-  region                      = "us-east-1"
-  s3_force_path_style         = false
+  region                      = "ca-central-1"
+  s3_force_path_style         = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
 
   endpoints {
-    apigateway     = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-    kms            = "http://localhost:4566"
+    apigateway     = "http://${var.localstack_host}:4566"
+    cloudformation = "http://${var.localstack_host}:4566"
+    cloudwatch     = "http://${var.localstack_host}:4566"
+    dynamodb       = "http://${var.localstack_host}:4566"
+    ec2            = "http://${var.localstack_host}:4566"
+    es             = "http://${var.localstack_host}:4566"
+    elasticache    = "http://${var.localstack_host}:4566"
+    firehose       = "http://${var.localstack_host}:4566"
+    iam            = "http://${var.localstack_host}:4566"
+    kinesis        = "http://${var.localstack_host}:4566"
+    lambda         = "http://${var.localstack_host}:4566"
+    rds            = "http://${var.localstack_host}:4566"
+    redshift       = "http://${var.localstack_host}:4566"
+    route53        = "http://${var.localstack_host}:4566"
+    s3             = "http://${var.localstack_host}:4566"
+    secretsmanager = "http://${var.localstack_host}:4566"
+    ses            = "http://${var.localstack_host}:4566"
+    sns            = "http://${var.localstack_host}:4566"
+    sqs            = "http://${var.localstack_host}:4566"
+    ssm            = "http://${var.localstack_host}:4566"
+    stepfunctions  = "http://${var.localstack_host}:4566"
+    sts            = "http://${var.localstack_host}:4566"
+    kms            = "http://${var.localstack_host}:4566"
   }
 }
 
-
 provider "aws" {
-  alias = "us-east-1"
+  alias                       = "us-east-1"
   access_key                  = "test"
   secret_key                  = "test"
   region                      = "us-east-1"
-  s3_force_path_style         = false
+  s3_force_path_style         = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
 
   endpoints {
-    apigateway     = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-    kms            = "http://localhost:4566"
+    apigateway     = "http://${var.localstack_host}:4566"
+    cloudformation = "http://${var.localstack_host}:4566"
+    cloudwatch     = "http://${var.localstack_host}:4566"
+    dynamodb       = "http://${var.localstack_host}:4566"
+    ec2            = "http://${var.localstack_host}:4566"
+    es             = "http://${var.localstack_host}:4566"
+    elasticache    = "http://${var.localstack_host}:4566"
+    firehose       = "http://${var.localstack_host}:4566"
+    iam            = "http://${var.localstack_host}:4566"
+    kinesis        = "http://${var.localstack_host}:4566"
+    lambda         = "http://${var.localstack_host}:4566"
+    rds            = "http://${var.localstack_host}:4566"
+    redshift       = "http://${var.localstack_host}:4566"
+    route53        = "http://${var.localstack_host}:4566"
+    s3             = "http://${var.localstack_host}:4566"
+    secretsmanager = "http://${var.localstack_host}:4566"
+    ses            = "http://${var.localstack_host}:4566"
+    sns            = "http://${var.localstack_host}:4566"
+    sqs            = "http://${var.localstack_host}:4566"
+    ssm            = "http://${var.localstack_host}:4566"
+    stepfunctions  = "http://${var.localstack_host}:4566"
+    sts            = "http://${var.localstack_host}:4566"
+    kms            = "http://${var.localstack_host}:4566"
+  }
+}
+
+provider "aws" {
+  alias                       = "ca-central-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "ca-central-1"
+  s3_force_path_style         = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    apigateway     = "http://${var.localstack_host}:4566"
+    cloudformation = "http://${var.localstack_host}:4566"
+    cloudwatch     = "http://${var.localstack_host}:4566"
+    dynamodb       = "http://${var.localstack_host}:4566"
+    ec2            = "http://${var.localstack_host}:4566"
+    es             = "http://${var.localstack_host}:4566"
+    elasticache    = "http://${var.localstack_host}:4566"
+    firehose       = "http://${var.localstack_host}:4566"
+    iam            = "http://${var.localstack_host}:4566"
+    kinesis        = "http://${var.localstack_host}:4566"
+    lambda         = "http://${var.localstack_host}:4566"
+    rds            = "http://${var.localstack_host}:4566"
+    redshift       = "http://${var.localstack_host}:4566"
+    route53        = "http://${var.localstack_host}:4566"
+    s3             = "http://${var.localstack_host}:4566"
+    secretsmanager = "http://${var.localstack_host}:4566"
+    ses            = "http://${var.localstack_host}:4566"
+    sns            = "http://${var.localstack_host}:4566"
+    sqs            = "http://${var.localstack_host}:4566"
+    ssm            = "http://${var.localstack_host}:4566"
+    stepfunctions  = "http://${var.localstack_host}:4566"
+    sts            = "http://${var.localstack_host}:4566"
+    kms            = "http://${var.localstack_host}:4566"
   }
 }

--- a/env/local/app/.terraform.lock.hcl
+++ b/env/local/app/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.2.0"
   hashes = [
     "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "3.63.0"
   hashes = [
     "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
     "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
     "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
     "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
@@ -42,6 +44,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",

--- a/env/local/app/terragrunt.hcl
+++ b/env/local/app/terragrunt.hcl
@@ -99,6 +99,9 @@ inputs = {
   sqs_reliability_queue_arn          = ""
   sqs_reliability_queue_id           = ""
   sqs_reprocess_submission_queue_arn = ""
+
+  gc_temp_token_template_id = "b6885d06-d10a-422a-973f-05e274d9aa86"
+  gc_template_id = "8d597a1b-a1d6-4e3c-8421-042a2b4158b7"
 }
 
 remote_state {

--- a/env/local/kms/.terraform.lock.hcl
+++ b/env/local/kms/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "3.63.0"
   hashes = [
     "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
     "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
     "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
     "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/env/local/sns/.terraform.lock.hcl
+++ b/env/local/sns/.terraform.lock.hcl
@@ -5,7 +5,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.63.0"
   constraints = "3.63.0"
   hashes = [
-    "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
     "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
     "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
     "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
@@ -26,7 +25,6 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.1.0"
   hashes = [
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
-    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",

--- a/env/local/sqs/.terraform.lock.hcl
+++ b/env/local/sqs/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "3.63.0"
   hashes = [
     "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
     "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
     "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
     "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -2,5 +2,4 @@ inputs = {
   account_id = "687401027353"
   domain     = "forms-staging.cdssandbox.xyz"
   env        = "staging"
-  region     = "ca-central-1"
 }

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -2,4 +2,5 @@ inputs = {
   account_id = "687401027353"
   domain     = "forms-staging.cdssandbox.xyz"
   env        = "staging"
+  region     = "ca-central-1"
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -8,7 +8,7 @@ inputs = {
   billing_tag_value = "forms-platform-${local.vars.inputs.env}"   
   domain            = "${local.vars.inputs.domain}"
   env               = "${local.vars.inputs.env}"
-  region            = "ca-central-1"
+  region            = "${local.vars.inputs.region}"
 }
 
 
@@ -22,7 +22,7 @@ remote_state {
     encrypt        = true
     bucket         = "forms-${local.vars.inputs.env}-tfstate"
     dynamodb_table = "tfstate-lock"
-    region         = "ca-central-1"
+    region         = local.vars.inputs.region
     key            = "${path_relative_to_include()}/terraform.tfstate"
   }
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -8,7 +8,7 @@ inputs = {
   billing_tag_value = "forms-platform-${local.vars.inputs.env}"   
   domain            = "${local.vars.inputs.domain}"
   env               = "${local.vars.inputs.env}"
-  region            = "${local.vars.inputs.region}"
+  region            = "ca-central-1"
 }
 
 
@@ -22,7 +22,7 @@ remote_state {
     encrypt        = true
     bucket         = "forms-${local.vars.inputs.env}-tfstate"
     dynamodb_table = "tfstate-lock"
-    region         = local.vars.inputs.region
+    region         = "ca-central-1"
     key            = "${path_relative_to_include()}/terraform.tfstate"
   }
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -8,7 +8,7 @@ inputs = {
   billing_tag_value = "forms-platform-${local.vars.inputs.env}"   
   domain            = "${local.vars.inputs.domain}"
   env               = "${local.vars.inputs.env}"
-  region            = local.vars.inputs.env == "local" ? "us-east-1":"ca-central-1"
+  region            = "ca-central-1"
 }
 
 


### PR DESCRIPTION
devcontainer updated to allow running localstack from within the container. AWS SAM still needs to be launched from outside the devcontainer due to issues with mounting within a docker-in-docker setup.

To launch the lambdas you can run the new `make lambdas` command while in the root directory from outside the devcontainer as long as you have aws sam installed.

Tested to confirm the localstack setup works the same when using a devcontainer or when running directly on our machines.