### PR TITLE
fix: update to README file, adjust iterator age alarm threshold and fix to vault data integrity check local lambda test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Pre-requisites:
   ```bash
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   ```
-- LocalStack : `brew install localstack`
+
+- LocalStack:
+
+  1. `brew install localstack`
+
+  Please note that the latest tested version of Localstack with your infrastructure code was `2.3.2`.
+
 - Terragrunt:
 
   1. `brew install warrensbox/tap/tfswitch`
@@ -32,10 +38,10 @@ Pre-requisites:
 
 - AWS SAM CLI
 
-  Please run these commands to install the aws sam cli using homebrew. The AWS SAM CLI is what we use to run the lambda functions locally and invoke them.
+  1. If you previously had it installed with Brew then you should first uninstall this package using `brew uninstall aws-sam-cli`
+  1. To install the AWS SAM CLI tool, follow the instructions on https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html under "macOS" and "Command line - All users" (you will have to download the .pkg file and run a command to install it on your machine)
 
-  1. `brew tap aws/tap`
-  1. `brew install aws-sam-cli`
+  Please note that the latest tested version of AWS SAM CLI with your infrastructure code was `1.99.0`.
 
 - Postgres and PGAdmin
   1. `brew install postgresql`

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -433,11 +433,11 @@ resource "aws_cloudwatch_metric_alarm" "vault_data_integrity_check_lambda_iterat
   metric_name         = "IteratorAge"
   statistic           = "Average"
   comparison_operator = "GreaterThanThreshold"
-  threshold           = "30000"
+  threshold           = "90000" // 90 seconds (Lambda consumes events every 60 seconds if low traffic. Adding 30 seconds on top of that for the processing time of that Lambda)
   period              = "60"
   evaluation_periods  = "2"
 
-  alarm_description = "The Vault data integrity check lambda function is unable to keep up with the amount of events sent by the Vault DynamoDB stream"
+  alarm_description = "Warning - Vault data integrity check lambda is unable to keep up with the amount of events sent by the Vault DynamoDB stream"
   alarm_actions     = [var.sns_topic_alert_warning_arn]
   ok_actions        = [var.sns_topic_alert_ok_arn]
 

--- a/aws/app/lambda/invoke_test_vault_data_integrity_check.sh
+++ b/aws/app/lambda/invoke_test_vault_data_integrity_check.sh
@@ -346,11 +346,11 @@ echo '{
           "FormID": {
             "S": "clmqej5xf0002mi8krkfmim02"
           },
+          "NAME_OR_CONF": {
+            "S": "NAME#19-09-0043"
+          },
           "ConfirmationCode": {
             "S": "fb303d9e-3afd-4ef3-bfd8-fc4596f70223"
-          },
-          "CreatedAt": {
-            "N": "1695139169449"
           },
           "FormSubmission": {
             "S": "{\"1\":\"\"}"


### PR DESCRIPTION
# Summary | Résumé

- Updated README file to reflect changes in Localstack and AWS SAM CLI versions
- Adjusted threshold for new IteratorAge alarm
- Fixed issue in payload being passed to the Vault data integrity check lambda when running locally