### PR TITLE
docs: update the devcontainer setup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ validate: 	## Terragrunt validate all resources
 	terragrunt run-all validate
 
 terragrunt: ## Create localstack resources
-	./devcontainer/scripts/terraform_apply_localstack.sh
+	.devcontainer/scripts/terraform_apply_localstack.sh
 
 lambdas: ## Start lambdas locally
 	cd aws/app/lambda &&\

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pre-requisites:
 
 1. forms-terraform: while **in** the devcontainer:
 ```sh
-.devcontainer/scripts/terraform_apply_localstack.sh
+make terragrunt
 ```
 
 1. forms-terraform: while **not** in the devcontainer:
@@ -50,11 +50,7 @@ make lambdas
 
 1. platform-forms-client: **in** the devcontainer:
 ```sh
-cd migrations
-yarn install
-node index.js
-
-cd ..
+yarn --cwd migrations install
 yarn install
 yarn dev
 ```


### PR DESCRIPTION
# Summary
Update the commands used to prepare a local dev environment when
using VS Code devcontainers.

Also fixes a minor typo in the `terragrunt` Makefile target.