### PR TITLE
fix: missing WAF rule and certificate. Health check now targets load balancer DNS

### DIFF
--- a/aws/load_balancer/certificates.tf
+++ b/aws/load_balancer/certificates.tf
@@ -1,11 +1,34 @@
 #
 # Domain certificate
 #
+
+locals {
+  domains = concat(var.domains, [aws_lb.form_viewer.dns_name])
+}
+
 resource "aws_acm_certificate" "form_viewer" {
   # First entry in domain list is the primary domain
-  domain_name       = var.domains[0]
-  validation_method = "DNS"
-  # subject_alternative_names = length(var.domains) > 1 ? setsubtract(var.domains, [var.domains[0]]) : []
+  domain_name               = local.domains[0]
+  validation_method         = "DNS"
+  subject_alternative_names = length(local.domains) > 1 ? setsubtract(local.domains, [local.domains[0]]) : []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_acm_certificate" "form_viewer_maintenance_mode" {
+  # First entry in domain list is the primary domain
+  domain_name               = local.domains[0]
+  validation_method         = "DNS"
+  subject_alternative_names = length(local.domains) > 1 ? setsubtract(local.domains, [local.domains[0]]) : []
+
+  provider = aws.us-east-1
 
   lifecycle {
     create_before_destroy = true

--- a/aws/load_balancer/cloudfront.tf
+++ b/aws/load_balancer/cloudfront.tf
@@ -12,8 +12,8 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
   enabled             = true
   http_version        = "http2"
   default_root_object = "index.html"
-  # web_acl_id          = aws_wafv2_web_acl.forms_acl.arn - We may want to create a new WAF2 web acl resource with a CLOUDFRONT scope just for this
-  price_class = "PriceClass_100"
+  web_acl_id          = aws_wafv2_web_acl.forms_maintenance_mode_acl.arn
+  price_class         = "PriceClass_100"
 
   origin {
     origin_id   = local.s3_origin_id
@@ -51,7 +51,9 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = aws_acm_certificate.form_viewer_maintenance_mode.arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
   }
 
   tags = {

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -46,7 +46,7 @@ resource "aws_route53_record" "form_viewer_maintenance" {
 # Certificate validation
 # 
 locals {
-  domain_name_to_zone_id = zipmap(var.domains, var.hosted_zone_ids)
+  domain_name_to_zone_id = zipmap(concat(var.domains, [aws_lb.form_viewer.dns_name]), concat(var.hosted_zone_ids, [aws_lb.form_viewer.zone_id]))
 }
 
 
@@ -70,8 +70,8 @@ resource "aws_route53_record" "form_viewer_certificate_validation" {
 }
 
 resource "aws_route53_health_check" "gc_forms_application" {
-  fqdn              = var.domains[0]
-  port              = "443"
+  fqdn              = aws_lb.form_viewer.dns_name
+  port              = 443
   type              = "HTTPS"
   resource_path     = "/form-builder/edit"
   failure_threshold = "2"


### PR DESCRIPTION
# Summary | Résumé

- Added basic WAF rule to only allow GET request on "/" for the Cloudfront distribution
- Added missing certificate for our Cloudfront distribution
- Health check now targets load balancer DNS address