### PR TITLE
Add property to generate user pool secret

### DIFF
--- a/aws/cognito/user_pool.tf
+++ b/aws/cognito/user_pool.tf
@@ -41,4 +41,5 @@ resource "aws_cognito_user_pool_client" "forms" {
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
   supported_identity_providers         = ["COGNITO"]
+  generate_secret                      = true
 }


### PR DESCRIPTION
The cognito user pool was created sucessfully however was not generating a Client Secret that could be stored in the Secret Manager.  This change ensures a secret is created.