### PR TITLE
feat: group Docker and GitHub Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,39 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all non-major GitHub actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major github action dependencies",
+      "groupSlug": "all-non-major-github-action"
+    },
+    {
+      "description": "Group all non-major Docker images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major docker images",
+      "groupSlug": "all-non-major-docker-images"
+    }
   ]
 }


### PR DESCRIPTION
# Summary 
Update the Renovate config so that non-major GitHub action and Docker digest update PRs are grouped together.

I've been testing these suggestions since our feedback session last week and they're working well to cut down on the PRs.

# Related
- cds-snc/platform-core-services#182