### PR TITLE
fix: only use supported lambda_version value in userpool

### DIFF
--- a/aws/cognito/lambda_iam.tf
+++ b/aws/cognito/lambda_iam.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "cognito_lambda_assume" {
 
     principals {
       type        = "Service"
-      identifiers = ["lambda.amazonaws.com", "cognito-idp.amazonaws.com"]
+      identifiers = ["lambda.amazonaws.com"]
     }
   }
 }

--- a/aws/cognito/user_pool.tf
+++ b/aws/cognito/user_pool.tf
@@ -43,3 +43,10 @@ resource "aws_cognito_user_pool_domain" "forms" {
   domain       = "forms"
   user_pool_id = aws_cognito_user_pool.forms.id
 }
+
+resource "aws_lambda_permission" "allow_cognito" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cognito_email_sender.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.forms.arn
+}


### PR DESCRIPTION
# Summary | Résumé

permissions for cognito to access lambda
