### PR TITLE
feat: upgrade S3_scan_object to SQS queue

### DIFF
--- a/aws/app/vault_scan_object.tf
+++ b/aws/app/vault_scan_object.tf
@@ -1,12 +1,6 @@
 module "vault_scan_object" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.9//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v6.0.2//S3_scan_object"
 
-  product_name          = "vault"
   s3_upload_bucket_name = aws_s3_bucket.vault_file_storage.id
-
-  alarm_on_lambda_error     = true
-  alarm_error_sns_topic_arn = var.sns_topic_alert_warning_arn
-  alarm_ok_sns_topic_arn    = var.sns_topic_alert_ok_arn
-
-  billing_tag_value = var.billing_tag_value
+  billing_tag_value     = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Upgrade the `S3_scan_object` module to use the SQS queue to deliver S3 object events to Scan Files.

This change was made to support Notify's high load of async file scanning and in performance testing, behaves much more consistently than the transport lambda used in the previous version of the module.

# ⚠️  Note
Once this has merged, a change will be needed to the Scan Files API to have it use the new SQS queue as a source of S3 events.

# Related
- cds-snc/platform-core-services#380
