### PR TITLE
fix: local Reliability lambda execution

### DIFF
--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -81,6 +81,14 @@ Resources:
             Ref: REGION
           NOTIFY_API_KEY:
             Ref: NOTIFY_API_KEY
+          PGUSER:
+            Ref: DBUser
+          PGPASSWORD:
+            Ref: DBPassword
+          PGHOST:
+            Ref: DBHost
+          PGDATABASE:
+            Ref: DBName
 
   Archiver:
     Type: AWS::Serverless::Function

--- a/aws/app/lambda/reliability/lib/templates.js
+++ b/aws/app/lambda/reliability/lib/templates.js
@@ -1,10 +1,11 @@
 const { RDSDataClient, ExecuteStatementCommand } = require("@aws-sdk/client-rds-data");
 const { Client } = require("pg");
+const util = require("util");
 
 const REGION = process.env.REGION;
 
 const formatError = (err) => {
-  return typeof err === "object" ? JSON.stringify(err) : err;
+  return typeof err === "object" ? util.inspect(err) : err;
 };
 /**
  * Get's the Form property on the Form Configuration
@@ -27,7 +28,7 @@ const getTemplateFormConfig = async (formID) => {
     } else {
       return null;
     }
-  } catch (e) {
+  } catch (error) {
     console.error(`{"status": "error", "error": "${formatError(error)}"}`);
     // Return as if no template with ID was found.
     // Handle error in calling function if template is not found.
@@ -114,7 +115,7 @@ const createSQLString = (formID) => {
     };
   } else {
     return {
-      SQL: `${selectSQL} WHERE id = '($1)'`,
+      SQL: `${selectSQL} WHERE id = $1`,
       parameters: [formID],
     };
   }


### PR DESCRIPTION
# Summary
- Add missing database environment variables 
- Fix the prepared statement used to retrieve form data.
- Update error logging to use `util.inspect`.  `JSON.stringify(err)` 
was only showing empty objects `{}` in the logs compared to 
`util.inspect` which shows the underlying error:

```javascript
// JSON.stringify(err)
{"status": "error", "error": "{}"}

// util.inspect(err)
{"status": "error", "error": "Error: Missing Environment Variables at processTicksAndRejections (internal/process/task_queues.js:95:5)"})

```

# Test instructions
1. Start local dev environment with `make terragrunt && make lambdas`.
2. Start platform forms client with `yarn dev`.
3. Perform a form submission.
4. Use `./aws/app/lambda/invoke_reliability.sh $SUBMISSION_ID` to trigger
the Reliability lambda.

# Related
* cds-snc/platform-forms-client#904