### PR TITLE
fix: deployment issue due to audit logs TTL resource block that is not needed anymore

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -120,11 +120,6 @@ resource "aws_dynamodb_table" "audit_logs" {
     projection_type = "KEYS_ONLY"
   }
 
-  ttl {
-    enabled        = false
-    attribute_name = "ArchiveDate"
-  }
-
   server_side_encryption {
     enabled     = true
     kms_key_arn = var.kms_key_dynamodb_arn


### PR DESCRIPTION
# Summary | Résumé

- Removed TTL resource block on DynamoDB Audit logs table since it was disable in both Staging and Production and now causes a conflict when being deployed on AWS

```
╷
│ Error: updating Amazon DynamoDB Table (AuditLogs): updating Time To Live: ValidationException: TimeToLive is already disabled
│ 	status code: 400, request id: DLKAF6N0BFHNB0T8S5GQ87SUUJVV4KQNSO5AEMVJF66Q9ASUAAJG
│ 
│   with aws_dynamodb_table.audit_logs,
│   on dynamo.tf line 92, in resource "aws_dynamodb_table" "audit_logs":
│   92: resource "aws_dynamodb_table" "audit_logs" {
│ 
╵
```