### PR TITLE
fix: add `limit` and `offset` parameters

### DIFF
--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -93,6 +93,9 @@ exports.handler = async function (event) {
                 },
               }) 
             : parameters.push(formID);
+
+        // break here since if there is a formID, then "limit" and "offset" aren't needed
+        break;
       }
       if (limit) {
         SQL += !process.env.AWS_SAM_LOCAL
@@ -174,10 +177,6 @@ exports.handler = async function (event) {
       }
       break;
   }
-
-  console.log("=======================");
-  console.log(SQL);
-  console.log(parameters);
 
   if (!SQL) {
     return { error: "Method not supported" };

--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -93,11 +93,8 @@ exports.handler = async function (event) {
                 },
               }) 
             : parameters.push(formID);
-
-        // break here since if there is a formID, then "limit" and "offset" aren't needed
-        break;
       }
-      if (limit) {
+      if (!formID && limit) {
         SQL += !process.env.AWS_SAM_LOCAL
           ? " LIMIT :limit"
           : " LIMIT ($1)";
@@ -112,7 +109,7 @@ exports.handler = async function (event) {
             }) 
           : parameters.push(limit);
       }
-      if (offset) {
+      if (!formID && offset) {
         SQL += !process.env.AWS_SAM_LOCAL
           ? " OFFSET :offset"
           : " OFFSET ($2)";

--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -35,6 +35,8 @@ exports.handler = async function (event) {
       - (Required) json_config - json config string defining a form
     GET:
       - (Optional) formID. Returns all entries if not provided
+      - (Optional) limit - number of rows to return
+      - (Optional) offset - row number where to start
     UPDATE:
       - (Required) formID to update
       - (Required) json_config - new json config string to update the entry
@@ -42,15 +44,17 @@ exports.handler = async function (event) {
       - (Required) formID to delete
   */
   const method = event.method;
-  let formID = event.formID ? parseInt(event.formID) : null,
-      formConfig = event.formConfig ? "'" + JSON.stringify(event.formConfig) + "'" : null;
+  let formID = event.formID ? parseInt(event.formID) : null
+  let formConfig = event.formConfig ? "'" + JSON.stringify(event.formConfig) + "'" : null;
+  let limit = event.limit ? parseInt(event.limit) : null;
+  let offset = event.offset ? parseInt(event.offset) : null;
 
   // if formID is NaN, assign it to an id we know will return no records
   if (isNaN(formID)) formID = 1;
 
-  let SQL = "",
-      parameters = [];
-
+  let SQL = "";
+  let parameters = [];
+  
   switch (method) {
     case "INSERT":
       if (formConfig) {
@@ -73,24 +77,54 @@ exports.handler = async function (event) {
       }
       break;
     case "GET":
+      SQL = "SELECT id, json_config, organization FROM Templates";
       // Get a specific form if given the id, all forms if not
       if (formID) {
-        SQL = !process.env.AWS_SAM_LOCAL
-            ? "SELECT id, json_config, organization FROM Templates WHERE id = :formID"
-            : "SELECT id, json_config, organization FROM Templates WHERE id = ($1)";
-        parameters = !process.env.AWS_SAM_LOCAL
-            ? [
+        SQL += !process.env.AWS_SAM_LOCAL
+            ? " WHERE id = :formID"
+            : " WHERE id = ($1)";
+
+        !process.env.AWS_SAM_LOCAL
+            ? parameters.push (
               {
                 name: "formID",
                 value: {
                   longValue: formID,
                 },
-              },
-            ]
-            : [formID];
-      } else {
-        SQL = "SELECT id, json_config, organization FROM Templates";
+              }) 
+            : parameters.push(formID);
       }
+      if (limit) {
+        SQL += !process.env.AWS_SAM_LOCAL
+          ? " LIMIT :limit"
+          : " LIMIT ($1)";
+
+        !process.env.AWS_SAM_LOCAL
+          ? parameters.push (
+            {
+              name: "limit",
+              value: {
+                longValue: limit,
+              },
+            }) 
+          : parameters.push(limit);
+      }
+      if (offset) {
+        SQL += !process.env.AWS_SAM_LOCAL
+          ? " OFFSET :offset"
+          : " OFFSET ($2)";
+
+        !process.env.AWS_SAM_LOCAL
+          ? parameters.push (
+            {
+              name: "offset",
+              value: {
+                longValue: offset,
+              },
+            }) 
+          : parameters.push(offset);          
+      }
+
       break;
     case "UPDATE":
       // needs the ID and the new json blob
@@ -140,6 +174,10 @@ exports.handler = async function (event) {
       }
       break;
   }
+
+  console.log("=======================");
+  console.log(SQL);
+  console.log(parameters);
 
   if (!SQL) {
     return { error: "Method not supported" };


### PR DESCRIPTION
# Summary | Résumé

Allows `LIMIT` and `OFFSET` to be passed as parameters to be used as keywords in the SQL statement for GET requests. This will limit the number of rows returned, so that the amount of data returned by the lambda function is under the 1MB limit.

Addresses Issue cds-snc/platform-forms-client/#786

# Test instructions | Instructions pour tester la modification

This will need PR 791 in `platform-forms-client` to be tested. 