### PR TITLE
feat: nagware lambda now ignores GC Notify safelist error in staging

### DIFF
--- a/aws/app/lambda/nagware/lib/emailNotification.js
+++ b/aws/app/lambda/nagware/lib/emailNotification.js
@@ -41,7 +41,14 @@ Si les réponses ne sont toujours pas confirmées après 45 jours, un processus 
       },
     });
   } catch (error) {
-    throw new Error(`Failed to send email to form owner. Reason: ${error.message}.`);
+    if (process.env.ENVIRONMENT === "staging") {
+      if (error.response?.data?.errors) {
+        if (error.response.data.errors.find(e => e.message.includes("Can’t send to this recipient using a team-only API key")) !== undefined) 
+          return;
+      }
+    }
+    
+    throw new Error(`Failed to send email to form owner. Reason: ${error.response?.data?.errors ? JSON.stringify(error.response.data.errors) : error.message}.`);
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

- Added condition to ignore GC Notify safelist error when Nagware lambda runs in staging