### PR TITLE
feat: add S3 object scan to Vault S3 bucket

### DIFF
--- a/aws/app/vault_scan_object.tf
+++ b/aws/app/vault_scan_object.tf
@@ -1,0 +1,9 @@
+module "vault_scan_object" {
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.3//S3_scan_object"
+
+  product_name            = "vault"
+  s3_upload_bucket_name   = aws_s3_bucket.vault_file_storage.id
+  s3_upload_bucket_create = false
+
+  billing_tag_value = var.billing_tag_value
+}


### PR DESCRIPTION
# Summary
This will enable Scan Files `ClamAV` scans on all new objects
created in the Vault S3 bucket.  The scan status and verdict
will be recorded via S3 object tags.

# 🧪  Test
Once this is merged, it can be tested by checking the object tags
on a newly created S3 object.

1. On create, it should have an `av-status = in_progress` tag added.
2. Once the scan completed (~30 seconds) the `av-status` tag value will be updated.

You can also check the `/aws/lambda/s3-scan-object-vault` to see the
execution logs from the lambda function that triggers the scan.

# Related
* #224
* [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object)
* [cds-snc/terraform-modules/S3_scan_object](https://github.com/cds-snc/terraform-modules/tree/main/S3_scan_object)
