### PR TITLE
fix: format of TF workflow Slack webhook URL

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -126,4 +126,4 @@ jobs:
           WORKFLOW_NAME: "${{ github.workflow }}"
         run: |
           json='{"channel":"#forms-production-events", "blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}    
+          curl -X POST -H 'Content-type: application/json' --data "$json" "https://hooks.slack.com${{ secrets.PRODUCTION_SLACK_WEBHOOK }}"

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -250,4 +250,4 @@ jobs:
           WORKFLOW_NAME: "${{ github.workflow }}"
         run: |
           json='{"channel":"#forms-staging-events", "blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.STAGING_SLACK_WEBHOOK }}
+          curl -X POST -H 'Content-type: application/json' --data "$json" "https://hooks.slack.com${{ secrets.STAGING_SLACK_WEBHOOK }}"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tf.plan
 
 # Ignore local stack data file
 .devcontainer/data
+
+# Local environment variables
+.env*


### PR DESCRIPTION
# Summary
Update the Slack webhook URLs in the Terraform apply workflows to include the protocol and host.

Update .gitignore to ignore `.env` files.