### PR TITLE
Remove engine version attribute from rds_cluster config

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -19,7 +19,6 @@ resource "aws_rds_cluster" "forms" {
   cluster_identifier        = "${var.rds_name}-cluster"
   engine                    = "aurora-postgresql"
   engine_mode               = "serverless"
-  engine_version            = "13.6"
   enable_http_endpoint      = true
   database_name             = var.rds_db_name
   deletion_protection       = true


### PR DESCRIPTION
# Summary | Résumé
Corrected the terraform configuration due to the attempt to update the engine version.
