### PR TITLE
fix: Terraform module version reference

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -2,7 +2,7 @@
 # Create Athena queries to view the WAF and load balancer access logs
 #
 module "athena" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.0.0//athena_access_logs"
+  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=v5.0.0"
 
   athena_bucket_name = module.athena_bucket.s3_bucket_id
 
@@ -18,7 +18,7 @@ module "athena" {
 # Hold the Athena data
 #
 module "athena_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.5//S3"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v2.0.5"
   bucket_name       = "forms-${var.env}-athena-bucket"
   billing_tag_value = var.billing_tag_value
 

--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -2,7 +2,7 @@
 # Create Athena queries to view the WAF and load balancer access logs
 #
 module "athena" {
-  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=v5.0.0"
+  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=v6.1.3"
 
   athena_bucket_name = module.athena_bucket.s3_bucket_id
 
@@ -18,7 +18,7 @@ module "athena" {
 # Hold the Athena data
 #
 module "athena_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v2.0.5"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v3.0.0"
   bucket_name       = "forms-${var.env}-athena-bucket"
   billing_tag_value = var.billing_tag_value
 

--- a/aws/app/vault_scan_object.tf
+++ b/aws/app/vault_scan_object.tf
@@ -1,5 +1,5 @@
 module "vault_scan_object" {
-  source = "github.com/cds-snc/terraform-modules?ref=v6.0.2//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.1.3"
 
   s3_upload_bucket_name = aws_s3_bucket.vault_file_storage.id
   billing_tag_value     = var.billing_tag_value


### PR DESCRIPTION
# Summary
Update the Terraform module version references so they are in the [correct format](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories): 

> If the source address has arguments, such as the ref argument supported for the version control sources, the sub-directory portion must be before those arguments:

This will allow Renovate dependency PRs to update the module versions without stripping the `//sub-directory` path.

# Note
All modules have been upgrade to their latest compatible versions.