### PR TITLE
fix: allow PR review env invoke Submission lambda

### DIFF
--- a/aws/app/outputs.tf
+++ b/aws/app/outputs.tf
@@ -8,6 +8,11 @@ output "lambda_reliability_log_group_name" {
   value       = "/aws/lambda/${aws_lambda_function.reliability.function_name}"
 }
 
+output "lambda_submission_function_name" {
+  description = "Submission lambda function name"
+  value       = aws_lambda_function.submission.function_name
+}
+
 output "ecs_cluster_name" {
   description = "ECS cluster name"
   value       = aws_ecs_cluster.forms.name

--- a/aws/pr_review/inputs.tf
+++ b/aws/pr_review/inputs.tf
@@ -47,3 +47,8 @@ variable "forms_redis_security_group_id" {
   description = "Security group ID for the redis"
   type        = string
 }
+
+variable "forms_submission_lambda_name" {
+  description = "Name of the Forms Submission Lambda function"
+  type        = string
+}

--- a/aws/pr_review/lambda.tf
+++ b/aws/pr_review/lambda.tf
@@ -1,0 +1,8 @@
+resource "aws_lambda_permission" "submission_lambda_invoke" {
+  count          = var.env == "staging" ? 1 : 0
+  statement_id   = "AllowSubmissionInvokeFromPRReviewEnvs"
+  action         = "lambda:InvokeFunction"
+  principal      = "lambda.amazonaws.com"
+  function_name  = var.forms_submission_lambda_name
+  source_account = var.account_id
+}

--- a/env/cloud/pr_review/terragrunt.hcl
+++ b/env/cloud/pr_review/terragrunt.hcl
@@ -13,16 +13,13 @@ dependency "app" {
   mock_outputs_merge_with_state           = true
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    ecs_cloudwatch_log_group_name     = ""
-    ecs_cluster_name                  = ""
-    ecs_service_name                  = ""
-    lambda_reliability_log_group_name = ""
+    lambda_submission_function_name          = ""
     ecs_iam_forms_secrets_manager_policy_arn = ""
-    ecs_iam_forms_kms_policy_arn = ""
-    ecs_iam_forms_s3_policy_arn = ""
-    ecs_iam_forms_dynamodb_policy_arn = ""
-    ecs_iam_forms_sqs_policy_arn = ""
-    ecs_iam_forms_cognito_policy_arn = ""
+    ecs_iam_forms_kms_policy_arn             = ""
+    ecs_iam_forms_s3_policy_arn              = ""
+    ecs_iam_forms_dynamodb_policy_arn        = ""
+    ecs_iam_forms_sqs_policy_arn             = ""
+    ecs_iam_forms_cognito_policy_arn         = ""
   }
 }
 
@@ -33,25 +30,25 @@ dependency "network" {
   mock_outputs_merge_with_state           = true
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    private_subnet_ids = [""]
-    vpc_id = ""
-    privatelink_security_group_id = ""
+    vpc_id                           = ""
+    privatelink_security_group_id    = ""
     forms_database_security_group_id = ""
-    forms_redis_security_group_id = ""
+    forms_redis_security_group_id    = ""
   }
 }
 
 inputs = {
-  vpc_id = dependency.network.outputs.vpc_id
+  vpc_id                                   = dependency.network.outputs.vpc_id
   ecs_iam_forms_secrets_manager_policy_arn = dependency.app.outputs.ecs_iam_forms_secrets_manager_policy_arn
-  ecs_iam_forms_kms_policy_arn = dependency.app.outputs.ecs_iam_forms_kms_policy_arn
-  ecs_iam_forms_s3_policy_arn = dependency.app.outputs.ecs_iam_forms_s3_policy_arn
-  ecs_iam_forms_dynamodb_policy_arn = dependency.app.outputs.ecs_iam_forms_dynamodb_policy_arn
-  ecs_iam_forms_sqs_policy_arn = dependency.app.outputs.ecs_iam_forms_sqs_policy_arn
-  ecs_iam_forms_cognito_policy_arn = dependency.app.outputs.ecs_iam_forms_cognito_policy_arn
-  privatelink_security_group_id = dependency.network.outputs.privatelink_security_group_id
-  forms_database_security_group_id = dependency.network.outputs.rds_security_group_id
-  forms_redis_security_group_id = dependency.network.outputs.redis_security_group_id
+  ecs_iam_forms_kms_policy_arn             = dependency.app.outputs.ecs_iam_forms_kms_policy_arn
+  ecs_iam_forms_s3_policy_arn              = dependency.app.outputs.ecs_iam_forms_s3_policy_arn
+  ecs_iam_forms_dynamodb_policy_arn        = dependency.app.outputs.ecs_iam_forms_dynamodb_policy_arn
+  ecs_iam_forms_sqs_policy_arn             = dependency.app.outputs.ecs_iam_forms_sqs_policy_arn
+  ecs_iam_forms_cognito_policy_arn         = dependency.app.outputs.ecs_iam_forms_cognito_policy_arn
+  privatelink_security_group_id            = dependency.network.outputs.privatelink_security_group_id
+  forms_database_security_group_id         = dependency.network.outputs.rds_security_group_id
+  forms_redis_security_group_id            = dependency.network.outputs.redis_security_group_id
+  forms_submission_lambda_name             = dependency.app.outputs.lambda_submission_function_name
 }
 
 include {

--- a/env/cloud/pr_review/terragrunt.hcl
+++ b/env/cloud/pr_review/terragrunt.hcl
@@ -13,7 +13,7 @@ dependency "app" {
   mock_outputs_merge_with_state           = true
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    lambda_submission_function_name          = ""
+    lambda_submission_function_name          = "Submission"
     ecs_iam_forms_secrets_manager_policy_arn = ""
     ecs_iam_forms_kms_policy_arn             = ""
     ecs_iam_forms_s3_policy_arn              = ""


### PR DESCRIPTION
# Summary
Add Lambda permission resource that allows the PR review environment lambda functions to invoke the Submission lambda.

# Related
- cds-snc/platform-core-services#378