### PR TITLE
chore: s3 scan object module version bump

### DIFF
--- a/aws/app/vault_scan_object.tf
+++ b/aws/app/vault_scan_object.tf
@@ -1,5 +1,5 @@
 module "vault_scan_object" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.5//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.7//S3_scan_object"
 
   product_name            = "vault"
   s3_upload_bucket_name   = aws_s3_bucket.vault_file_storage.id


### PR DESCRIPTION
# Summary
Update the S3 scan object Terraform module to inlude the version
with the following fixes:
- Skip scans of new S3 folders
- Properly interpret SNS messages with a checksum of `None`.

# Related
* #224 
* cds-snc/scan-files#158
* cds-snc/scan-files#162