### PR TITLE
feat: Form Viewer read Vault S3 objects

### DIFF
--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -41,6 +41,7 @@ data "template_file" "form_viewer_task" {
     nextauth_url                    = "https://${var.domain}"
     submission_api                  = aws_lambda_function.submission.arn
     reliability_file_storage        = aws_s3_bucket.reliability_file_storage.id
+    vault_file_storage              = aws_s3_bucket.vault_file_storage.id
     gc_temp_token_template_id       = var.gc_temp_token_template_id
     gc_template_id                  = var.gc_template_id
   }

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -81,6 +81,23 @@ data "aws_iam_policy_document" "forms_s3" {
       "${aws_s3_bucket.reliability_file_storage.arn}/*"
     ]
   }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging"
+    ]
+
+    resources = [
+      aws_s3_bucket.vault_file_storage.arn,
+      "${aws_s3_bucket.vault_file_storage.arn}/*"
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_forms" {

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -56,6 +56,10 @@
       {
         "name": "TEMPLATE_ID",
         "value": "${gc_template_id}"
+      },
+      {
+        "name": "VAULT_FILE_STORAGE",
+        "value": "${vault_file_storage}"
       }
     ],
     "secrets": [


### PR DESCRIPTION
# Summary
Update the Form Viewer ECS task to grant read access to the Vault
S3 bucket objects and their tags.  

This will be used by the file scanning API endpoints to download 
form attachments and list the antivirus scan metadata which is 
stored as S3 object tags.

# Test instructions
Once the file upload API endpoints are finished:
1. Submit a form that includes file attachments.
2. Request the file antivirus scan metadata.
3. Download the form submission's files.

# Related
* cds-snc/platform-forms-client#837