### PR TITLE
fix: split Staging/Prod use of Scan Files service

### DIFF
--- a/aws/file_scanning/vault_scan_object.tf
+++ b/aws/file_scanning/vault_scan_object.tf
@@ -1,6 +1,13 @@
-module "vault_scan_object" {
-  source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.1.3"
+locals {
+  scan_files_account = var.env == "production" ? "806545929748" : "127893201980"
+}
 
-  s3_upload_bucket_name = var.vault_file_storage_id
-  billing_tag_value     = var.billing_tag_value
+module "vault_scan_object" {
+  source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v9.0.0"
+
+  s3_upload_bucket_name   = var.vault_file_storage_id
+  s3_scan_object_role_arn = "arn:aws:iam::${local.scan_files_account}:role/s3-scan-object"
+  scan_files_role_arn     = "arn:aws:iam::${local.scan_files_account}:role/scan-files-api"
+
+  billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Update the Scan Object integration to send Forms Staging file scans to the Scan Files Staging environment.

This will ensure that Staging environment performance and penetration testing does not impact the Scan Files Production service.
