### PR TITLE
Remove logic creating 2 different WAF settings for Prod and Staging

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -38,7 +38,7 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     }
   }
 
-    rule {
+  rule {
     name     = "PostRequestLimit"
     priority = 2
 

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -42,7 +42,6 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     name     = "PostRequestLimit"
     priority = 2
 
-    # Only block in `production`
     action {
       block {}
     }


### PR DESCRIPTION
# Summary | Résumé
This PR removes dynamic logic to ensure that Staging is an accurate representation of Production.
