### PR TITLE
fix: allow Lambda forms client VPC access

### DIFF
--- a/aws/pr_review/iam.tf
+++ b/aws/pr_review/iam.tf
@@ -56,3 +56,9 @@ resource "aws_iam_role_policy_attachment" "cognito_forms_lambda_client" {
   role       = aws_iam_role.forms_lambda_client[0].name
   policy_arn = var.ecs_iam_forms_cognito_policy_arn
 }
+
+resource "aws_iam_role_policy_attachment" "forms_lambda_client_vpc_access" {
+  count      = var.env == "staging" ? 1 : 0
+  role       = aws_iam_role.forms_lambda_client[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}


### PR DESCRIPTION
# Summary
Update the PR review environment's IAM role to allow it to attach to a VPC.  This is needed as it will then allow the lambda function access to the forms VPC resources, as allowed through the resource security groups.

# Related
- cds-snc/platform-core-services#378