### PR TITLE
fix: GitHub workflow OIDC role claims

### DIFF
--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-plan-workflow-dispatch
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-plan
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 

--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -1,34 +1,21 @@
 locals {
-  forms_terraform_apply_release          = "forms-terraform-apply-release"
-  forms_terraform_plan_workflow_dispatch = "forms-terraform-plan-workflow-dispatch"
-  platform_forms_client_pr_review_env    = "platform-forms-client-pr-review-env"
-  platform_forms_client_release          = "platform-forms-client-release"
+  forms_terraform_apply_release       = "forms-terraform-apply-release"
+  platform_forms_client_pr_review_env = "platform-forms-client-pr-review-env"
+  platform_forms_client_release       = "platform-forms-client-release"
 }
 
 # 
-# Built-in AWS polices attached to the roles
+# Built-in AWS policy attached to the roles
 #
 data "aws_iam_policy" "admin" {
   # checkov:skip=CKV_AWS_275:This policy is required for the Terraform apply
   name = "AdministratorAccess"
 }
 
-data "aws_iam_policy" "readonly" {
-  name = "ReadOnlyAccess"
-}
-
-#
-# Custom OIDC policy managed by the SRE team.  It is created and managed by
-# cds-snc/aft-global-customizations/terraform/oidc_terraform_roles.tf
-#
-data "aws_iam_policy" "terraform_plan" {
-  name = "OIDCPlanPolicy"
-}
-
 #
 # Create the OIDC roles used by the GitHub workflows
 # The roles can be assumed by the GitHub workflows according to the `claim`
-# attribute of each role, which corresponds to the GitHub workflow's event_name.
+# attribute of each role.
 # 
 module "github_workflow_roles" {
   source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=dca686fdd6670f0b3625bc17a5661bec3ea5aa62" #v9.0.3
@@ -37,12 +24,7 @@ module "github_workflow_roles" {
     {
       name      = local.forms_terraform_apply_release
       repo_name = "forms-terraform"
-      claim     = "release"
-    },
-    {
-      name      = local.forms_terraform_plan_workflow_dispatch
-      repo_name = "forms-terraform"
-      claim     = "workflow_dispatch"
+      claim     = "ref:refs/tags/v*"
     },
     {
       name      = local.platform_forms_client_pr_review_env
@@ -52,7 +34,7 @@ module "github_workflow_roles" {
     {
       name      = local.platform_forms_client_release
       repo_name = "platform-forms-client"
-      claim     = "release"
+      claim     = "ref:refs/tags/v*"
     }
   ]
 }
@@ -65,24 +47,6 @@ resource "aws_iam_role_policy_attachment" "forms_terraform_apply_release_admin" 
   count      = var.env == "production" ? 1 : 0
   role       = local.forms_terraform_apply_release
   policy_arn = data.aws_iam_policy.admin.arn
-  depends_on = [
-    module.github_workflow_roles
-  ]
-}
-
-resource "aws_iam_role_policy_attachment" "forms_terraform_plan_workflow_dispatch_terraform_plan" {
-  count      = var.env == "staging" ? 1 : 0
-  role       = local.forms_terraform_plan_workflow_dispatch
-  policy_arn = data.aws_iam_policy.terraform_plan.arn
-  depends_on = [
-    module.github_workflow_roles
-  ]
-}
-
-resource "aws_iam_role_policy_attachment" "forms_terraform_plan_workflow_dispatch_readonly" {
-  count      = var.env == "staging" ? 1 : 0
-  role       = local.forms_terraform_plan_workflow_dispatch
-  policy_arn = data.aws_iam_policy.readonly.arn
   depends_on = [
     module.github_workflow_roles
   ]


### PR DESCRIPTION
# Summary
Update the release OIDC roles to use tag references as GitHub does not consistently pass the workflow's event name as part of the role assume request.

Update the Terraform plan all workflow to use the default `forms-terraform-plan` role.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512