### PR TITLE
chore: create env file that gets automatically loaded when we start the infra in Localstack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+APP_ENV="local"
+NOTIFY_API_KEY="<can_be_found_in_1Password>"

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ tf.plan
 .devcontainer/data
 
 # Local environment variables
-.env*
+.env

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ RELIABILITY_FILE_STORAGE=forms-local-reliability-file-storage
 LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
 ```
 
+#### Set your environment variables (optional)
+
+Copy the `.env.example` file and rename it to `.env`. Some of the variables require values that can be found in the 1Password shared secrets note.
+
+#### Launch the infrastructure and the application
+
 Everytime you want to run localstack and lambdas locally
 
 1. In one terminal run `docker-compose up`

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
-export APP_ENV="local"
-
-# Exit on any error
-set -e
-
 # Text colors
 color='\033[1;95m' 
 reset='\033[0m' # No Color
+
+if test -f .env
+then
+  set -o allexport
+  source .env
+  set +o allexport
+  printf "${color}=> Environment variables loaded from .env${reset}\n"
+else
+  # In case developers have not set up their .env file (can be removed in the future)
+  export APP_ENV="local"
+fi
+
+# Exit on any error
+set -e
 
 # Set proper terraform and terragrunt versions
 


### PR DESCRIPTION
# Summary | Résumé

In order to make it less annoying for us to deploy the infra without having to make sure all environment variables are properly set in the terraform files I decided to add a `.env` file with a mechanism to load them when we call the `localstack_services.sh` script.