### PR TITLE
feat: add lambda function to delete archived form templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,28 @@ REPORT RequestId: fc1f1509-63af-4a96-a798-81a295e6ca2f	Init Duration: 0.27 ms	Du
 {"statusCode":"SUCCESS"}
 ```
 
+#### Running the archive_form_templates lambda
+
+Unfortunately due to AWS SAM limitations it is not possible to automatically trigger the archive_form_templates lambda function on a daily basis.
+
+In order to run the archive_form_templates lambda you will have to call the `invoke_archive_form_templates.sh` script.
+
+```shell
+$ ./invoke_archive_form_templates.sh
+
+Reading invoke payload from stdin (you can also pass it from file with --event)
+Invoking archiver.handler (nodejs14.x)
+ReliabilityLayer is a local Layer in the template
+Building image.......................
+Skip pulling image and use local one: samcli/lambda:nodejs14.x-x86_64-2ab34c74bed6bccfbae4c6fc8.
+
+Mounting /Users/clementjanin/github/forms-terraform/aws/app/lambda/archive_form_templates as /var/task:ro,delegated inside runtime container
+START RequestId: 9ce70de4-77c1-4a39-9d4e-e46bd73d1091 Version: $LATEST
+END RequestId: 9ce70de4-77c1-4a39-9d4e-e46bd73d1091
+REPORT RequestId: 9ce70de4-77c1-4a39-9d4e-e46bd73d1091	Init Duration: 0.05 ms	Duration: 426.80 ms	Billed Duration: 427 ms	Memory Size: 128 MB	Max Memory Used: 128 MB
+{"statusCode":"SUCCESS"}
+```
+
 ## Terraform secrets
 
 Terraform will require the following variables to plan and apply:

--- a/aws/app/lambda/archive_form_templates/archiver.js
+++ b/aws/app/lambda/archive_form_templates/archiver.js
@@ -1,0 +1,10 @@
+const { deleteFormTemplatesMarkedAsArchived } = require("templates");
+
+exports.handler = async (event) => {
+  try {
+    await deleteFormTemplatesMarkedAsArchived();
+    return { status: true };
+  } catch (error) {
+    throw new Error(`Could not delete archived templates because ${error.message}`);
+  }
+};

--- a/aws/app/lambda/invoke_archive_form_templates.sh
+++ b/aws/app/lambda/invoke_archive_form_templates.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#
+# Helper script to invoke archive form templates lambda function
+#
+
+cp -a ./reliability/lib/. ./reliability/nodejs/node_modules
+
+echo '{}' | sam local invoke -t ./local_development/template.yml --event - "ArchiveFormTemplates"

--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -127,6 +127,28 @@ Resources:
           SQS_SUBMISSION_PROCESSING_QUEUE_URL:
             Ref: http://localhost:4566/000000000000/submission_processing.fifo
 
+  ArchiveFormTemplates:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName:
+        Fn::Sub: ${Environment}-${AppName}-ArchiveFormTemplates
+      CodeUri: ../archive_form_templates/
+      Handler: archiver.handler
+      Layers:
+        - Ref: ReliabilityLayer
+      Environment:
+        Variables:
+          REGION:
+            Ref: REGION
+          PGUSER:
+            Ref: DBUser
+          PGPASSWORD:
+            Ref: DBPassword
+          PGHOST:
+            Ref: DBHost
+          PGDATABASE:
+            Ref: DBName
+
   SubmissionLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:


### PR DESCRIPTION
# Summary | Résumé

linked to https://github.com/cds-snc/platform-forms-client/pull/1179

- Added a new lambda function that runs on a daily basis in order to delete form templates that have been marked as archived

# Test instructions | Instructions pour tester la modification

- Delete a form template using the admin UI
- Using the `yarn prisma:studio` database UI you can modify the `ttl` DateTime value (that is currently in the future) of the form you have deleted in order to put a date that is in the past
- Run the `archive_form_template` lambda function locally (see README.md)
- The form template should now be deleted from the database