### PR TITLE
feat: added new 2FA alarm for when a user is locked out because of too many verification failed attempts

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -594,12 +594,12 @@ resource "aws_cloudwatch_log_metric_filter" "cognito_signin_exceeded" {
 resource "aws_cloudwatch_metric_alarm" "cognito_signin_exceeded" {
   alarm_name          = "CognitoSigninExceeded"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = aws_cloudwatch_log_metric_filter.cognito_signin_exceeded.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.cognito_signin_exceeded.metric_transformation[0].namespace
-  period              = "60"
+  period              = 60
   statistic           = "Sum"
-  threshold           = "10" # this could also be adjusted depending on what we think is a good threshold
+  threshold           = 5 # this could also be adjusted depending on what we think is a good threshold
   treat_missing_data  = "notBreaching"
   alarm_description   = "Cognito - multiple failed sign-in attempts detected."
 
@@ -627,12 +627,12 @@ resource "aws_cloudwatch_log_metric_filter" "twoFa_verification_exceeded" {
 resource "aws_cloudwatch_metric_alarm" "twoFa_verification_exceeded" {
   alarm_name          = "2FAVerificationExceeded"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = aws_cloudwatch_log_metric_filter.twoFa_verification_exceeded.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.twoFa_verification_exceeded.metric_transformation[0].namespace
-  period              = "60"
+  period              = 60
   statistic           = "Sum"
-  threshold           = "10" # this could also be adjusted depending on what we think is a good threshold
+  threshold           = 2 # this could also be adjusted depending on what we think is a good threshold
   treat_missing_data  = "notBreaching"
   alarm_description   = "2FA - multiple failed verification attempts detected. User has been locked out (see audit logs)."
 


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/2150
Goes with https://github.com/cds-snc/platform-forms-client/pull/2227

- Add new 2FA alarm for when a user is locked out because of too many verification failed attempts