### PR TITLE
fix: nagware lambda trigger CRON definition is incorrect

### DIFF
--- a/aws/lambdas/cloudwatch.tf
+++ b/aws/lambdas/cloudwatch.tf
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_event_rule" "form_archiver_lambda_trigger" {
 resource "aws_cloudwatch_event_rule" "nagware_lambda_trigger" {
   name                = "nagware-lambda-trigger"
   description         = "Fires every Tuesday, Thursday and Sunday at 5am EST"
-  schedule_expression = "cron(0 10 * * TUE,THU,SUN *)" # 5 AM EST = 10 AM UTC ; every Tuesday, Thursday and Sunday
+  schedule_expression = "cron(0 10 ? * TUE,THU,SUN *)" # 5 AM EST = 10 AM UTC ; every Tuesday, Thursday and Sunday
 }
 
 resource "aws_cloudwatch_event_target" "reliability_dlq_lambda_trigger" {


### PR DESCRIPTION
# Summary | Résumé

- Fixed Nagware lambda trigger CRON definition