### PR TITLE
Add alarm for Audit Log DQL and Redrive policy

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -171,24 +171,53 @@ resource "aws_cloudwatch_metric_alarm" "reliability_error_warn" {
 }
 
 #
-# Submissions in Dead Letter Queue
+# Submissions Dead Letter Queue
 #
-resource "aws_cloudwatch_metric_alarm" "forms_dead_letter_queue_warn" {
-  alarm_name          = "DeadLetterQueueWarn"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  datapoints_to_alarm = "1"
-  metric_name         = "ApproximateNumberOfMessagesDelayed"
-  namespace           = "AWS/SQS"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = "1"
-  treat_missing_data  = "notBreaching"
-  alarm_description   = "End User Forms Warning - A message has been sent to the Dead Letter Queue."
-
+resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
+  alarm_name          = "ReliabilityDeadLetterQueueWarn"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  threshold                 = "0"
+  alarm_description         = "Detect when a message is sent to the Audit Log Dead Letter Queue"
   alarm_actions = [var.sns_topic_alert_warning_arn]
-  dimensions = {
-    QueueName = var.sqs_deadletter_queue_arn
+
+  metric_query {
+    id          = "e1"
+    expression  = "RATE(m2+m1)"
+    label       = "Error Rate"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace                 = "AWS/SQS"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        QueueName    = var.sqs_reliability_deadletter_queue_arn
+      }
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesNotVisible"
+      namespace                 = "AWS/SQS"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        QueueName    = var.sqs_reliability_deadletter_queue_arn
+      }
+    }
   }
 
   tags = {
@@ -196,6 +225,64 @@ resource "aws_cloudwatch_metric_alarm" "forms_dead_letter_queue_warn" {
     Terraform             = true
   }
 }
+
+#
+# Audit Log Dead Letter Queue
+#
+resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
+  alarm_name                = "AuditLogDeadLetterQueueWarn"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  threshold                 = "0"
+  alarm_description         = "Detect when a message is sent to the Audit Log Dead Letter Queue"
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+
+  metric_query {
+    id          = "e1"
+    expression  = "RATE(m2+m1)"
+    label       = "Error Rate"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace                 = "AWS/SQS"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        QueueName    = var.sqs_audit_log_deadletter_queue_arn
+      }
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesNotVisible"
+      namespace                 = "AWS/SQS"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        QueueName    = var.sqs_audit_log_deadletter_queue_arn
+      }
+    }
+  }
+    tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+
+
 
 #
 # Service down alarm

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -175,11 +175,11 @@ resource "aws_cloudwatch_metric_alarm" "reliability_error_warn" {
 #
 resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
   alarm_name          = "ReliabilityDeadLetterQueueWarn"
-  comparison_operator       = "GreaterThanThreshold"
-  evaluation_periods        = "1"
-  threshold                 = "0"
-  alarm_description         = "Detect when a message is sent to the Audit Log Dead Letter Queue"
-  alarm_actions = [var.sns_topic_alert_warning_arn]
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = "0"
+  alarm_description   = "Detect when a message is sent to the Audit Log Dead Letter Queue"
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   metric_query {
     id          = "e1"
@@ -193,13 +193,13 @@ resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
 
     metric {
       metric_name = "ApproximateNumberOfMessagesVisible"
-      namespace                 = "AWS/SQS"
+      namespace   = "AWS/SQS"
       period      = "60"
       stat        = "Sum"
       unit        = "Count"
 
       dimensions = {
-        QueueName    = var.sqs_reliability_deadletter_queue_arn
+        QueueName = var.sqs_reliability_deadletter_queue_arn
       }
     }
   }
@@ -209,13 +209,13 @@ resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
 
     metric {
       metric_name = "ApproximateNumberOfMessagesNotVisible"
-      namespace                 = "AWS/SQS"
+      namespace   = "AWS/SQS"
       period      = "60"
       stat        = "Sum"
       unit        = "Count"
 
       dimensions = {
-        QueueName    = var.sqs_reliability_deadletter_queue_arn
+        QueueName = var.sqs_reliability_deadletter_queue_arn
       }
     }
   }
@@ -230,12 +230,12 @@ resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
 # Audit Log Dead Letter Queue
 #
 resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
-  alarm_name                = "AuditLogDeadLetterQueueWarn"
-  comparison_operator       = "GreaterThanThreshold"
-  evaluation_periods        = "1"
-  threshold                 = "0"
-  alarm_description         = "Detect when a message is sent to the Audit Log Dead Letter Queue"
-  alarm_actions = [var.sns_topic_alert_warning_arn]
+  alarm_name          = "AuditLogDeadLetterQueueWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = "0"
+  alarm_description   = "Detect when a message is sent to the Audit Log Dead Letter Queue"
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   metric_query {
     id          = "e1"
@@ -249,13 +249,13 @@ resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
 
     metric {
       metric_name = "ApproximateNumberOfMessagesVisible"
-      namespace                 = "AWS/SQS"
+      namespace   = "AWS/SQS"
       period      = "60"
       stat        = "Sum"
       unit        = "Count"
 
       dimensions = {
-        QueueName    = var.sqs_audit_log_deadletter_queue_arn
+        QueueName = var.sqs_audit_log_deadletter_queue_arn
       }
     }
   }
@@ -265,17 +265,17 @@ resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
 
     metric {
       metric_name = "ApproximateNumberOfMessagesNotVisible"
-      namespace                 = "AWS/SQS"
+      namespace   = "AWS/SQS"
       period      = "60"
       stat        = "Sum"
       unit        = "Count"
 
       dimensions = {
-        QueueName    = var.sqs_audit_log_deadletter_queue_arn
+        QueueName = var.sqs_audit_log_deadletter_queue_arn
       }
     }
   }
-    tags = {
+  tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
   }

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -178,7 +178,7 @@ resource "aws_cloudwatch_metric_alarm" "reliability_dead_letter_queue_warn" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   threshold           = "0"
-  alarm_description   = "Detect when a message is sent to the Audit Log Dead Letter Queue"
+  alarm_description   = "Detect when a message is sent to the Reliability Dead Letter Queue"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   metric_query {

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -39,8 +39,13 @@ variable "slack_webhook" {
   sensitive   = true
 }
 
-variable "sqs_deadletter_queue_arn" {
+variable "sqs_reliability_deadletter_queue_arn" {
   description = "ARN of the Reliability queue's SQS Dead Letter Queue"
+  type        = string
+}
+
+variable "sqs_audit_log_deadletter_queue_arn" {
+  description = "ARN of the Audit Log queue's SQS Dead Letter Queue"
   type        = string
 }
 

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -5,7 +5,7 @@ output "sqs_reliability_queue_id" {
 
 output "sqs_dead_letter_queue_id" {
   description = "SQS dead letter queue URL"
-  value       = aws_sqs_queue.deadletter_queue.id
+  value       = aws_sqs_queue.reliability_deadletter_queue.id
 }
 
 output "sqs_reliability_queue_arn" {
@@ -23,9 +23,14 @@ output "sqs_reprocess_submission_queue_id" {
   value       = aws_sqs_queue.reprocess_submission_queue.id
 }
 
-output "sqs_deadletter_queue_arn" {
+output "sqs_reliability_deadletter_queue_arn" {
   description = "Reliability queue's dead-letter queue ARN"
-  value       = aws_sqs_queue.deadletter_queue.name
+  value       = aws_sqs_queue.reliability_deadletter_queue.name
+}
+
+output "sqs_audit_log_deadletter_queue_arn" {
+  description = "Audit Log queue's dead-letter queue ARN"
+  value       = aws_sqs_queue.audit_log_deadletter_queue.name
 }
 
 output "sqs_audit_log_queue_arn" {

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -28,11 +28,6 @@ output "sqs_reliability_deadletter_queue_arn" {
   value       = aws_sqs_queue.reliability_deadletter_queue.name
 }
 
-output "sqs_audit_log_deadletter_queue_arn" {
-  description = "Audit Log queue's dead-letter queue ARN"
-  value       = aws_sqs_queue.audit_log_deadletter_queue.name
-}
-
 output "sqs_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
   value       = aws_sqs_queue.audit_log_queue.arn

--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -19,7 +19,7 @@ resource "aws_sqs_queue" "reliability_queue" {
   kms_data_key_reuse_period_seconds = 300
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.deadletter_queue.arn
+    deadLetterTargetArn = aws_sqs_queue.reliability_deadletter_queue.arn
     maxReceiveCount     = 5
   })
 
@@ -29,8 +29,8 @@ resource "aws_sqs_queue" "reliability_queue" {
   }
 }
 
-resource "aws_sqs_queue" "deadletter_queue" {
-  name                        = "deadletter_queue.fifo"
+resource "aws_sqs_queue" "reliability_deadletter_queue" {
+  name                        = "reliability_deadletter_queue.fifo"
   delay_seconds               = 60
   max_message_size            = 262144
   message_retention_seconds   = 1209600
@@ -64,7 +64,7 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
   kms_data_key_reuse_period_seconds = 300
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.deadletter_queue.arn
+    deadLetterTargetArn = aws_sqs_queue.reliability_deadletter_queue.arn
     maxReceiveCount     = 5
   })
 
@@ -92,6 +92,11 @@ resource "aws_sqs_queue" "audit_log_queue" {
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.audit_log_deadletter_queue.arn
     maxReceiveCount     = 5
+  })
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.audit_log_deadletter_queue.arn]
   })
 
   tags = {

--- a/env/production/alarms/terragrunt.hcl
+++ b/env/production/alarms/terragrunt.hcl
@@ -44,7 +44,8 @@ dependency "sqs" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    sqs_deadletter_queue_arn = ""
+    sqs_reliability_deadletter_queue_arn = ""
+    sqs_audit_log_deadletter_queue_arn = ""
   }
 }
 
@@ -88,7 +89,8 @@ inputs = {
   lb_arn        = dependency.load_balancer.outputs.lb_arn
   lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
 
-  sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
+  sqs_reliability_deadletter_queue_arn = dependency.sqs.outputs.sqs_reliability_deadletter_queue_arn
+  sqs_audit_log_deadletter_queue_arn   = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn
 
   ecs_cloudwatch_log_group_name     = dependency.app.outputs.ecs_cloudwatch_log_group_name
   ecs_cluster_name                  = dependency.app.outputs.ecs_cluster_name

--- a/env/staging/alarms/terragrunt.hcl
+++ b/env/staging/alarms/terragrunt.hcl
@@ -44,7 +44,8 @@ dependency "sqs" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    sqs_deadletter_queue_arn = ""
+    sqs_reliability_deadletter_queue_arn = ""
+    sqs_audit_log_deadletter_queue_arn = ""
   }
 }
 
@@ -88,7 +89,8 @@ inputs = {
   lb_arn        = dependency.load_balancer.outputs.lb_arn
   lb_arn_suffix = dependency.load_balancer.outputs.lb_arn_suffix
 
-  sqs_deadletter_queue_arn = dependency.sqs.outputs.sqs_deadletter_queue_arn
+  sqs_reliability_deadletter_queue_arn = dependency.sqs.outputs.sqs_reliability_deadletter_queue_arn
+  sqs_audit_log_deadletter_queue_arn   = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn
 
   ecs_cloudwatch_log_group_name     = dependency.app.outputs.ecs_cloudwatch_log_group_name
   ecs_cluster_name                  = dependency.app.outputs.ecs_cluster_name


### PR DESCRIPTION
# Summary | Résumé
- Adds an alarm for when messages are sent to the Audit Log DLQ
- Modifies existing alarm for reliability DLQ.  Alarm will not reset until messages are cleared.
- Adds redrive policy so that Audit Log messages can be retried through the AWS Management Console and removes the requirement for an additional lambda function.

closes #342 
