### PR TITLE
fix: GC Notify API Key is not properly passed to Nagware and Reliability lambdas

### DIFF
--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -216,9 +216,7 @@ data "aws_iam_policy_document" "lambda_secrets" {
     ]
 
     resources = [
-      var.database_secret_arn,
-      var.notify_api_key_secret_arn,
-      var.token_secret_arn
+      var.database_secret_arn
     ]
   }
 }

--- a/aws/lambdas/inputs.tf
+++ b/aws/lambdas/inputs.tf
@@ -1,16 +1,11 @@
-
-variable "notify_api_key_secret_arn" {
-  description = "ARN of notify_api_key secret"
+variable "notify_api_key_secret_value" {
+  description = "Value of notify_api_key secret"
   type        = string
+  sensitive   = true
 }
 
 variable "gc_template_id" {
   description = "GC Notify send a notification templateID"
-  type        = string
-}
-
-variable "token_secret_arn" {
-  description = "Token secret used for app"
   type        = string
 }
 

--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "nagware" {
       DB_ARN                    = var.rds_cluster_arn
       DB_SECRET                 = var.database_secret_arn
       DB_NAME                   = var.rds_db_name
-      NOTIFY_API_KEY            = var.notify_api_key_secret_arn
+      NOTIFY_API_KEY            = var.notify_api_key_secret_value
       TEMPLATE_ID               = var.gc_template_id
       SNS_ERROR_TOPIC_ARN       = var.sns_topic_alert_critical_arn
       LOCALSTACK                = var.localstack_hosted

--- a/aws/lambdas/reliability.tf
+++ b/aws/lambdas/reliability.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "reliability" {
     variables = {
       ENVIRONMENT    = var.env
       REGION         = var.region
-      NOTIFY_API_KEY = var.notify_api_key_secret_arn
+      NOTIFY_API_KEY = var.notify_api_key_secret_value
       TEMPLATE_ID    = var.gc_template_id
       DB_ARN         = var.rds_cluster_arn
       DB_SECRET      = var.database_secret_arn

--- a/aws/secrets/outputs.tf
+++ b/aws/secrets/outputs.tf
@@ -3,6 +3,12 @@ output "notify_api_key_secret_arn" {
   value       = aws_secretsmanager_secret_version.notify_api_key.arn
 }
 
+output "notify_api_key_secret_value" {
+  description = "Value of notify_api_key secret"
+  value       = aws_secretsmanager_secret_version.notify_api_key.secret_string
+  sensitive   = true
+}
+
 output "freshdesk_api_key_secret_arn" {
   description = "ARN of freshdesk_api_key secret"
   value       = aws_secretsmanager_secret.freshdesk_api_key.arn

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -106,6 +106,7 @@ dependency "secrets" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     notify_api_key_secret_arn               = ""
+    notify_api_key_secret_value             = ""
     freshdesk_api_key_secret_arn            = ""
     token_secret_arn                        = ""
     recaptcha_secret_arn                    = ""

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -90,6 +90,7 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
     notify_api_key_secret_arn               = ""
+    notify_api_key_secret_value             = ""
     freshdesk_api_key_secret_arn            = ""
     token_secret_arn                        = ""
     recaptcha_secret_arn                    = ""
@@ -134,8 +135,7 @@ inputs = {
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
 
-  notify_api_key_secret_arn = dependency.secrets.outputs.notify_api_key_secret_arn
-  token_secret_arn          = dependency.secrets.outputs.token_secret_arn
+  notify_api_key_secret_value = dependency.secrets.outputs.notify_api_key_secret_value
 
   reliability_file_storage_arn = dependency.s3.outputs.reliability_file_storage_arn
   vault_file_storage_arn       = dependency.s3.outputs.vault_file_storage_arn


### PR DESCRIPTION
# Summary | Résumé

- Fixed GC Notify API key not being properly passed (string instead of ARN) to Nagware and Reliability lambdas
- Removed `token_secret` from lambda module as it was not used

What happened:
With the new infra rework we did not take into account the fact that two of our lambdas were using the string value of the GC Notify API key secret. We converted it to an ARN value but the code does not know how to handle such value.

Note: We could definitely rework that at some point by adding an extra request to go get the secret value using the ARN.