### PR TITLE
chore: use GitHub app token with release-please

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -13,9 +13,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@49ce228ea7cddec9f88dd09c5b7740dbac82d7ba # v1.2.1
+        id: sre_app_token
+        with:
+          app_id: ${{ vars.SRE_APP_ID }}
+          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+
       - uses: google-github-actions/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # v3.7.11
         with:
           command: manifest
-          token: ${{secrets.RELEASE_GENERATOR_TOKEN}}
+          token: ${{ steps.sre_app_token.outputs.token }}
           release-type: simple
           default-branch: develop


### PR DESCRIPTION
# Summary | Résumé
Update the Release Please workflow to use a GitHub app token generated using the SRE Read/Write bot which has the required `Content (read/write)` and `PR (read/write)` permissions.

The temporary token generated will allow for the invoke of dependent workflows and be revoked once the workflow is finished.

 # Related | Associé
- https://github.com/cds-snc/platform-core-services/issues/441