### PR TITLE
Update firewall rule

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -208,7 +208,7 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
   }
-/*
+  /*
   rule {
     name     = "BlockInvalidURLPath"
     priority = 3


### PR DESCRIPTION
# Summary | Résumé

Firewall blocking renamed and newly created pages.

New Regex statement is too long with added pages.
Commenting out rule for now until we can revisit.

Closes cds-snc/platform-forms-client#2036