### PR TITLE
fix: ECS service autoscaling target

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -4,13 +4,15 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   APP_ENV: production
   APP_DOMAINS: ${{ vars.PRODUCTION_APP_DOMAINS}}
   AWS_ACCOUNT_ID: ${{ vars.PRODUCTION_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_VERSION: 1.6.6
   TERRAGRUNT_VERSION: 0.54.8
   TF_INPUT: false
@@ -38,18 +40,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1.4.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
+      # Setup Terraform, Terragrunt, and Conftest
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply-release
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
       # No dependencies
       - name: Terragrunt apply ecr
         working-directory: env/cloud/ecr

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -205,7 +205,7 @@ jobs:
         with:
           directory: "env/cloud/lambdas"
           comment-delete: "true"
-          comment-title: "Staging: lambdas"
+          comment-title: "Production: lambdas"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -122,9 +122,9 @@ resource "aws_appautoscaling_policy" "forms_cpu" {
 
   name               = "forms_cpu"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = aws_appautoscaling_target.forms.service_namespace
-  resource_id        = aws_appautoscaling_target.forms.resource_id
-  scalable_dimension = aws_appautoscaling_target.forms.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.forms[0].service_namespace
+  resource_id        = aws_appautoscaling_target.forms[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.forms[0].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.ecs_scale_in_cooldown
@@ -141,9 +141,9 @@ resource "aws_appautoscaling_policy" "forms_memory" {
 
   name               = "forms_memory"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = aws_appautoscaling_target.forms.service_namespace
-  resource_id        = aws_appautoscaling_target.forms.resource_id
-  scalable_dimension = aws_appautoscaling_target.forms.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.forms[0].service_namespace
+  resource_id        = aws_appautoscaling_target.forms[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.forms[0].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.ecs_scale_in_cooldown

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -108,21 +108,23 @@ resource "aws_ecs_service" "form_viewer" {
 # Service autoscaling config
 #
 resource "aws_appautoscaling_target" "forms" {
-  count              = var.ecs_autoscale_enabled ? 1 : 0
+  count = var.ecs_autoscale_enabled ? 1 : 0
+
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.form_viewer.cluster}/${aws_ecs_service.form_viewer.name}"
+  resource_id        = "service/${aws_ecs_cluster.form_viewer.name}/${aws_ecs_service.form_viewer.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.ecs_min_tasks
   max_capacity       = var.ecs_max_tasks
 }
 
 resource "aws_appautoscaling_policy" "forms_cpu" {
-  count              = var.ecs_autoscale_enabled ? 1 : 0
+  count = var.ecs_autoscale_enabled ? 1 : 0
+
   name               = "forms_cpu"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.form_viewer.cluster}/${aws_ecs_service.form_viewer.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.forms.service_namespace
+  resource_id        = aws_appautoscaling_target.forms.resource_id
+  scalable_dimension = aws_appautoscaling_target.forms.scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.ecs_scale_in_cooldown
@@ -135,12 +137,13 @@ resource "aws_appautoscaling_policy" "forms_cpu" {
 }
 
 resource "aws_appautoscaling_policy" "forms_memory" {
-  count              = var.ecs_autoscale_enabled ? 1 : 0
+  count = var.ecs_autoscale_enabled ? 1 : 0
+
   name               = "forms_memory"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.form_viewer.cluster}/${aws_ecs_service.form_viewer.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.forms.service_namespace
+  resource_id        = aws_appautoscaling_target.forms.resource_id
+  scalable_dimension = aws_appautoscaling_target.forms.scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.ecs_scale_in_cooldown

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -111,7 +111,7 @@ resource "aws_appautoscaling_target" "forms" {
   count = var.ecs_autoscale_enabled ? 1 : 0
 
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.form_viewer.name}/${aws_ecs_service.form_viewer.name}"
+  resource_id        = "service/${aws_ecs_cluster.forms.name}/${aws_ecs_service.form_viewer.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.ecs_min_tasks
   max_capacity       = var.ecs_max_tasks


### PR DESCRIPTION
# Summary
Update the ECS autoscaling target so that the Form viewer task will scale as expected with CPU and memory load.

Update the TF apply production workflow to use the new OIDC release role.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512
- https://github.com/cds-snc/forms-terraform/pull/526