### PR TITLE
Step one : attempt to upgrade db engine version from 11.16 to 13.6

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -19,7 +19,7 @@ resource "aws_rds_cluster" "forms" {
   cluster_identifier        = "${var.rds_name}-cluster"
   engine                    = "aurora-postgresql"
   engine_mode               = "serverless"
-  engine_version            = "13.6" 
+  engine_version            = "13.6"
   enable_http_endpoint      = true
   database_name             = var.rds_db_name
   deletion_protection       = true


### PR DESCRIPTION
# Summary | Résumé

This is the first PR in a suite of PRs to migrate the `aurora-postgresql` cluster to support `Serverless V2`.

The reasoning behind this approach is that it helps mitigate risks associated with major upgrades by breaking them down into smaller, manageable steps. It allows us to identity and address potential issues early on, reducing the impact on your production environment. It also provides an opportunity to make necessary adjustments or optimizations along the way to ensure a smoother transition. 

## Caution before merge

- A snapshot of the `forms-staging-db-cluster` was taken to ensure a return to safety.
## Post-merge check.

- Engine version was successful updated from 11.16 to 13.6.
- Monitor the cluster health status.
- Check there is no errors (connexion, sql errors etc...) in cloudWatch.


