### PR TITLE
feat: notify Slack if Terraform apply fails

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -123,6 +123,9 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
+        env:
+          WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_NAME: "${{ github.workflow }}"
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}    

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -120,3 +120,9 @@ jobs:
       - name: Terragrunt apply alarms
         working-directory: env/cloud/alarms
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}    

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -107,9 +107,6 @@ jobs:
             sqs:
               - 'aws/sqs/**'
               - 'env/cloud/sqs/**'
-            pr_review:
-              - 'aws/pr_review/**'
-              - 'env/cloud/pr_review/**'
 
       # No dependencies
       - name: Terragrunt apply ecr
@@ -245,6 +242,11 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply pr_review
-        if: ${{ steps.filter.outputs.pr_review == 'true' || steps.filter.outputs.common == 'true' }}
         working-directory: env/cloud/pr_review
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.STAGING_SLACK_WEBHOOK }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -247,6 +247,9 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
+        env:
+          WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_NAME: "${{ github.workflow }}"
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.STAGING_SLACK_WEBHOOK }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -103,9 +103,6 @@ jobs:
             sqs:
               - 'aws/sqs/**'
               - 'env/cloud/sqs/**'
-            pr_review:
-              - 'aws/pr_review/**'
-              - 'env/cloud/pr_review/**'
 
       # No dependencies
       - name: Terragrunt plan ecr
@@ -273,7 +270,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan pr_review
-        if: ${{ steps.filter.outputs.pr_review == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@28d2efe5155573489fa5b5816fad20d44d1f274b # v3.0.7
         with:
           directory: "env/cloud/pr_review"


### PR DESCRIPTION
# Summary
Add a failure step to the Staging and Production Terraform apply workflows that will post a message to the appropriate `#forms-production-events` or `#forms-staging-events` channel if the workflow fails.

Additionally, remove the `pr_review` module filter condition from the Staging Terraform workflows. This will ensure that the `pr_review` module is always run during a Terraform apply and that its security groups are properly created.

# Related
- https://github.com/cds-snc/platform-core-services/issues/441