### PR TITLE
chore: upgrade python image

### DIFF
--- a/aws/load_testing/lambda/Dockerfile
+++ b/aws/load_testing/lambda/Dockerfile
@@ -1,8 +1,9 @@
-FROM amazon/aws-lambda-python:3.7@sha256:4aead3a75aa0c0b63a493bb8c5417ee0f1a166cde60e9c49f382817761ea827e
-
+FROM amazon/aws-lambda-python:3.11@sha256:93f1bd317ac630ad7fac3e5acd782697a6c1c0a461b2cb254e205328fd27ca53
 COPY lambda_locust.py .
 COPY tests ./tests
 COPY requirements.txt .
+
+RUN yum groupinstall "Development Tools"
 
 RUN pip3 install --upgrade pip
 

--- a/aws/load_testing/lambda/Dockerfile
+++ b/aws/load_testing/lambda/Dockerfile
@@ -3,7 +3,7 @@ COPY lambda_locust.py .
 COPY tests ./tests
 COPY requirements.txt .
 
-RUN yum groupinstall "Development Tools"
+RUN yum -y groupinstall "Development Tools"
 
 RUN pip3 install --upgrade pip
 


### PR DESCRIPTION
# Summary | Résumé

Updates python image for load testing lambda to 3.11 and ensures invokust compilation by installing Development Tools at build time.