### PR TITLE
fix: devcontainer Node.js version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,11 +6,8 @@ ARG AWS_SAM_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends build-essential ca-certificates curl dnsutils git gnupg2 jq libffi-dev make nodejs npm openssh-client python3-dev python3-pip vim zsh \
+    && apt-get -y install --no-install-recommends build-essential ca-certificates curl dnsutils git gnupg2 jq libffi-dev make openssh-client python3-dev python3-pip vim zsh \
     && apt-get autoremove -y && apt-get clean -y 
-
-# Install yarn
-RUN npm install -g yarn
 
 # Install aws-sam
 ARG AWS_SAM_SRC=https://github.com/aws/aws-sam-cli/releases/download
@@ -50,5 +47,4 @@ complete -C /usr/local/bin/terraform terragrunt\n\
 alias tf='terraform'\n\
 alias tg='terragrunt'\n\
 alias ll='la -la' \n\
-alias laws='aws --endpoint-url=http://localstack:4566 --region=ca-central-1' \n\
-export PATH=$PATH:/usr/local/go/bin/" >> /home/vscode/.zshrc
+alias laws='aws --endpoint-url=http://localstack:4566 --region=ca-central-1'" >> /home/vscode/.zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
     },
     "aws-cli": {
       "version": "2.5.6"
+    },
+    "node": {
+      "version": "lts"
     }
   },
 

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ validate: 	## Terragrunt validate all resources
 	terragrunt run-all validate
 
 terragrunt: ## Create localstack resources
+	./aws/app/lambda/deps.sh delete &&\
 	.devcontainer/scripts/terraform_apply_localstack.sh
 
 lambdas: ## Start lambdas locally
+	./aws/app/lambda/deps.sh install &&\
 	./aws/app/lambda/start_local_lambdas.sh
 
 local: terragrunt lambdas


### PR DESCRIPTION
# Summary
1. Update the Node.js version in the devcontainer so it meets
the version constraints of the new lambda dependencies.

2. Update the Makefile targets to remove lambda deps before
running the localstack Terragrunt commands.  This is done
to avoid the `node_modules` folders in the `.terragrunt-cache`
folder, which slows down the Terragrunt apply command.

3. Remove the manual `$PATH` update since it is not required and
was breaking the Node.js devcontainer feature in `zsh`.

# Testing
1. Open the project in the devcontainer.
2. Test that the following commands work:
```sh
node -v
npm -v
yarn -v
```
3. Build the local infrastructure and start the lambdas:
```sh
make terragrunt
make lambdas
```