### PR TITLE
Launch Script + Reliability Invoker

### DIFF
--- a/aws/app/lambda/invoke_reliability.sh
+++ b/aws/app/lambda/invoke_reliability.sh
@@ -4,8 +4,36 @@
 # Helper script to invoke reliability lambda function
 #
 
-SUBMISSION_ID=$1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=ca-central-1
 
-cp -a ./reliability/lib/. ./reliability/nodejs/node_modules
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-echo '{"Records":[{"body": "{\"submissionID\": \"'$SUBMISSION_ID'\"}" }]}' | sam local invoke -t ./local_development/template.yml --event - "Reliability"
+cp -a $SCRIPT_DIR/reliability/lib/. $SCRIPT_DIR/reliability/nodejs/node_modules
+
+# Get Queue URL
+QUEUE_URL=$(aws sqs get-queue-url --queue-name submission_processing.fifo --endpoint-url http://localhost:4566 --query QueueUrl --output text)
+
+while :
+do
+  RAW_MESSAGE=$(aws sqs receive-message --queue-url $QUEUE_URL --max-number-of-messages 1 --visibility-timeout 60 --wait-time-seconds 2 --endpoint-url http://localhost:4566 --query 'Messages[0]')
+  if [[ $RAW_MESSAGE == "null" ]]; then
+    echo "No messages to process"
+    break
+  fi
+  RECEIPT_HANDLE=$(echo $RAW_MESSAGE | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['ReceiptHandle'])")
+  echo "Receipt Handle: $RECEIPT_HANDLE"
+  SUBMISSION_ID=$(echo $RAW_MESSAGE | python3 -c "import sys, json; data=json.load(sys.stdin); print(json.loads(data['Body'])['submissionID'])")
+  echo "SubmissionID: $SUBMISSION_ID"
+
+  echo "Running Reliability Queue Lambda"
+  echo '{"Records":[{"body": "{\"submissionID\": \"'$SUBMISSION_ID'\"}" }]}' | sam local invoke -t ./local_development/template.yml --event - "Reliability"
+
+  echo "Deleting message from SQS Queue"
+  aws sqs delete-message --queue-url $QUEUE_URL --receipt-handle $RECEIPT_HANDLE --endpoint-url http://localhost:4566 
+
+
+done
+
+

--- a/aws/app/lambda/invoke_reliability_single.sh
+++ b/aws/app/lambda/invoke_reliability_single.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Helper script to invoke reliability lambda function
+#
+
+SUBMISSION_ID=$1
+
+cp -a ./reliability/lib/. ./reliability/nodejs/node_modules
+
+echo '{"Records":[{"body": "{\"submissionID\": \"'$SUBMISSION_ID'\"}" }]}' | sam local invoke -t ./local_development/template.yml --event - "Reliability"

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -16,7 +16,7 @@ ACTION=$1
 
 printf "Configuring localstack components via terraform...\n"
 
-if [["${ACTION}" = "clean"]]; then
+if ["${ACTION}" = "clean"]; then
   printf "=> Cleaning up previous caches, terraform state, and lambda dependencies\n"
 
   printf "...Purging stale localstack related files\n"
@@ -36,19 +36,19 @@ printf "=> Creating AWS services in Localstack\n"
 
 printf "...Setting up local KMS\n"
 cd $basedir/env/local/kms
-terragrunt apply --terragrunt-non-interactive -auto-approve
+terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
 
 printf "...Creating SQS queue\n"
 cd $basedir/env/local/sqs
-terragrunt apply --terragrunt-non-interactive -auto-approve
+terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
 
 printf "...Creating SNS queue\n"
 cd $basedir/env/local/sns
-terragrunt apply --terragrunt-non-interactive -auto-approve
+terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
 
 printf "...Creating the DynamoDB database\n"
 cd $basedir/env/local/dynamodb
-terragrunt apply --terragrunt-non-interactive -auto-approve
+terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
 
 printf "...Installing lambda dependencies\n"
 cd $basedir/aws/app/lambda
@@ -56,7 +56,7 @@ cd $basedir/aws/app/lambda
 
 printf "...Creating the S3 buckets...\n"
 cd $basedir/env/local/app
-terragrunt apply --terragrunt-non-interactive -auto-approve
+terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
 
 printf "=> Starting Lambdas\n"
 cd $basedir/aws/app/lambda

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -16,7 +16,7 @@ ACTION=$1
 
 printf "Configuring localstack components via terraform...\n"
 
-if ["${ACTION}" = "clean"]; then
+if [[ "${ACTION}" == "clean" ]]; then
   printf "=> Cleaning up previous caches, terraform state, and lambda dependencies\n"
 
   printf "...Purging stale localstack related files\n"

--- a/start_dev_env.sh
+++ b/start_dev_env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+basedir=$(pwd)
+
+(trap 'kill 0' SIGINT; localstack start & (sleep 10 && $basedir/localstack_services.sh))


### PR DESCRIPTION
# Summary | Résumé
Fixes:
- A logic problem in the script `localstack_services`.  The 'clean' flag was not being triggered
Adds:
- A new script `start_dev_env` that is a quick shortcut to run localstack and lambdas in a single terminal.  This command only works if you've previously run `localstack start` and `localstack_services` separately at least once before.
Modifies:
- The script `invoke_reliability.sh` no longer requires the submission ID.  It will connect to the SQS in LocalStack, pull the messages, and process them to the Reliability Lambda.