### PR TITLE
add type module to package.json

### DIFF
--- a/aws/app/lambda/audit_logs/nodejs/package.json
+++ b/aws/app/lambda/audit_logs/nodejs/package.json
@@ -2,6 +2,7 @@
   "name": "audit_logs",
   "version": "1.0.0",
   "main": "audit_logs.js",
+  "type": "module",
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.300.0",


### PR DESCRIPTION
# Summary | Résumé

Add's `{"type" : "module"}` to package.json so Lambda is correctly run using ES6 instead of ES5. 