### PR TITLE
fix: Add missing output to app module

### DIFF
--- a/aws/app/outputs.tf
+++ b/aws/app/outputs.tf
@@ -13,6 +13,11 @@ output "ecs_service_name" {
   value       = aws_ecs_service.form_viewer.name
 }
 
+output "ecs_iam_role_arn" {
+  description = "ECS task's IAM role ARN"
+  value       = aws_iam_role.forms.arn
+}
+
 output "ecs_iam_forms_secrets_manager_policy_arn" {
   description = "IAM policy for access to Secrets Manager"
   value       = aws_iam_policy.forms_secrets_manager.arn


### PR DESCRIPTION
# Summary | Résumé

Adds missing iam_role for ecs task to output of app module