### PR TITLE
Fix: Ensure no duplicate responses are sent through Notify

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false
+}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ LOCAL_AWS_ENDPOINT=http://localhost:4566
 ##### Everytime you want to run localstack and lambdas locally
 
 1. In one terminal run `localstack start`
-2. In a second terminal run `./localstack_services.sh`
+2. In a second terminal run `./localstack_services.sh` (If there have been infrastructure changes you'll want to run `./localstack_services.sh clean`)
 3. In a third terminal in the `platform-forms-client` repo run `yarn dev`
 
 #### It didn't work.... I need the details

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ yarn dev
 # localstack only simulates a us-east-1 region
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
-AWS_REGION=us-east-1
+AWS_REGION=ca-central-1
 RELIABILITY_FILE_STORAGE=forms-local-reliability-file-storage
 LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001
-LOCAL_S3_ENDPOINT=http://localhost:4566
+LOCAL_AWS_ENDPOINT=http://localhost:4566
 ```
 
 ##### Everytime you want to run localstack and lambdas locally

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -27,12 +27,12 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
     }, {});
 
     const templateID = process.env.TEMPLATE_ID;
-    /*
+
     const notify = new NotifyClient(
       "https://api.notification.canada.ca",
       process.env.NOTIFY_API_KEY
     );
-    */
+
     const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
     const messageSubject =
       language === "fr"
@@ -42,7 +42,7 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
         : formSubmission.deliveryOption.emailSubjectEn
         ? formSubmission.deliveryOption.emailSubjectEn
         : formSubmission.form.titleEn;
-    /*
+
     await notify.sendEmail(templateID, formSubmission.deliveryOption.emailAddress, {
       personalisation: {
         subject: messageSubject,
@@ -51,7 +51,7 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
       },
       reference: submissionID,
     });
-*/
+
     await notifyProcessed(submissionID);
 
     console.log(

--- a/aws/app/lambda/reliability/lib/notifyProcessing.js
+++ b/aws/app/lambda/reliability/lib/notifyProcessing.js
@@ -1,17 +1,20 @@
 const { NotifyClient } = require("notifications-node-client");
 const convertMessage = require("markdown");
-const { extractFileInputResponses, updateTTL } = require("dataLayer");
+const { extractFileInputResponses, notifyProcessed } = require("dataLayer");
 const { retrieveFilesFromReliabilityStorage } = require("s3FileInput");
 
 module.exports = async (submissionID, sendReceipt, formSubmission, language, createdAt) => {
   try {
     // Making sure currently processed submission email address is defined
-    if (!formSubmission.deliveryOption?.emailAddress || formSubmission.deliveryOption.emailAddress === "") {
+    if (
+      !formSubmission.deliveryOption?.emailAddress ||
+      formSubmission.deliveryOption.emailAddress === ""
+    ) {
       throw Error("Email address is missing or empty.");
     }
 
     const fileInputPaths = extractFileInputResponses(formSubmission);
-    const files = await retrieveFilesFromReliabilityStorage(fileInputPaths)
+    const files = await retrieveFilesFromReliabilityStorage(fileInputPaths);
     const attachFileParameters = fileInputPaths.reduce((acc, current, index) => {
       return {
         [`file${index}`]: {
@@ -24,7 +27,12 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
     }, {});
 
     const templateID = process.env.TEMPLATE_ID;
-    const notify = new NotifyClient("https://api.notification.canada.ca", process.env.NOTIFY_API_KEY);
+    /*
+    const notify = new NotifyClient(
+      "https://api.notification.canada.ca",
+      process.env.NOTIFY_API_KEY
+    );
+    */
     const emailBody = convertMessage(formSubmission, submissionID, language, createdAt);
     const messageSubject =
       language === "fr"
@@ -34,25 +42,26 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
         : formSubmission.deliveryOption.emailSubjectEn
         ? formSubmission.deliveryOption.emailSubjectEn
         : formSubmission.form.titleEn;
+    /*
+    await notify.sendEmail(templateID, formSubmission.deliveryOption.emailAddress, {
+      personalisation: {
+        subject: messageSubject,
+        formResponse: emailBody,
+        ...attachFileParameters,
+      },
+      reference: submissionID,
+    });
+*/
+    await notifyProcessed(submissionID);
 
-    await notify
-      .sendEmail(templateID, formSubmission.deliveryOption.emailAddress, {
-        personalisation: {
-          subject: messageSubject,
-          formResponse: emailBody,
-          ...attachFileParameters,
-        },
-        reference: submissionID,
-      });
-
-    await updateTTL(submissionID);
-
-    console.log(JSON.stringify({
-      status: "success",
-      submissionId: submissionID,
-      sendReceipt: sendReceipt,
-      message: "Successfully sent submission through GC Notify.",
-    }));
+    console.log(
+      JSON.stringify({
+        status: "success",
+        submissionId: submissionID,
+        sendReceipt: sendReceipt,
+        message: "Successfully sent submission through GC Notify.",
+      })
+    );
   } catch (error) {
     let errorMessage = "";
 
@@ -77,13 +86,15 @@ module.exports = async (submissionID, sendReceipt, formSubmission, language, cre
       errorMessage = `${error.message}.`;
     }
 
-    console.error(JSON.stringify({
-      status: "failed",
-      submissionId: submissionID ?? "n/a",
-      sendReceipt: sendReceipt ?? "n/a",
-      message: "Failed to send submission through GC Notify.",
-      error: errorMessage,
-    }));
+    console.error(
+      JSON.stringify({
+        status: "failed",
+        submissionId: submissionID ?? "n/a",
+        sendReceipt: sendReceipt ?? "n/a",
+        message: "Failed to send submission through GC Notify.",
+        error: errorMessage,
+      })
+    );
     throw new Error(`Failed to send submission through GC Notify.`);
   }
 };

--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -10,7 +10,10 @@ resource "aws_sqs_queue" "reliability_queue" {
   fifo_queue                  = true
   content_based_deduplication = true
   receive_wait_time_seconds   = 0
-  visibility_timeout_seconds  = 400
+  visibility_timeout_seconds  = 1800
+  # https://aws.amazon.com/premiumsupport/knowledge-center/lambda-function-process-sqs-messages/
+  # The SQS visibility timeout must be at least six times the total of the function timeout and the batch window timeout.
+  # Lambda function timeout is 300.
 
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = 300
@@ -52,7 +55,10 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
   fifo_queue                  = true
   content_based_deduplication = true
   receive_wait_time_seconds   = 0
-  visibility_timeout_seconds  = 400
+  visibility_timeout_seconds  = 1800
+  # https://aws.amazon.com/premiumsupport/knowledge-center/lambda-function-process-sqs-messages/
+  # The SQS visibility timeout must be at least six times the total of the function timeout and the batch window timeout.
+  # Lambda function timeout is 300.
 
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = 300

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -6,6 +6,9 @@ export TF_VAR_cognito_user_pool_arn=""
 export TF_VAR_email_address_contact_us=""
 export TF_VAR_email_address_support=""
 
+# Usage:
+# Without any args will reuse the existing cached packages saving some tiem and bandwidth
+# With the 'clean' argument will remove all cached packages for terraform and node modules for lambdas.
 
 basedir=$(pwd)
 

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -1,19 +1,33 @@
 #!/bin/bash
 
+export TF_VAR_cognito_client_id=""
+export TF_VAR_cognito_endpoint_url=""
+export TF_VAR_cognito_user_pool_arn=""
+export TF_VAR_email_address_contact_us=""
+export TF_VAR_email_address_support=""
+
 
 basedir=$(pwd)
 
+ACTION=$1
 
 printf "Configuring localstack components via terraform...\n"
 
-printf "=> Cleaning up previous caches and lambda dependency packages\n"
+if [["${ACTION}" = "clean"]]; then
+  printf "=> Cleaning up previous caches, terraform state, and lambda dependencies\n"
 
-printf "...Purging stale localstack related files\n"
+  printf "...Purging stale localstack related files\n"
   find $basedir/env/local -type d -name .terragrunt-cache -prune -exec rm -rf {} \;
 
-printf "...Removing old lambda dependencies\n"
-  cd $basedir/aws/app/lambda
-  ./deps.sh delete
+  printf "...Removing old lambda dependencies\n"
+    cd $basedir/aws/app/lambda
+    ./deps.sh delete
+fi
+
+printf "=> Cleaning previous terrafrom state, keeping previous terraform packages and lambda dependencies\n"
+
+printf "...Purging stale terraform state files\n"
+  find $basedir/env/local -type d -name terraform.tfstate -prune -exec rm -rf {} \;
 
 printf "=> Creating AWS services in Localstack\n"
 


### PR DESCRIPTION
# Summary | Résumé

closes cds-snc/platform-forms-client#1582

This PR adds a new field to the Reliability Queue Submission record that tracks if it has already been processed by Notify.
This ensures that if there is an error between polling and deleting the message from SQS the submission will be identified as already processed.

This only applies to Submissions that are processed by Notify.  Submissions processed by the Vault are instantly deleted from the Reliability queue when moved to the Vault.

**Clean Up:**
- Add a prettierrc.json so that all projects use the same formatting to reduce the number of unrelated code changes in PR's
- Modify the readme to use `ca-central-1` for the AWS Region in the client.  Otherwise the dynamodb will not function correctly when being called from the app.
- Update the SQS visibility timeout to be 6 times the lambda function timeout.  This is the suggested length in AWS documentations to reduce duplicate events sent to the Lambdas.
- Update the localstack services script to use the existing caches terraform dependencies unless used with the argument `clean`.

# Test instructions | Instructions pour tester la modification

Localstack:
- Ensure the form you will use to submit a response has a DeliveryOption set.
- Submit a form
- Invoke the reliability queue lambda through cli using `./invoke_reliability.sh ${submissionID}`
- Verify the Lambda output to ensure it was processed by Notify
- Invoke the same command again and ensure the Lambda output correctly states that it will not be processed because it is a duplicate.
- Use PostMan or another tool to send a request to `api/notify-callback` on the forms client with the submission ID of the previously submitted form.  Use a status other than delivered or permanent-failure
- The API should return a status that the submission will be reprocessed.
- Invoke the reliability queue lambda through cli using `./invoke_reliability.sh ${submissionID}`
- Verify the Lambda output to ensure it was processed by Notify