### PR TITLE
fix: s3 scan object function timeout

### DIFF
--- a/aws/app/vault_scan_object.tf
+++ b/aws/app/vault_scan_object.tf
@@ -1,5 +1,5 @@
 module "vault_scan_object" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.13//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.9//S3_scan_object"
 
   product_name          = "vault"
   s3_upload_bucket_name = aws_s3_bucket.vault_file_storage.id


### PR DESCRIPTION
# Summary
Update to the latest version of the `s3_scan_object` module which increases the transport lambda function's timeout from 3s to 120s.

This fixes an issue seen in Notify where the transport lambda was timing out if it had to wait for a Scan Files API function cold start.

# Related
- cds-snc/platform-core-services#297
- cds-snc/terraform-modules#251