### PR TITLE
chore: reduce number of Nagware emails and Slack notifications

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -40,6 +40,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      # https://github.com/jlumbroso/free-disk-space/tree/54081f138730dfa15788a46383842cd2f914a1be#example
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -44,6 +44,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      # https://github.com/jlumbroso/free-disk-space/tree/54081f138730dfa15788a46383842cd2f914a1be#example
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -36,6 +36,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      # https://github.com/jlumbroso/free-disk-space/tree/54081f138730dfa15788a46383842cd2f914a1be#example
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -40,6 +40,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      # https://github.com/jlumbroso/free-disk-space/tree/54081f138730dfa15788a46383842cd2f914a1be#example
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -48,6 +48,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      # https://github.com/jlumbroso/free-disk-space/tree/54081f138730dfa15788a46383842cd2f914a1be#example
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1

--- a/aws/lambdas/cloudwatch.tf
+++ b/aws/lambdas/cloudwatch.tf
@@ -1,63 +1,47 @@
 #
-# CRON events that fires every day at different times
+# Lambda triggers
 #
 
-resource "aws_cloudwatch_event_rule" "cron_2am_every_day" {
-  name                = "every-day-at-2am"
+resource "aws_cloudwatch_event_rule" "reliability_dlq_lambda_trigger" {
+  name                = "reliability-dlq-lambda-trigger"
   description         = "Fires every day at 2am EST"
   schedule_expression = "cron(0 7 * * ? *)" # 2 AM EST = 7 AM UTC
 }
 
-resource "aws_cloudwatch_event_rule" "cron_3am_every_day" {
-  name                = "every-day-at-3am"
+resource "aws_cloudwatch_event_rule" "response_archiver_lambda_trigger" {
+  name                = "response-archiver-lambda-trigger"
   description         = "Fires every day at 3am EST"
   schedule_expression = "cron(0 8 * * ? *)" # 3 AM EST = 8 AM UTC
 }
 
-resource "aws_cloudwatch_event_rule" "cron_4am_every_day" {
-  name                = "every-day-at-4am"
+resource "aws_cloudwatch_event_rule" "form_archiver_lambda_trigger" {
+  name                = "form-archiver-lambda-trigger"
   description         = "Fires every day at 4am EST"
   schedule_expression = "cron(0 9 * * ? *)" # 4 AM EST = 9 AM UTC
 }
 
-resource "aws_cloudwatch_event_rule" "cron_5am_every_business_day" {
-  name                = "every-business-day-at-5am"
+resource "aws_cloudwatch_event_rule" "nagware_lambda_trigger" {
+  name                = "nagware-lambda-trigger"
   description         = "Fires every business day at 5am EST"
   schedule_expression = "cron(0 10 ? * MON-FRI *)" # 5 AM EST = 10 AM UTC ; every Monday through Friday
 }
 
-#
-# Connect CRON to Dead letter queue consumer lambda function
-#
-
-resource "aws_cloudwatch_event_target" "run_dead_letter_queue_consumer_lambda_every_day" {
-  rule = aws_cloudwatch_event_rule.cron_2am_every_day.name
+resource "aws_cloudwatch_event_target" "reliability_dlq_lambda_trigger" {
+  rule = aws_cloudwatch_event_rule.reliability_dlq_lambda_trigger.name
   arn  = aws_lambda_function.reliability_dlq_consumer.arn
 }
 
-#
-# Connect CRON to Archive form responses lambda function
-#
-
-resource "aws_cloudwatch_event_target" "run_archive_form_responses_lambda_every_day" {
-  rule = aws_cloudwatch_event_rule.cron_3am_every_day.name
+resource "aws_cloudwatch_event_target" "response_archiver_lambda_trigger" {
+  rule = aws_cloudwatch_event_rule.response_archiver_lambda_trigger.name
   arn  = aws_lambda_function.response_archiver.arn
 }
 
-#
-# Connect CRON to Archive form templates lambda function
-#
-
-resource "aws_cloudwatch_event_target" "run_archive_form_templates_lambda_every_day" {
-  rule = aws_cloudwatch_event_rule.cron_4am_every_day.name
+resource "aws_cloudwatch_event_target" "form_archiver_lambda_trigger" {
+  rule = aws_cloudwatch_event_rule.form_archiver_lambda_trigger.name
   arn  = aws_lambda_function.form_archiver.arn
 }
 
-#
-# Connect CRON to Nagware lambda function
-#
-
-resource "aws_cloudwatch_event_target" "run_nagware_lambda_every_day" {
-  rule = aws_cloudwatch_event_rule.cron_5am_every_business_day.name
+resource "aws_cloudwatch_event_target" "nagware_lambda_trigger" {
+  rule = aws_cloudwatch_event_rule.nagware_lambda_trigger.name
   arn  = aws_lambda_function.nagware.arn
 }

--- a/aws/lambdas/cloudwatch.tf
+++ b/aws/lambdas/cloudwatch.tf
@@ -22,8 +22,8 @@ resource "aws_cloudwatch_event_rule" "form_archiver_lambda_trigger" {
 
 resource "aws_cloudwatch_event_rule" "nagware_lambda_trigger" {
   name                = "nagware-lambda-trigger"
-  description         = "Fires every business day at 5am EST"
-  schedule_expression = "cron(0 10 ? * MON-FRI *)" # 5 AM EST = 10 AM UTC ; every Monday through Friday
+  description         = "Fires every Tuesday, Thursday and Sunday at 5am EST"
+  schedule_expression = "cron(0 10 * * TUE,THU,SUN *)" # 5 AM EST = 10 AM UTC ; every Tuesday, Thursday and Sunday
 }
 
 resource "aws_cloudwatch_event_target" "reliability_dlq_lambda_trigger" {

--- a/aws/lambdas/form_archiver.tf
+++ b/aws/lambdas/form_archiver.tf
@@ -1,7 +1,6 @@
 #
 # Archive form templates
 #
-
 data "archive_file" "form_archiver_code" {
   type        = "zip"
   source_dir  = "./code/form_archiver/dist"
@@ -42,17 +41,14 @@ resource "aws_lambda_function" "form_archiver" {
   tracing_config {
     mode = "PassThrough"
   }
-
-
 }
-
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_run_form_archiver_lambda" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.form_archiver.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cron_4am_every_day.arn
+  source_arn    = aws_cloudwatch_event_rule.form_archiver_lambda_trigger.arn
 }
 
 resource "aws_cloudwatch_log_group" "archive_form_templates" {

--- a/aws/lambdas/form_archiver.tf
+++ b/aws/lambdas/form_archiver.tf
@@ -35,6 +35,10 @@ resource "aws_lambda_function" "form_archiver" {
       DB_SECRET   = var.database_secret_arn
       DB_NAME     = var.rds_db_name
       LOCALSTACK  = var.localstack_hosted
+      PGHOST      = var.localstack_hosted ? "host.docker.internal" : null
+      PGUSER      = var.localstack_hosted ? "postgres" : null
+      PGDATABASE  = var.localstack_hosted ? "formsDB" : null
+      PGPASSWORD  = var.localstack_hosted ? "chummy" : null
     }
   }
 

--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -1,7 +1,6 @@
 #
 # Nagware
 #
-
 data "archive_file" "nagware_code" {
   type        = "zip"
   source_dir  = "./code/nagware/dist"
@@ -15,7 +14,6 @@ resource "aws_s3_object" "nagware_code" {
   source_hash = data.archive_file.nagware_code.output_base64sha256
 }
 
-
 resource "aws_lambda_function" "nagware" {
   s3_bucket         = aws_s3_object.nagware_code.bucket
   s3_key            = aws_s3_object.nagware_code.key
@@ -28,8 +26,7 @@ resource "aws_lambda_function" "nagware" {
   source_code_hash = data.archive_file.nagware_code.output_base64sha256
 
   runtime = "nodejs18.x"
-
-
+  
   environment {
     variables = {
       ENVIRONMENT               = var.env
@@ -49,8 +46,6 @@ resource "aws_lambda_function" "nagware" {
   tracing_config {
     mode = "PassThrough"
   }
-
-
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_run_nagware_lambda" {
@@ -58,7 +53,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_run_nagware_lambda" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.nagware.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cron_5am_every_business_day.arn
+  source_arn    = aws_cloudwatch_event_rule.nagware_lambda_trigger.arn
 }
 
 resource "aws_cloudwatch_log_group" "nagware" {

--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "nagware" {
   source_code_hash = data.archive_file.nagware_code.output_base64sha256
 
   runtime = "nodejs18.x"
-  
+
   environment {
     variables = {
       ENVIRONMENT               = var.env
@@ -38,7 +38,6 @@ resource "aws_lambda_function" "nagware" {
       DB_NAME                   = var.rds_db_name
       NOTIFY_API_KEY            = var.notify_api_key_secret_arn
       TEMPLATE_ID               = var.gc_template_id
-      SNS_ERROR_TOPIC_ARN       = var.sns_topic_alert_critical_arn
       LOCALSTACK                = var.localstack_hosted
     }
   }

--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -39,6 +39,10 @@ resource "aws_lambda_function" "nagware" {
       NOTIFY_API_KEY            = var.notify_api_key_secret_arn
       TEMPLATE_ID               = var.gc_template_id
       LOCALSTACK                = var.localstack_hosted
+      PGHOST                    = var.localstack_hosted ? "host.docker.internal" : null
+      PGUSER                    = var.localstack_hosted ? "postgres" : null
+      PGDATABASE                = var.localstack_hosted ? "formsDB" : null
+      PGPASSWORD                = var.localstack_hosted ? "chummy" : null
     }
   }
 

--- a/aws/lambdas/reliability.tf
+++ b/aws/lambdas/reliability.tf
@@ -1,9 +1,7 @@
-
 data "archive_file" "reliability_code" {
   type        = "zip"
   source_dir  = "./code/reliability/dist/"
   output_path = "/tmp/reliability_code.zip"
-
 }
 
 resource "aws_s3_object" "reliability_code" {
@@ -40,15 +38,12 @@ resource "aws_lambda_function" "reliability" {
       PGUSER         = var.localstack_hosted ? "postgres" : null
       PGDATABASE     = var.localstack_hosted ? "formsDB" : null
       PGPASSWORD     = var.localstack_hosted ? "chummy" : null
-
     }
   }
 
   tracing_config {
     mode = "PassThrough"
   }
-
-
 }
 
 resource "aws_lambda_event_source_mapping" "reliability" {
@@ -70,4 +65,3 @@ resource "aws_cloudwatch_log_group" "reliability" {
   kms_key_id        = var.kms_key_cloudwatch_arn
   retention_in_days = 731
 }
-

--- a/aws/lambdas/reliability_dlq_consumer.tf
+++ b/aws/lambdas/reliability_dlq_consumer.tf
@@ -2,7 +2,6 @@
 #
 # Dead letter queue consumer
 #
-
 data "archive_file" "reliability_dlq_consumer_code" {
   type        = "zip"
   source_dir  = "./code/reliability_dlq_consumer/dist"
@@ -15,9 +14,6 @@ resource "aws_s3_object" "reliability_dlq_consumer_code" {
   source      = data.archive_file.reliability_dlq_consumer_code.output_path
   source_hash = data.archive_file.reliability_dlq_consumer_code.output_base64sha256
 }
-
-
-
 
 resource "aws_lambda_function" "reliability_dlq_consumer" {
   s3_bucket         = aws_s3_object.reliability_dlq_consumer_code.bucket
@@ -44,8 +40,6 @@ resource "aws_lambda_function" "reliability_dlq_consumer" {
   tracing_config {
     mode = "PassThrough"
   }
-
-
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_run_dead_letter_queue_consumer_lambda" {
@@ -53,7 +47,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_run_dead_letter_queue_cons
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.reliability_dlq_consumer.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cron_2am_every_day.arn
+  source_arn    = aws_cloudwatch_event_rule.reliability_dlq_lambda_trigger.arn
 }
 
 resource "aws_cloudwatch_log_group" "dead_letter_queue_consumer" {

--- a/aws/lambdas/response_archiver.tf
+++ b/aws/lambdas/response_archiver.tf
@@ -15,7 +15,6 @@ resource "aws_s3_object" "response_archiver_code" {
   source_hash = data.archive_file.response_archiver_code.output_base64sha256
 }
 
-
 resource "aws_lambda_function" "response_archiver" {
   s3_bucket         = aws_s3_object.response_archiver_code.bucket
   s3_key            = aws_s3_object.response_archiver_code.key
@@ -41,17 +40,14 @@ resource "aws_lambda_function" "response_archiver" {
   tracing_config {
     mode = "PassThrough"
   }
-
-
 }
-
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_run_archive_form_responses_lambda" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.response_archiver.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cron_3am_every_day.arn
+  source_arn    = aws_cloudwatch_event_rule.response_archiver_lambda_trigger.arn
 }
 
 resource "aws_cloudwatch_log_group" "response_archiver" {


### PR DESCRIPTION
# Summary | Résumé

related to https://github.com/cds-snc/platform-forms-client/issues/3202

- Added new free disk space step in some of the Github workflows (more information below)
- Renamed lambda trigger resources
- Reworked Nagware to always send emails no matter how old is the detected form response. Nagware will now run on Tuesdays, Thursdays and Sundays. It will only send email on Tuesday and Thursday and will send Slack notifications on Sunday.
- Added missing environment variable in Nagware and Form archiver lambdas (to reach PostgreSQL while running in Localstack)

# New free disk space step in Github workflows

For some reason that still need some investigation, our Github workflow (`terraform-plan-staging`) has started reaching the limit of the Github runner disk space. There are multiple people on the internet that have encountered the same issue and one of the solutions that always comes back is to use a script that will delete unnecessary resources in the machine.

Here is the Github action I used: [free-disk-space](https://github.com/jlumbroso/free-disk-space)

Here is the disk usage (given by the free disk space Github action) when running the `terraform-plan-staging` workflow:
```
============ BEGINNING OF WORKFLOW ===============

== BEFORE CLEAN-UP ==

$ dh -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   53G   21G  73% /

== AFTER CLEAN-UP ==

$ dh -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   29G   44G  40% /

============ END OF WORKFLOW ===============

$ dh -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   40G   33G  55% /
```