### PR TITLE
fix: Needed to use double quote on domain local placeholder

### DIFF
--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -7,7 +7,7 @@ dependencies {
 }
 
 locals {
-  domain = jsondecode(get_env("APP_DOMAINS", "['localhost:3000']"))
+  domain = jsondecode(get_env("APP_DOMAINS", "[\"localhost:3000\"]"))
 }
 
 dependency "hosted_zone" {

--- a/env/cloud/load_balancer/terragrunt.hcl
+++ b/env/cloud/load_balancer/terragrunt.hcl
@@ -7,7 +7,7 @@ dependencies {
 }
 
 locals {
-  domain = jsondecode(get_env("APP_DOMAINS", "['localhost:3000']"))
+  domain = jsondecode(get_env("APP_DOMAINS", "[\"localhost:3000\"]"))
 }
 
 

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -1,7 +1,7 @@
 locals {
   account_id = get_env("AWS_ACCOUNT_ID", "")
   env = get_env("APP_ENV", "local")
-  domains = get_env("APP_DOMAINS", "['localhost:3000']")
+  domains = get_env("APP_DOMAINS", "[\"localhost:3000\"]")
 }
 
 inputs = {


### PR DESCRIPTION
# Summary | Résumé

Changes the default local value for the domains array to use double quotes.