### PR TITLE
fix: update Terragrunt mock values to fix TF plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ tf.plan
 **/node_modules/
 
 # Ignore lambda builds
-**/code/**/dist/
+**/dist
 
 # Ignore Mac OS file types
 .DS_Store

--- a/aws/lambdas/code/deps.sh
+++ b/aws/lambdas/code/deps.sh
@@ -15,6 +15,7 @@ for LAMBDA_DIR in "$SCRIPT_DIR"/*/; do
         echo "⚡ $LAMBDA_DIR $ACTION"
         if [ "$ACTION" = "delete" ]; then
             rm -rf "$LAMBDA_DIR/node_modules"
+            rm -rf "$LAMBDA_DIR/dist" || true
         else
             yarn --cwd "$LAMBDA_DIR" install
             if test -f "$LAMBDA_DIR/tsconfig.json"; then

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -45,7 +45,12 @@ resource "aws_route53_record" "form_viewer_maintenance" {
 # Certificate validation
 # 
 locals {
-  domain_name_to_zone_id = zipmap(var.domains, var.hosted_zone_ids)
+  # Temporary workaround for the removal of the `forms-formulaires.canada.ca` hosted zone.
+  # This will allow the module to plan correctly before the `/aws/hosted_zone` module
+  # has been applied.
+  domain_name_to_zone_id = {
+    (var.domains[0]) = var.hosted_zone_ids[0]
+  }
 }
 
 

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -69,15 +69,15 @@ dependency "lambdas" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    lambda_reliability_log_group_name                = null
-    lambda_submission_log_group_name                 = null
-    lambda_response_archiver_log_group_name          = null
-    lambda_dlq_consumer_log_group_name               = null
-    lambda_template_archiver_log_group_name          = null
-    lambda_audit_log_group_name                      = null
-    lambda_nagware_log_group_name                    = null
-    lambda_vault_data_integrity_check_log_group_name = null
-    lambda_vault_data_integrity_check_function_name  = null
+    lambda_reliability_log_group_name                = "/aws/lambda/Reliability"
+    lambda_submission_log_group_name                 = "/aws/lambda/Submission"
+    lambda_response_archiver_log_group_name          = "/aws/lambda/Response_Archiver"
+    lambda_dlq_consumer_log_group_name               = "/aws/lambda/DeadLetterQueueConsumer"
+    lambda_template_archiver_log_group_name          = "/aws/lambda/Archive_Form_Templates"
+    lambda_audit_log_group_name                      = "/aws/lambda/AuditLogs"
+    lambda_nagware_log_group_name                    = "/aws/lambda/Nagware"
+    lambda_vault_data_integrity_check_log_group_name = "/aws/lambda/Vault_Data_Integrity_Check"
+    lambda_vault_data_integrity_check_function_name  = "Vault_Data_Integrity_Check"
   }
 }
 

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -105,12 +105,11 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    notify_api_key_secret_arn               = null
-    notify_api_key_secret_value             = null
-    freshdesk_api_key_secret_arn            = null
-    token_secret_arn                        = null
-    recaptcha_secret_arn                    = null
-    notify_callback_bearer_token_secret_arn = null
+    notify_api_key_secret_arn               = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:notify_api_key"
+    freshdesk_api_key_secret_arn            = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:freshdesk_api_key_secret"
+    token_secret_arn                        = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:token_secret"
+    recaptcha_secret_arn                    = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:recaptcha_secret"
+    notify_callback_bearer_token_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:notify_callback_bearer_token_secret"
 
   }
 }
@@ -120,10 +119,10 @@ dependency "s3" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    vault_file_storage_id = null
-    vault_file_storage_arn = null
-    reliability_file_storage_id = null
-    reliability_file_storage_arn = null
+    vault_file_storage_id        = "forms-staging-vault-file-storage"
+    vault_file_storage_arn       = "arn:aws:s3:::forms-staging-vault-file-storage"
+    reliability_file_storage_id  = "forms-staging-reliability-file-storage"
+    reliability_file_storage_arn = "arn:aws:s3:::forms-staging-reliability-file-storage"
   }
 }
 

--- a/env/cloud/cognito/terragrunt.hcl
+++ b/env/cloud/cognito/terragrunt.hcl
@@ -22,7 +22,7 @@ dependency "secrets" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    notify_api_key_secret_arn               = null
+    notify_api_key_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:notify_api_key"
   }
 }
 
@@ -31,8 +31,8 @@ dependency "s3" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    lambda_code_arn              = null
-    lambda_code_id               = "placeholder"
+    lambda_code_arn = "arn:aws:s3:::forms-staging-lambda-code"
+    lambda_code_id  = "forms-staging-lambda-code"
   }
 }
 

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "app" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    ecs_iam_role_arn = null
+    ecs_iam_role_arn = "arn:aws:iam::123456789012:role/form-viewer"
   }
 }
 
@@ -76,11 +76,11 @@ dependency "dynamodb" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    dynamodb_relability_queue_arn = null
-    dynamodb_vault_arn            = null
-    dynamodb_vault_table_name     = null
-    dynamodb_vault_stream_arn     = null
-    dynamodb_audit_logs_arn       = null
+    dynamodb_relability_queue_arn  = "arn:aws:dynamodb:ca-central-1:123456789012:table/ReliabilityQueue"
+    dynamodb_vault_arn             = "arn:aws:dynamodb:ca-central-1:123456789012:table/Vault"
+    dynamodb_vault_table_name      = "Vault"
+    dynamodb_vault_stream_arn      = "arn:aws:dynamodb:ca-central-1:123456789012:table/Vault/stream/2023-03-14T15:54:31.086"
+    dynamodb_audit_logs_arn        = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
   }
 }
 
@@ -89,11 +89,11 @@ dependency "secrets" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    notify_api_key_secret_arn               = null
-    freshdesk_api_key_secret_arn            = null
-    token_secret_arn                        = null
-    recaptcha_secret_arn                    = null
-    notify_callback_bearer_token_secret_arn = null
+    notify_api_key_secret_arn               = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:notify_api_key"
+    freshdesk_api_key_secret_arn            = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:freshdesk_api_key_secret"
+    token_secret_arn                        = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:token_secret"
+    recaptcha_secret_arn                    = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:recaptcha_secret"
+    notify_callback_bearer_token_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:notify_callback_bearer_token_secret"
   }
 }
 
@@ -102,13 +102,13 @@ dependency "s3" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    reliability_file_storage_arn = null
-    vault_file_storage_arn       = null
-    vault_file_storage_id        = "placeholder"
-    archive_storage_arn          = null
-    archive_storage_id           = "placeholder"
-    lambda_code_arn              = null
-    lambda_code_id               = "placeholder"
+    reliability_file_storage_arn = "arn:aws:s3:::forms-staging-reliability-file-storage"
+    vault_file_storage_arn       = "arn:aws:s3:::forms-staging-vault-file-storage"
+    vault_file_storage_id        = "forms-staging-vault-file-storage"
+    archive_storage_arn          = "arn:aws:s3:::forms-staging-archive-storage"
+    archive_storage_id           = "forms-staging-archive-storage"
+    lambda_code_arn              = "arn:aws:s3:::forms-staging-lambda-code"
+    lambda_code_id               = "forms-staging-lambda-code"
   }
 }
 
@@ -152,51 +152,4 @@ inputs = {
 
   # Overwritten in GitHub Actions by TFVARS
   gc_template_id = "8d597a1b-a1d6-4e3c-8421-042a2b4158b7" # GC Notify template ID used for local setup
-}
-
-generate "import_existing_cloudwatch_logs" {
-  disable     = local.env == "local"
-  path      = "import.tf"
-  if_exists = "overwrite"
-  contents  = <<EOF
-import {
-  to = aws_cloudwatch_log_group.archive_form_templates
-  id = "/aws/lambda/ArchiveFormTemplates"
-}
-
-import {
-  to = aws_cloudwatch_log_group.audit_logs
-  id = "/aws/lambda/AuditLogs"
-}
-
-import {
-  to = aws_cloudwatch_log_group.dead_letter_queue_consumer
-  id = "/aws/lambda/DeadLetterQueueConsumer"
-}
-
-import {
-  to = aws_cloudwatch_log_group.nagware
-  id = "/aws/lambda/Nagware"
-}
-
-import {
-  to = aws_cloudwatch_log_group.reliability
-  id = "/aws/lambda/Reliability"
-}
-
-import {
-  to = aws_cloudwatch_log_group.submission
-  id = "/aws/lambda/Submission"
-}
-
-import {
-  to = aws_cloudwatch_log_group.vault_integrity
-  id = "/aws/lambda/VaultDataIntegrityCheck"
-}
-
-import {
-  to = aws_cloudwatch_log_group.response_archiver
-  id = "/aws/lambda/Archiver"
-}
-EOF
 }

--- a/env/cloud/s3/terragrunt.hcl
+++ b/env/cloud/s3/terragrunt.hcl
@@ -9,26 +9,3 @@ include {
 locals {
   env = get_env("APP_ENV", "local")
 }
-
-
-generate "import_existing_s3_buckets" {
-  disable     = local.env == "local"
-  path      = "import.tf"
-  if_exists = "overwrite"
-  contents  = <<EOF
-import {
-  to = aws_s3_bucket.reliability_file_storage
-  id = "forms-${local.env}-reliability-file-storage"
-}
-
-import {
-  to = aws_s3_bucket.archive_storage
-  id = "forms-${local.env}-archive-storage"
-}
-
-import {
-  to = aws_s3_bucket.vault_file_storage
-  id = "forms-${local.env}-vault-file-storage"
-}
-EOF
-}


### PR DESCRIPTION
# Summary
Update the Terragrunt mock values so that the Production release can properly run `terraform plan`.

Update the `load_balancer` module to only expect a single hosted zone.  This is a temporary workaround while the `forms-formulaires.canada.ca` hosted zone still exists as a `hosted_zone` output and can be removed after the release.

Update the deps.sh script to also remove the lambda function `/dist` folders.

Remove the `import` blocks as these will be run using a script before the `terraform apply`.

# Related
- https://github.com/cds-snc/platform-core-services/issues/528