### PR TITLE
fix: block scoped variable called in other block

### DIFF
--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -7,6 +7,10 @@ Parameters:
     Type: String
     Description: Name of application (no spaces). Value must be globally unique
     Default: FormsTest
+  REGION:
+    Type: AWS::SSM::Parameter::Value<String>
+    Description: Name of application (no spaces). Value must be globally unique
+    Default: ca-central-1
   DBUser:
     Type: AWS::SSM::Parameter::Value<String>
     Default: "postgres"
@@ -78,6 +82,8 @@ Resources:
         - Ref: SubmissionLayer
       Environment:
         Variables:
+          REGION:
+            Ref: REGION
           SQS_URL:
             Ref: SQS_URL
 
@@ -93,6 +99,8 @@ Resources:
         - Ref: ReliabilityLayer
       Environment:
         Variables:
+          REGION:
+            Ref: REGION
           NOTIFY_API_KEY:
             Ref: NOTIFY_API_KEY
 
@@ -127,6 +135,8 @@ Resources:
         - Ref: ArchiverLayer
       Environment:
         Variables:
+          REGION:
+            Ref: REGION
           DYNAMODB_VAULT_TABLE_NAME:
             Ref: Vault
           ARCHIVING_S3_BUCKET:

--- a/aws/app/lambda/reliability/lib/vaultProcessing.js
+++ b/aws/app/lambda/reliability/lib/vaultProcessing.js
@@ -35,8 +35,10 @@ module.exports = async (
   }
 
   try {
-    await removeSubmission(submissionID);
-    await removeFilesFromReliabilityStorage(fileInputPaths);
+    await Promise.all([
+      removeFilesFromReliabilityStorage(fileInputPaths),
+      removeSubmission(submissionID),
+    ]);
   } catch (err) {
     // Not throwing an error back to SQS because the message was
     // sucessfully processed by the vault.  Only cleanup required.

--- a/aws/app/lambda/reliability/lib/vaultProcessing.js
+++ b/aws/app/lambda/reliability/lib/vaultProcessing.js
@@ -18,8 +18,9 @@ module.exports = async (
   createdAt,
   securityAttribute
 ) => {
+  let fileInputPaths
   try {
-    const fileInputPaths = extractFileInputResponses(formSubmission);
+    fileInputPaths = extractFileInputResponses(formSubmission);
     await copyFilesFromReliabilityToVaultStorage(fileInputPaths);
     await saveToVault(
       submissionID,
@@ -34,10 +35,8 @@ module.exports = async (
   }
 
   try {
-    await Promise.all([
-      removeSubmission(submissionID),
-      removeFilesFromReliabilityStorage(fileInputPaths),
-    ]);
+    await removeSubmission(submissionID);
+    await removeFilesFromReliabilityStorage(fileInputPaths);
   } catch (err) {
     // Not throwing an error back to SQS because the message was
     // sucessfully processed by the vault.  Only cleanup required.


### PR DESCRIPTION
# Summary 
No issue for this just a bug that currently exists in staging

* Declare fileInputPaths so it's available to the whole function block
* Remove Promise.all as it functionally provides no purpose in an async function other than to bunch up the individual promises into one
* Fix AWS SAM template to account for changes ( region ) 

# Test instructions | Instructions pour tester la modification

1. Run localstack 
2. Create test form that has the submission set to vault mode
3. Submit form
4. Invoke reliability queue and there should be no errors


