### PR TITLE
fix iam permissiosn for freskdesk secret

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -49,7 +49,8 @@ data "aws_iam_policy_document" "forms_secrets_manager" {
       aws_secretsmanager_secret_version.recaptcha_secret.arn,
       aws_secretsmanager_secret_version.notify_api_key.arn,
       aws_secretsmanager_secret_version.token_secret.arn,
-      aws_secretsmanager_secret_version.gc_notify_callback_bearer_token.arn
+      aws_secretsmanager_secret_version.gc_notify_callback_bearer_token.arn,
+      aws_secretsmanager_secret_version.freshdesk_api_key.arn
     ]
   }
 }


### PR DESCRIPTION
# Summary | Résumé
Fix IAM permissions to allow ecs to access freskdesk scret