### PR TITLE
feat: redirect to static maintenance web page when in maintenance mode or service is down

### DIFF
--- a/aws/load_balancer/cloudfront.tf
+++ b/aws/load_balancer/cloudfront.tf
@@ -1,0 +1,65 @@
+locals {
+  s3_origin_id = "MaintenanceMode"
+}
+
+resource "aws_cloudfront_origin_access_identity" "maintenance_mode" {
+  comment = "Access Identity for the Maintenance Website"
+}
+
+resource "aws_cloudfront_distribution" "maintenance_mode" {
+  # checkov:skip=CKV_AWS_68: WAF ACL not required
+  # checkov:skip=CKV_AWS_86: Access logging not required
+  enabled             = true
+  http_version        = "http2"
+  default_root_object = "index.html"
+  web_acl_id          = aws_wafv2_web_acl.forms_acl.arn
+  aliases             = var.domains
+
+  origin {
+    origin_id   = local.s3_origin_id
+    domain_name = aws_s3_bucket.maintenance_mode.bucket_regional_domain_name
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.maintenance_mode.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    compress         = true
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+
+  depends_on = [
+    aws_s3_bucket.maintenance_mode
+  ]
+}

--- a/aws/load_balancer/cloudfront.tf
+++ b/aws/load_balancer/cloudfront.tf
@@ -14,6 +14,7 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
   default_root_object = "index.html"
   web_acl_id          = aws_wafv2_web_acl.forms_acl.arn
   aliases             = var.domains
+  price_class         = "PriceClass_100"
 
   origin {
     origin_id   = local.s3_origin_id

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -1,6 +1,7 @@
 #
 # Route53 records
 #
+
 resource "aws_route53_record" "form_viewer" {
   count   = length(var.domains)
   zone_id = var.hosted_zone_ids[count.index]
@@ -12,6 +13,33 @@ resource "aws_route53_record" "form_viewer" {
     zone_id                = aws_lb.form_viewer.zone_id
     evaluate_target_health = true
   }
+
+  failover_routing_policy {
+    type = "PRIMARY"
+  }
+
+  set_identifier  = "form_viewer_${var.domains[count.index]}_primary"
+  health_check_id = aws_route53_health_check.gc_forms_application.id
+}
+
+resource "aws_route53_record" "form_viewer_maintenance" {
+  # checkov:skip=CKV2_AWS_23: False-positive, record is attached to Cloudfront domain name
+  count   = length(var.domains)
+  zone_id = var.hosted_zone_ids[count.index]
+  name    = var.domains[count.index]
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.maintenance_mode.domain_name
+    zone_id                = aws_cloudfront_distribution.maintenance_mode.hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  failover_routing_policy {
+    type = "SECONDARY"
+  }
+
+  set_identifier = "form_viewer_${var.domains[count.index]}_secondary"
 }
 
 #
@@ -39,4 +67,18 @@ resource "aws_route53_record" "form_viewer_certificate_validation" {
   type            = each.value.type
   zone_id         = local.domain_name_to_zone_id[each.value.domain]
 
+}
+
+resource "aws_route53_health_check" "gc_forms_application" {
+  fqdn              = var.domains[0]
+  port              = "443"
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "2"
+  request_interval  = "30"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
 }

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -73,7 +73,7 @@ resource "aws_route53_health_check" "gc_forms_application" {
   fqdn              = var.domains[0]
   port              = "443"
   type              = "HTTPS"
-  resource_path     = "/"
+  resource_path     = "/form-builder/edit"
   failure_threshold = "2"
   request_interval  = "30"
 

--- a/aws/load_balancer/s3.tf
+++ b/aws/load_balancer/s3.tf
@@ -1,0 +1,77 @@
+resource "aws_s3_bucket" "maintenance_mode" {
+  # checkov:skip=CKV_AWS_18: Versioning not required
+  # checkov:skip=CKV_AWS_19: False-positive, server side encryption is enabled but probably not detected because defined in a different Terraform resource
+  # checkov:skip=CKV_AWS_21: Access logging not required
+  bucket = "gc-forms-application-maintenance-page"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_s3_bucket_acl" "maintenance_mode" {
+  bucket = aws_s3_bucket.maintenance_mode.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "maintenance_mode" {
+  bucket = aws_s3_bucket.maintenance_mode.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "maintenance_mode" {
+  bucket                  = aws_s3_bucket.maintenance_mode.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_website_configuration" "maintenance_mode" {
+  bucket = aws_s3_bucket.maintenance_mode.id
+
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_object" "maintenance_static_page" {
+  bucket       = aws_s3_bucket.maintenance_mode.bucket
+  key          = "index.html"
+  source       = "./static_website/index.html"
+  content_type = "text/html"
+  etag         = filemd5("./static_website/index.html")
+}
+
+data "aws_iam_policy_document" "allow_cloudfront_to_access_static_website_in_s3" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.maintenance_mode.iam_arn
+      ]
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.maintenance_mode.arn,
+      "${aws_s3_bucket.maintenance_mode.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_cloudfront_to_access_static_website_in_s3" {
+  bucket = aws_s3_bucket.maintenance_mode.id
+  policy = data.aws_iam_policy_document.allow_cloudfront_to_access_static_website_in_s3.json
+}

--- a/aws/load_balancer/static_website/index.html
+++ b/aws/load_balancer/static_website/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Under maintenance</title>
+  </head>
+  <body>
+    Under maintenance
+  </body>
+</html>


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/forms-terraform/issues/29

- Added infra resources to redirect users to a static maintenance page when system is down or under maintenance mode

Note: since this cannot be tested locally, I expect changes/fixes to be required after we merge this as there will probably be stuff missing in the configuration of resources.