### PR TITLE
Fix: Missed an S3 ACL on previous PR

### DIFF
--- a/aws/load_balancer/s3.tf
+++ b/aws/load_balancer/s3.tf
@@ -14,12 +14,6 @@ resource "aws_s3_bucket_ownership_controls" "maintenance_mode" {
   }
 }
 
-resource "aws_s3_bucket_acl" "maintenance_mode" {
-  depends_on = [aws_s3_bucket_ownership_controls.maintenance_mode]
-  bucket     = aws_s3_bucket.maintenance_mode.id
-  acl        = "private"
-}
-
 resource "aws_s3_bucket_public_access_block" "maintenance_mode" {
   bucket                  = aws_s3_bucket.maintenance_mode.id
   block_public_acls       = true


### PR DESCRIPTION
# Summary | Résumé
Remove S3 ACL that conflicts with bucket ownership enforcement.