### PR TITLE
Add missing import in Reliability Queue Data Layer

### DIFF
--- a/aws/app/lambda/reliability/lib/dataLayer.js
+++ b/aws/app/lambda/reliability/lib/dataLayer.js
@@ -3,6 +3,7 @@ const {
   GetItemCommand,
   PutItemCommand,
   UpdateItemCommand,
+  DeleteItemCommand,
 } = require("@aws-sdk/client-dynamodb");
 
 const REGION = process.env.REGION;


### PR DESCRIPTION
# Summary | Résumé
This PR fixes an error that we are seeing in AWS Staging where DeleteItemCommand is referenced in code block but is not imported into the function from the AWS module.