### PR TITLE
chore: update engine to 13.9 and allow major version upgrade

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -16,20 +16,20 @@ resource "aws_db_subnet_group" "forms" {
 }
 
 resource "aws_rds_cluster" "forms" {
-  cluster_identifier        = "${var.rds_name}-cluster"
-  engine                    = "aurora-postgresql"
-  engine_mode               = "serverless"
-  engine_version            = "13.9"
-  enable_http_endpoint      = true
-  database_name             = var.rds_db_name
-  deletion_protection       = true
-  final_snapshot_identifier = "server-${random_string.random.result}"
-  master_username           = var.rds_db_user
-  master_password           = var.rds_db_password
-  backup_retention_period   = 5
-  preferred_backup_window   = "07:00-09:00"
-  db_subnet_group_name      = aws_db_subnet_group.forms.name
-  storage_encrypted         = true
+  cluster_identifier          = "${var.rds_name}-cluster"
+  engine                      = "aurora-postgresql"
+  engine_mode                 = "serverless"
+  engine_version              = "13.9"
+  enable_http_endpoint        = true
+  database_name               = var.rds_db_name
+  deletion_protection         = true
+  final_snapshot_identifier   = "server-${random_string.random.result}"
+  master_username             = var.rds_db_user
+  master_password             = var.rds_db_password
+  backup_retention_period     = 5
+  preferred_backup_window     = "07:00-09:00"
+  db_subnet_group_name        = aws_db_subnet_group.forms.name
+  storage_encrypted           = true
   allow_major_version_upgrade = true
 
 

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -19,6 +19,7 @@ resource "aws_rds_cluster" "forms" {
   cluster_identifier        = "${var.rds_name}-cluster"
   engine                    = "aurora-postgresql"
   engine_mode               = "serverless"
+  engine_version            = "13.9"
   enable_http_endpoint      = true
   database_name             = var.rds_db_name
   deletion_protection       = true
@@ -29,6 +30,7 @@ resource "aws_rds_cluster" "forms" {
   preferred_backup_window   = "07:00-09:00"
   db_subnet_group_name      = aws_db_subnet_group.forms.name
   storage_encrypted         = true
+  allow_major_version_upgrade = true
 
 
   scaling_configuration {


### PR DESCRIPTION
# Summary | Résumé
I'd like to retry the in place engine upgrade of #399.

The AWS [upgrade chart](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.html) shows that we should be able to go from version 11.16 to version 13.9.  The original PR attempted to upgrade to version 13.6, which is impossible for version 11.16.

This PR also enables the major version upgrade by including the `allow_major_version_upgrade = true` switch.

# Test instructions | Instructions pour tester la modification

The PR planning should show an in place engine update and not a destroy event.
