### PR TITLE
fix: SQS Max Message size to 256kb

### DIFF
--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -5,7 +5,7 @@
 resource "aws_sqs_queue" "reliability_queue" {
   name                        = "submission_processing.fifo"
   delay_seconds               = 5
-  max_message_size            = 2048
+  max_message_size            = 262144
   message_retention_seconds   = 345600
   fifo_queue                  = true
   content_based_deduplication = true
@@ -50,7 +50,7 @@ resource "aws_sqs_queue" "reliability_deadletter_queue" {
 resource "aws_sqs_queue" "reprocess_submission_queue" {
   name                        = "reprocess_submission_queue.fifo"
   delay_seconds               = 900 // 15 minutes
-  max_message_size            = 2048
+  max_message_size            = 262144
   message_retention_seconds   = 172800 // 2 days
   fifo_queue                  = true
   content_based_deduplication = true
@@ -79,7 +79,7 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
 resource "aws_sqs_queue" "audit_log_queue" {
   name                       = "audit_log_queue"
   delay_seconds              = 0
-  max_message_size           = 2048
+  max_message_size           = 262144
   message_retention_seconds  = 172800 // 2 days
   visibility_timeout_seconds = 1960
   # https://aws.amazon.com/premiumsupport/knowledge-center/lambda-function-process-sqs-messages/


### PR DESCRIPTION
# Summary | Résumé
Fixes an issue where the GC Forms app could not properly send audit logs that were larger than 2048 bytes.