### PR TITLE
fix: detection of zombie dind_add_host script

### DIFF
--- a/aws/app/lambda/start_local_lambdas.sh
+++ b/aws/app/lambda/start_local_lambdas.sh
@@ -3,14 +3,21 @@ set -eo pipefail
 
 SCRIPT_DIR="$(dirname $(readlink -f $0))"
 
+# Check if a given process is actively running
+function pgrep_live {
+  PIDS=$(pgrep "$1");
+  [ "$PIDS" ] || return;
+  ps -o s= -o pid= $PIDS | sed -n 's/^[^ZT][[:space:]]\+//p';
+}
+
 # Install yarn dependencies
 find "$SCRIPT_DIR" -maxdepth 3 -name package.json -execdir yarn install \;
 
 # Devcontainer specific startup commands
-if [ -n "${DEVCONTAINER}" ]; then
+if [[ -n "${DEVCONTAINER}" ]]; then
 
   # Start the Docker-in-Docker helper in the bacgkround if it's not already running
-  if ! pgrep "dind_add_host" > /dev/null; then
+  if [[ "$(pgrep_live 'dind_add_host')" = "" ]]; then
     echo "⚡ Starting Docker-in-Docker add host helper"
     nohup bash -c '/workspace/.devcontainer/scripts/dind_add_host.sh &' >/dev/null 2>&1
   fi


### PR DESCRIPTION
# Summary
Update the `make lambdas` target so that it can correctly
identify zombie and reaped `dind_add_host.sh` script
processes so that they are restarted.

Prior to this change, a `<defunct> dind_add_host.sh` was
considered running.