### PR TITLE
fix: increased nagware lambda timeout

### DIFF
--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -517,6 +517,7 @@ resource "aws_lambda_function" "nagware" {
   function_name = "Nagware"
   role          = aws_iam_role.lambda.arn
   handler       = "nagware.handler"
+  timeout       = 300
 
   source_code_hash = data.archive_file.nagware_main.output_base64sha256
 


### PR DESCRIPTION
# Summary | Résumé

- Increased nagware lambda timeout to 300 seconds (from 3). Two days ago our lambda started to reach that timeout limit.