### PR TITLE
feat: add code signing to vault data integrity check lambda

### DIFF
--- a/aws/app/lambda.tf
+++ b/aws/app/lambda.tf
@@ -625,15 +625,16 @@ data "archive_file" "vault_data_integrity_check_main" {
 }
 
 resource "aws_lambda_function" "vault_data_integrity_check" {
-  filename      = "/tmp/vault_data_integrity_check_main.zip"
   function_name = "VaultDataIntegrityCheck"
   role          = aws_iam_role.lambda.arn
-  handler       = "vault_data_integrity_check.handler"
   timeout       = 60
+  runtime       = "nodejs18.x"
 
-  source_code_hash = data.archive_file.vault_data_integrity_check_main.output_base64sha256
-
-  runtime = "nodejs18.x"
+  s3_bucket               = aws_signer_signing_job.vault_data_integrity_check_lambda_signing_job.signed_object[0].s3[0].bucket
+  s3_key                  = aws_signer_signing_job.vault_data_integrity_check_lambda_signing_job.signed_object[0].s3[0].key
+  handler                 = "vault_data_integrity_check.handler"
+  source_code_hash        = data.archive_file.vault_data_integrity_check_main.output_base64sha256
+  code_signing_config_arn = aws_lambda_code_signing_config.lambda_code_signing_config.arn
 
   tracing_config {
     mode = "PassThrough"

--- a/aws/app/s3.tf
+++ b/aws/app/s3.tf
@@ -108,3 +108,51 @@ resource "aws_s3_bucket_public_access_block" "archive_storage" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+#
+# Code signed Lambda
+#
+
+resource "aws_s3_bucket" "code_signed_lambda_storage" {
+  # checkov:skip=CKV_AWS_18: Versioning not required
+  # checkov:skip=CKV_AWS_21: Access logging not required
+  bucket = "forms-${var.env}-code-signed-lambda-storage"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "code_signed_lambda_storage" {
+  bucket                  = aws_s3_bucket.code_signed_lambda_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_object" "vault_data_integrity_check_main" {
+  bucket      = aws_s3_bucket.code_signed_lambda_storage.id
+  key         = "unsigned/vault_data_integrity_check_main.zip"
+  source      = data.archive_file.vault_data_integrity_check_main.output_path
+  source_hash = data.archive_file.vault_data_integrity_check_main.output_base64sha256
+
+  depends_on = [
+    aws_s3_bucket.code_signed_lambda_storage,
+    data.archive_file.vault_data_integrity_check_main
+  ]
+}

--- a/aws/app/signer.tf
+++ b/aws/app/signer.tf
@@ -1,0 +1,39 @@
+resource "aws_signer_signing_profile" "lambda_signing_profile" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  name_prefix = "lambda_signing_profile_"
+}
+
+resource "aws_lambda_code_signing_config" "lambda_code_signing_config" {
+  allowed_publishers {
+    signing_profile_version_arns = [aws_signer_signing_profile.lambda_signing_profile.version_arn]
+  }
+
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
+}
+
+resource "aws_signer_signing_job" "vault_data_integrity_check_lambda_signing_job" {
+  profile_name = aws_signer_signing_profile.lambda_signing_profile.name
+
+  source {
+    s3 {
+      bucket  = aws_s3_bucket.code_signed_lambda_storage.id
+      key     = aws_s3_bucket_object.vault_data_integrity_check_main.id
+      version = aws_s3_bucket_object.vault_data_integrity_check_main.version_id
+    }
+  }
+
+  destination {
+    s3 {
+      bucket = aws_s3_bucket.code_signed_lambda_storage.id
+      prefix = "signed/"
+    }
+  }
+
+  ignore_signing_job_failure = true
+
+  depends_on = [
+    aws_s3_bucket_object.vault_data_integrity_check_main
+  ]
+}


### PR DESCRIPTION
# Summary | Résumé

- Added code signing to vault data integrity check lambda

PS: I could not fully test it in Localstack as it does not support AWS Signer and also we do not yet have a proper lambda implementation.