### PR TITLE
fix: waf regex invalid syntax

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -282,11 +282,11 @@ resource "aws_wafv2_regex_pattern_set" "valid_app_uri_paths" {
   description = "Regex to match the app valid urls"
 
   regular_expression {
-    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|id|api|auth|signup|myforms|unsupported-browser|terms-of-use|404)(?:\\/[\\w-]+)?+)(?:\\/.*)?$"
+    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|id|api|auth|signup|myforms|unsupported-browser|terms-of-use|404)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
   }
 
   regular_expression {
-    regex_string = "^\\/(?:en|fr)?\\/?(?:(form-builder|sla|unlock-publishing|terms-and-conditions|javascript-disabled)(?:\\/[\\w-]+)?+)(?:\\/.*)?$"
+    regex_string = "^\\/(?:en|fr)?\\/?(?:(form-builder|sla|unlock-publishing|terms-and-conditions|javascript-disabled)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
   }
 
   regular_expression {


### PR DESCRIPTION
# Summary | Résumé
Fix WAF invalid parameter exception error on regex pattern set due to invalid syntax