### PR TITLE
fix: missing variables in GC Notify call when Cognito tries to send emails

### DIFF
--- a/aws/cognito/lambda/cognito_email_sender/cognito_email_sender.js
+++ b/aws/cognito/lambda/cognito_email_sender/cognito_email_sender.js
@@ -47,6 +47,9 @@ exports.handler = async (event) => {
       await notify.sendEmail(TEMPLATE_ID, userEmail, {
         personalisation: {
           passwordReset: event.triggerSource === "CustomEmailSender_ForgotPassword",
+          // Keeping `accountVerification` and `resendCode` variables in case we need them in the future. They were removed when we implemented 2FA.
+          accountVerification: false,
+          resendCode: false,
           code: plainTextCode
         }
       });


### PR DESCRIPTION
# Summary | Résumé

- Re-added `accountVerification` and `resendCode` to the GC Notify `personalisation` object. They are still required by the GC Notify email template. We could have removed them from the template but since we are still early in the development process of the 2FA feature we never know what will happen. We may need them back at some point...