### PR TITLE
fix: missing provider in waf rule

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -304,6 +304,8 @@ resource "aws_wafv2_web_acl" "forms_maintenance_mode_acl" {
   name  = "GCFormsMaintenanceMode"
   scope = "CLOUDFRONT"
 
+  provider = aws.us-east-1
+
   default_action {
     block {}
   }


### PR DESCRIPTION
# Summary | Résumé

- Fixed missing provider in new WAF rule for Cloudfront.