### PR TITLE
fix: converting number to string while making dynamodb query

### DIFF
--- a/aws/app/lambda/archive_form_responses/archiver.js
+++ b/aws/app/lambda/archive_form_responses/archiver.js
@@ -106,7 +106,7 @@ async function retrieveFormResponsesToBeArchived(dynamoDb) {
             S: "Confirmed",
           },
           ":removalDate": {
-            N: Date.now(),
+            N: Date.now().toString(),
           },
         },
         ProjectionExpression:


### PR DESCRIPTION
# Summary | Résumé

- Converted number to string in dynamodb query inputs