### PR TITLE
chore: disable TTL for Audit logs DynamoDB table

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -121,7 +121,7 @@ resource "aws_dynamodb_table" "audit_logs" {
   }
 
   ttl {
-    enabled        = true
+    enabled        = false
     attribute_name = "ArchiveDate"
   }
 


### PR DESCRIPTION
# Summary | Résumé

- Disable TTL for DynamoDB Audit logs table