### PR TITLE
feat: enable versioning on Vault S3 bucket

### DIFF
--- a/aws/app/s3.tf
+++ b/aws/app/s3.tf
@@ -53,6 +53,10 @@ resource "aws_s3_bucket" "vault_file_storage" {
     }
   }
 
+  versioning {
+    enabled = true
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true


### PR DESCRIPTION
# Summary
Update the Vault S3 bucket to enable versioning.  This will
help prevent accidental deletion of objects by console
and CLI users.