### PR TITLE
fix: only run docker-in-docker helper in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Terraform",
+  "name": "forms-terraform",
   "dockerComposeFile": "docker-compose.yml",
   "service": "iac",
   "workspaceFolder": "/workspace",
@@ -31,5 +31,5 @@
 
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
-  "forwardPorts": [3001],
+  "forwardPorts": [3001]
 }

--- a/aws/app/lambda/start_local_lambdas.sh
+++ b/aws/app/lambda/start_local_lambdas.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR="$(dirname $(readlink -f $0))"
 
 # Install yarn dependencies
 find "$SCRIPT_DIR" -maxdepth 3 -name package.json -execdir yarn install \;
 
-# Start the Docker-in-Docker helper for the devcontainer
-if ! pgrep "dind_add_host" > /dev/null; then
-  echo "⚡ Start Docker-in-Docker add host"
-  nohup bash -c '/workspace/.devcontainer/scripts/dind_add_host.sh &' >/dev/null 2>&1
+# Devcontainer specific startup commands
+if [ -n "${DEVCONTAINER}" ]; then
+
+  # Start the Docker-in-Docker helper in the bacgkround if it's not already running
+  if ! pgrep "dind_add_host" > /dev/null; then
+    echo "⚡ Starting Docker-in-Docker add host helper"
+    nohup bash -c '/workspace/.devcontainer/scripts/dind_add_host.sh &' >/dev/null 2>&1
+  fi
+
 fi
 
 # Start the lambda functions


### PR DESCRIPTION
# Summary
Limit the execution of the Docker-in-Docker `host.docker.internal` helper
script to only run when `make lambdas` is triggered from a devcontainer.

This fixes the use off `make lambdas` when run locally on the host
which was accidentally broken by #214.

# Related
* #214 
