### PR TITLE
Restore missing output for lambda function name

### DIFF
--- a/aws/app/outputs.tf
+++ b/aws/app/outputs.tf
@@ -8,6 +8,11 @@ output "lambda_reliability_log_group_name" {
   value       = aws_cloudwatch_log_group.reliability.name
 }
 
+output "lambda_submission_function_name" {
+  description = "Submission lambda function name"
+  value       = aws_lambda_function.submission.function_name
+}
+
 output "lambda_submission_log_group_name" {
   description = "Submission Lambda CloudWatch log group name"
   value       = aws_cloudwatch_log_group.submission.name


### PR DESCRIPTION
# Summary | Résumé

Restores an app module output for `lambda_submission_function_name` needed to get the pr_review module to run.
