### PR TITLE
chore: use form-builder edit page for health check

### DIFF
--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -35,7 +35,7 @@ resource "aws_lb_target_group" "form_viewer_1" {
   health_check {
     enabled             = true
     interval            = 10
-    path                = "/api/version"
+    path                = "/form-builder/edit"
     port                = 3000
     matcher             = "301,200"
     timeout             = 5
@@ -62,7 +62,7 @@ resource "aws_lb_target_group" "form_viewer_2" {
     enabled             = true
     interval            = 10
     port                = 3000
-    path                = "/api/version"
+    path                = "/form-builder/edit"
     matcher             = "301,200"
     timeout             = 5
     healthy_threshold   = 2


### PR DESCRIPTION
# Summary | Résumé

In preparation for the auto-change log on platform-forms-client change the load balancer health check to monitor a dynamic page like '/form-builder/edit' which is rendered on every call and is a better test of the viability of the application.