### PR TITLE
Fix / Templates parseConfig function

### DIFF
--- a/aws/app/lambda/reliability/lib/templates.js
+++ b/aws/app/lambda/reliability/lib/templates.js
@@ -142,6 +142,7 @@ const parseConfig = (records) => {
   if (records) {
     const parsedRecords = records.map((record) => {
       let formConfig;
+      let deliveryOption;
       if (!process.env.AWS_SAM_LOCAL) {
         formConfig = JSON.parse(record[0].stringValue.trim(1, -1)) || undefined;
       } else {


### PR DESCRIPTION
# Summary | Résumé

The Template lib's parseConfig function is missing a variable declaration.
