### PR TITLE
Added sms_message even though it will not be used

### DIFF
--- a/aws/cognito/user_pool.tf
+++ b/aws/cognito/user_pool.tf
@@ -25,7 +25,7 @@ resource "aws_cognito_user_pool" "forms" {
     invite_message_template {
       email_message = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
       email_subject = "Welcome to GCForms"
-      sms_message = ""Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
+      sms_message = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
     }
   }
 

--- a/aws/cognito/user_pool.tf
+++ b/aws/cognito/user_pool.tf
@@ -25,6 +25,7 @@ resource "aws_cognito_user_pool" "forms" {
     invite_message_template {
       email_message = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
       email_subject = "Welcome to GCForms"
+      sms_message = ""Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
     }
   }
 

--- a/aws/cognito/user_pool.tf
+++ b/aws/cognito/user_pool.tf
@@ -25,7 +25,7 @@ resource "aws_cognito_user_pool" "forms" {
     invite_message_template {
       email_message = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
       email_subject = "Welcome to GCForms"
-      sms_message = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
+      sms_message   = "Welcome!  Please log in using the following credentials:/n  Username: {username}/n  Password: {####}"
     }
   }
 


### PR DESCRIPTION
Fixes an error thrown by terraform when creating a cognito user pool.  Even though SMS will not be used a message needs to be defined if using the 'invite_message_template' doc.  This is a known issue even if Terraform AWS documentation states the field as optional.  
https://github.com/hashicorp/terraform-provider-aws/issues/13060