### PR TITLE
fix: PR review OIDC role for VPC lambda deploys

### DIFF
--- a/aws/oidc_roles/iam_policies.tf
+++ b/aws/oidc_roles/iam_policies.tf
@@ -99,6 +99,16 @@ data "aws_iam_policy_document" "platform_forms_client_pr_review_env" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs"
+    ]
+    resources = ["*"]
+  }
 }
 
 #


### PR DESCRIPTION
# Summary
Update the PR review environment's OIDC role so that it can create the lambda functions in the VPC.

# ⚠️  Note
This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512
- https://github.com/cds-snc/platform-forms-client/pull/3116