### PR TITLE
fix: ACL not compatible with Owernship Controls

### DIFF
--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -17,13 +17,6 @@ resource "aws_s3_bucket_ownership_controls" "reliability_file_storage" {
   }
 }
 
-resource "aws_s3_bucket_acl" "reliability_file_storage" {
-  depends_on = [aws_s3_bucket_ownership_controls.reliability_file_storage]
-  bucket     = aws_s3_bucket.reliability_file_storage.id
-
-  acl = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "reliability_file_storage" {
   # checkov:skip=CKV_AWS_300: Lifecycle configuration for aborting failed (multipart) upload not required
   bucket = aws_s3_bucket.reliability_file_storage.id
@@ -76,14 +69,6 @@ resource "aws_s3_bucket_ownership_controls" "vault_file_storage" {
   }
 }
 
-resource "aws_s3_bucket_acl" "vault_file_storage" {
-  depends_on = [aws_s3_bucket_ownership_controls.vault_file_storage]
-  bucket     = aws_s3_bucket.vault_file_storage.id
-
-  acl = "private"
-}
-
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "vault_file_storage" {
   bucket = aws_s3_bucket.vault_file_storage.id
 
@@ -119,13 +104,6 @@ resource "aws_s3_bucket_ownership_controls" "archive_storage" {
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
-}
-
-resource "aws_s3_bucket_acl" "archive_storage" {
-  depends_on = [aws_s3_bucket_ownership_controls.archive_storage]
-  bucket     = aws_s3_bucket.archive_storage.id
-
-  acl = "private"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "archive_storage" {
@@ -175,13 +153,6 @@ resource "aws_s3_bucket_ownership_controls" "lambda_code" {
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
-}
-
-resource "aws_s3_bucket_acl" "lambda_code" {
-  depends_on = [aws_s3_bucket_ownership_controls.lambda_code]
-  bucket     = aws_s3_bucket.lambda_code.id
-
-  acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "lambda_code" {


### PR DESCRIPTION
# Summary | Résumé
Removes the "private" acl block as it is not compatible with Enforced Bucket Ownership.