### PR TITLE
fix: Submission lambda permission for PR review env

### DIFF
--- a/aws/pr_review/lambda.tf
+++ b/aws/pr_review/lambda.tf
@@ -1,8 +1,7 @@
 resource "aws_lambda_permission" "submission_lambda_invoke" {
-  count          = var.env == "staging" ? 1 : 0
-  statement_id   = "AllowSubmissionInvokeFromPRReviewEnvs"
-  action         = "lambda:InvokeFunction"
-  principal      = "lambda.amazonaws.com"
-  function_name  = var.forms_submission_lambda_name
-  source_account = var.account_id
+  count         = var.env == "staging" ? 1 : 0
+  statement_id  = "AllowSubmissionInvokeFromPRReviewEnvs"
+  action        = "lambda:InvokeFunction"
+  principal     = aws_iam_role.forms_lambda_client.arn
+  function_name = var.forms_submission_lambda_name
 }

--- a/aws/pr_review/lambda.tf
+++ b/aws/pr_review/lambda.tf
@@ -2,6 +2,6 @@ resource "aws_lambda_permission" "submission_lambda_invoke" {
   count         = var.env == "staging" ? 1 : 0
   statement_id  = "AllowSubmissionInvokeFromPRReviewEnvs"
   action        = "lambda:InvokeFunction"
-  principal     = aws_iam_role.forms_lambda_client.arn
+  principal     = aws_iam_role.forms_lambda_client[0].arn
   function_name = var.forms_submission_lambda_name
 }


### PR DESCRIPTION
# Summary
Update the Submission lambda function permissions to grant the PR review env's IAM role the ability to invoke the function.

# Related
- cds-snc/platform-core-services#386