### PR TITLE
feat: adapt code to benefit from Template DB schema rework

### DIFF
--- a/aws/app/lambda/local_development/template.yml
+++ b/aws/app/lambda/local_development/template.yml
@@ -81,6 +81,8 @@ Resources:
             Ref: REGION
           NOTIFY_API_KEY:
             Ref: NOTIFY_API_KEY
+          TEMPLATE_ID:
+            Ref: TEMPLATE_ID
           PGUSER:
             Ref: DBUser
           PGPASSWORD:

--- a/aws/app/lambda/reliability/lib/markdown.js
+++ b/aws/app/lambda/reliability/lib/markdown.js
@@ -1,15 +1,15 @@
 const json2md = require("json2md");
 const { extractFormData } = require("dataLayer");
 
-module.exports = (formResponse, submissionID, language, createdAt) => {
+module.exports = (formSubmission, submissionID, language, createdAt) => {
 
-  const title = `${language === "fr" ? (formResponse.form.emailSubjectFr
-      ? formResponse.form.emailSubjectFr
-      : formResponse.form.titleFr): (formResponse.form.emailSubjectEn
-      ? formResponse.form.emailSubjectEn
-      : formResponse.form.titleEn)}`;
+  const title = `${language === "fr" ? (formSubmission.deliveryOption.emailSubjectFr
+      ? formSubmission.deliveryOption.emailSubjectFr
+      : formSubmission.form.titleFr): (formSubmission.deliveryOption.emailSubjectEn
+      ? formSubmission.deliveryOption.emailSubjectEn
+      : formSubmission.form.titleEn)}`;
 
-  const stringifiedData = extractFormData(formResponse, language);
+  const stringifiedData = extractFormData(formSubmission, language);
   const mdBody = stringifiedData.map((item) => {
     return { p: item };
   });

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -6,7 +6,7 @@ const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 module.exports = async (submissionID, sendReceipt, formSubmission, language, createdAt) => {
   try {
     // Making sure currently processed submission email address is defined
-    if (!formSubmission.submission?.email || formSubmission.submission.email === "") {
+    if (!formSubmission.deliveryOption?.emailAddress || formSubmission.deliveryOption.emailAddress === "") {
       throw Error("Email address is missing or empty.");
     }
 
@@ -28,15 +28,15 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
     const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
     const messageSubject =
       language === "fr"
-        ? formSubmission.form.emailSubjectFr
-          ? formSubmission.form.emailSubjectFr
+        ? formSubmission.deliveryOption.emailSubjectFr
+          ? formSubmission.deliveryOption.emailSubjectFr
           : formSubmission.form.titleFr
-        : formSubmission.form.emailSubjectEn
-        ? formSubmission.form.emailSubjectEn
+        : formSubmission.deliveryOption.emailSubjectEn
+        ? formSubmission.deliveryOption.emailSubjectEn
         : formSubmission.form.titleEn;
 
     await notify
-      .sendEmail(templateID, formSubmission.submission.email, {
+      .sendEmail(templateID, formSubmission.deliveryOption.emailAddress, {
         personalisation: {
           subject: messageSubject,
           formResponse: emailBody,
@@ -79,8 +79,8 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
 
     console.error(JSON.stringify({
       status: "failed",
-      submissionId: submissionID,
-      sendReceipt: sendReceipt,
+      submissionId: submissionID ?? "n/a",
+      sendReceipt: sendReceipt ?? "n/a",
       message: "Failed to send submission through GC Notify.",
       error: errorMessage,
     }));

--- a/aws/app/lambda/reliability/lib/templates.js
+++ b/aws/app/lambda/reliability/lib/templates.js
@@ -24,7 +24,7 @@ const getTemplateFormConfig = async (formID) => {
     const data = await getTemplateData(SQL, parameters);
 
     if (data.records.length === 1) {
-      return { ...data.records[0].formConfig.form };
+      return { ...data.records[0].formConfig };
     } else {
       return null;
     }

--- a/aws/app/lambda/reliability/lib/vaultProcessing.js
+++ b/aws/app/lambda/reliability/lib/vaultProcessing.js
@@ -58,8 +58,8 @@ module.exports = async (
     // Not throwing an error back to SQS because the message was sucessfully processed by the vault. Only cleanup required.
     console.warn(JSON.stringify({
       status: "success",
-      submissionId: submissionID,
-      sendReceipt: sendReceipt,
+      submissionId: submissionID  ?? "n/a",
+      sendReceipt: sendReceipt ?? "n/a",
       message: "Successfully saved submission to Vault but failed to clean up submission processing files from database.",
       error: `${error.message}`,
     }));

--- a/aws/app/lambda/submission/submission.js
+++ b/aws/app/lambda/submission/submission.js
@@ -18,8 +18,8 @@ const sqs = new SQSClient({
 Params:
   formID - ID of form,
   language - form submission language "fr" or "en",
-  submission - submission type: email, vault
   responses - form responses: {formID, securityAttribute, questionID: answer}
+  deliveryOption - (optional) Will be present if user wants to receive form responses by email (`{ emailAddress: string; emailSubjectEn?: string; emailSubjectFr?: string }`)
   securityAttribute - string of security classification
 */
 exports.handler = async function (event) {


### PR DESCRIPTION
# Summary | Résumé

platform-forms-client pull request connected to that work: https://github.com/cds-snc/platform-forms-client/pull/1548

- Adapted code to new Template DB schema rework

# Test instructions | Instructions pour tester la modification

- Make sure your client is connected to your Localstack backend
- Create a form and add a delivery email address to it
- Fill out that form and get the `submissionId` from the submission lambda output (logs)
- Run the reliability lambda using the `submissionId`

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

- When we release that change in production there is possibility that if a form is in the process of being processed by the reliability queue we would end-up getting a failure that would not be easily recoverable. We could add more code to handle that scenario but I would like to have your inputs first.