### PR TITLE
feat: send VPC and WAF logs to Cloud Based Sensor (#253)

### DIFF
--- a/aws/load_balancer/locals.tf
+++ b/aws/load_balancer/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+}

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -234,4 +234,10 @@ resource "aws_wafv2_web_acl_association" "form_viewer_assocation" {
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_forms" {
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.forms_acl.arn
+
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
 }

--- a/aws/network/vpc_flow_log.tf
+++ b/aws/network/vpc_flow_log.tf
@@ -3,10 +3,11 @@
 # Capture network traffic over the VPC
 #
 resource "aws_flow_log" "vpc_flow_logs" {
-  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
-  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
-  traffic_type    = "ALL"
-  vpc_id          = aws_vpc.forms.id
+  log_destination      = "arn:aws:s3:::${var.cbs_satellite_bucket_name}/vpc_flow_logs/"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.forms.id
+  log_format           = "$${vpc-id} $${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${subnet-id} $${instance-id}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -14,6 +15,10 @@ resource "aws_flow_log" "vpc_flow_logs" {
   }
 }
 
+#
+# Log group can be deleted 30 days after `terraform apply` as
+# the retention period will have expired.
+#
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name              = "vpc_flow_logs"
   kms_key_id        = var.kms_key_cloudwatch_arn
@@ -22,51 +27,5 @@ resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-  }
-}
-
-resource "aws_iam_role" "vpc_flow_logs" {
-  name               = "vpc_flow_logs"
-  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_role_policy.json
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = true
-  }
-}
-
-data "aws_iam_policy_document" "vpc_flow_logs_role_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["vpc-flow-logs.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy" "vpc_flow_logs" {
-  name   = "vpc_flow_logs"
-  role   = aws_iam_role.vpc_flow_logs.id
-  policy = data.aws_iam_policy_document.vpc_flow_logs_policy.json
-}
-
-data "aws_iam_policy_document" "vpc_flow_logs_policy" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "logs:CreateLogStream",
-      "logs:DescribeLogGroups",
-      "logs:DescribeLogStreams",
-      "logs:PutLogEvents"
-    ]
-
-    resources = [
-      aws_cloudwatch_log_group.vpc_flow_logs.arn,
-      "${aws_cloudwatch_log_group.vpc_flow_logs.arn}:log-stream:*"
-    ]
   }
 }


### PR DESCRIPTION
# Summary
Update the VPC flow logs and WAF ACL logs to send to the Cloud Based Sensor satellite bucket.

The existing log bucket and CloudWatch log group can be deleted once their lifecycle rule and retention period have elapsed.

# Related
- #253 