### PR TITLE
fix: intergrity alarm

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -436,7 +436,8 @@ resource "aws_cloudwatch_metric_alarm" "vault_data_integrity_check_lambda_iterat
   threshold           = "90000" // 90 seconds (Lambda consumes events every 60 seconds if low traffic. Adding 30 seconds on top of that for the processing time of that Lambda)
   period              = "60"
   evaluation_periods  = "2"
-
+  treat_missing_data  = "notBreaching"
+  
   alarm_description = "Warning - Vault data integrity check lambda is unable to keep up with the amount of events sent by the Vault DynamoDB stream"
   alarm_actions     = [var.sns_topic_alert_warning_arn]
   ok_actions        = [var.sns_topic_alert_ok_arn]

--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -437,7 +437,7 @@ resource "aws_cloudwatch_metric_alarm" "vault_data_integrity_check_lambda_iterat
   period              = "60"
   evaluation_periods  = "2"
   treat_missing_data  = "notBreaching"
-  
+
   alarm_description = "Warning - Vault data integrity check lambda is unable to keep up with the amount of events sent by the Vault DynamoDB stream"
   alarm_actions     = [var.sns_topic_alert_warning_arn]
   ok_actions        = [var.sns_topic_alert_ok_arn]


### PR DESCRIPTION
# Summary | Résumé

Intregrity alarm treats no data as non-breaching

Fixes:
![Screenshot 2023-12-06 at 8 26 41 AM](https://github.com/cds-snc/forms-terraform/assets/25329319/808f7ee8-a410-4213-ba49-3a397bec9a80)

