### PR TITLE
Fix missing rename in app module for lambda

### DIFF
--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -220,8 +220,8 @@ variable "sqs_reprocess_submission_queue_id" {
 }
 
 
-variable "sqs_dead_letter_queue_id" {
-  description = "SQS dead letter queue URL"
+variable "sqs_reliability_dead_letter_queue_id" {
+  description = "SQS Reliability dead letter queue URL"
   type        = string
 }
 

--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -291,7 +291,7 @@ resource "aws_lambda_function" "dead_letter_queue_consumer" {
   environment {
     variables = {
       REGION                              = var.region
-      SQS_DEAD_LETTER_QUEUE_URL           = var.sqs_dead_letter_queue_id
+      SQS_DEAD_LETTER_QUEUE_URL           = var.sqs_reliability_dead_letter_queue_id
       SQS_SUBMISSION_PROCESSING_QUEUE_URL = var.sqs_reliability_queue_id
       SNS_ERROR_TOPIC_ARN                 = var.sns_topic_alert_critical_arn
     }

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -3,8 +3,8 @@ output "sqs_reliability_queue_id" {
   value       = aws_sqs_queue.reliability_queue.id
 }
 
-output "sqs_dead_letter_queue_id" {
-  description = "SQS dead letter queue URL"
+output "sqs_reliability_dead_letter_queue_id" {
+  description = "SQS Reliability dead letter queue URL"
   value       = aws_sqs_queue.reliability_deadletter_queue.id
 }
 

--- a/env/local/app/terragrunt.hcl
+++ b/env/local/app/terragrunt.hcl
@@ -40,7 +40,7 @@ dependency "sqs" {
     sqs_reliability_queue_arn          = ""
     sqs_reliability_queue_id           = ""
     sqs_reprocess_submission_queue_arn = ""
-    sqs_dead_letter_queue_id           = ""
+    sqs_reliability_dead_letter_queue_id           = ""
     sqs_audit_log_queue_arn            = ""
     sqs_audit_log_queue_id             = ""
     sqs_audit_log_deadletter_queue_arn = ""
@@ -117,7 +117,7 @@ inputs = {
   sqs_reliability_queue_arn          = dependency.sqs.outputs.sqs_reliability_queue_arn
   sqs_reliability_queue_id           = dependency.sqs.outputs.sqs_reliability_queue_id
   sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
-  sqs_dead_letter_queue_id           = dependency.sqs.outputs.sqs_dead_letter_queue_id
+  sqs_reliability_dead_letter_queue_id           = dependency.sqs.outputs.sqs_reliability_dead_letter_queue_id
   sqs_audit_log_queue_arn            = dependency.sqs.outputs.sqs_audit_log_queue_arn
   sqs_audit_log_queue_id             = dependency.sqs.outputs.sqs_audit_log_queue_id
   sqs_audit_log_deadletter_queue_arn = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn

--- a/env/production/app/terragrunt.hcl
+++ b/env/production/app/terragrunt.hcl
@@ -92,7 +92,7 @@ dependency "sqs" {
     sqs_reliability_queue_arn          = "" 
     sqs_reliability_queue_id           = ""
     sqs_reprocess_submission_queue_arn = ""
-    sqs_dead_letter_queue_id           = ""
+    sqs_reliability_dead_letter_queue_id           = ""
   }
 }
 
@@ -151,7 +151,7 @@ inputs = {
   sqs_reliability_queue_arn          = dependency.sqs.outputs.sqs_reliability_queue_arn 
   sqs_reliability_queue_id           = dependency.sqs.outputs.sqs_reliability_queue_id
   sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
-  sqs_dead_letter_queue_id           = dependency.sqs.outputs.sqs_dead_letter_queue_id
+  sqs_reliability_           = dependency.sqs.outputs.sqs_reliability_dead_letter_queue_id
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
   sns_topic_alert_warning_arn  = dependency.sns.outputs.sns_topic_alert_warning_arn

--- a/env/staging/app/terragrunt.hcl
+++ b/env/staging/app/terragrunt.hcl
@@ -90,7 +90,7 @@ dependency "sqs" {
     sqs_reliability_queue_arn          = ""
     sqs_reliability_queue_id           = ""
     sqs_reprocess_submission_queue_arn = ""
-    sqs_dead_letter_queue_id           = ""
+    sqs_reliability_dead_letter_queue_id           = ""
     sqs_audit_log_queue_arn            = ""
     sqs_audit_log_queue_id             = ""
     sqs_audit_log_deadletter_queue_arn = ""
@@ -167,7 +167,7 @@ inputs = {
   sqs_reliability_queue_arn          = dependency.sqs.outputs.sqs_reliability_queue_arn
   sqs_reliability_queue_id           = dependency.sqs.outputs.sqs_reliability_queue_id
   sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
-  sqs_dead_letter_queue_id           = dependency.sqs.outputs.sqs_dead_letter_queue_id
+  sqs_reliability_dead_letter_queue_id           = dependency.sqs.outputs.sqs_reliability_dead_letter_queue_id
   sqs_audit_log_queue_arn            = dependency.sqs.outputs.sqs_audit_log_queue_arn
   sqs_audit_log_queue_id             = dependency.sqs.outputs.sqs_audit_log_queue_id
   sqs_audit_log_deadletter_queue_arn = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn


### PR DESCRIPTION
# Summary | Résumé

Fixes rename for the Reliability DLQ that was missed in an earlier PR.
