### PR TITLE
fix: Add missing freshdesk api key to ecs task

### DIFF
--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -114,6 +114,10 @@
       {
         "name": "GC_NOTIFY_CALLBACK_BEARER_TOKEN",
         "valueFrom": "${gc_notify_callback_bearer_token}"
+      },
+      {
+        "name": "FRESHDESK_API_KEY",
+        "valueFrom": "${freshdesk_api_key}"
       }
     ]
   }


### PR DESCRIPTION
# Summary | Résumé
Adds missing entry under secrets in ECS task