### PR TITLE
Fix DLQ Queue

### DIFF
--- a/aws/app/lambda/dead_letter_queue_consumer/dead_letter_queue_consumer.js
+++ b/aws/app/lambda/dead_letter_queue_consumer/dead_letter_queue_consumer.js
@@ -29,12 +29,12 @@ exports.handler = async (event) => {
       );
 
       if (receiveMessageCommandOutput.Messages) {
-        const message = receiveMessageCommandOutput.Messages[0];
+        const message = JSON.parse(receiveMessageCommandOutput.Messages[0]);
 
-        const submissionID = message.Body;
+        const { submissionID } = message.Body;
         const sendMessageCommandInput = {
           QueueUrl: SQS_SUBMISSION_PROCESSING_QUEUE_URL,
-          MessageBody: JSON.stringify({ submissionID: submissionID }),
+          MessageBody: JSON.stringify(message.Body),
           MessageDeduplicationId: submissionID,
           MessageGroupId: "Group-" + submissionID,
         };


### PR DESCRIPTION
# Summary | Résumé

The DLQ redrive Lambda was incorrectly creating new messages leading to errors that the Reliability Queue could not find the submission to retry.

Each subsequent message was being created with an additional layer:
`{"submissionID":"{\"submissionID\":\"{\\\"submissionID\\\":\\\"edab5fe5-0e16-445d-851e-d057156fd0f6\\\"}\"}"}`
Instead of:
`{"submissionID":"edab5fe5-0e16-445d-851e-d057156fd0f6"}`