### PR TITLE
feat: send critical/error events to OpsGenie

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -23,7 +23,7 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
-  TV_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
+  TF_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -23,6 +23,8 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+  TV_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
+
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
   TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -29,6 +29,8 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
+  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -29,7 +29,7 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
-  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+  TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -23,7 +23,7 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
-  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+  TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -23,6 +23,8 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
+  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -26,6 +26,8 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+  TV_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
+
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
   TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -26,7 +26,7 @@ env:
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
-  TV_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
+  TF_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -34,7 +34,7 @@ env:
 
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
-  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+  TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -34,6 +34,7 @@ env:
 
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
+  TV_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
 
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7

--- a/README.md
+++ b/README.md
@@ -313,4 +313,5 @@ notify_api_key          # Notify API key to send messages
 freshdesk_api_key       # FreshDesk API key to send messages
 rds_db_password         # Database password
 slack_webhook           # Slack webhook to send CloudWatch notifications
+opsgenie_api_key        # OpsGenie API key to create alert
 ```

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -84,6 +84,12 @@ variable "slack_webhook" {
   sensitive   = true
 }
 
+variable "opsgenie_api_key" {
+  description = "The OpsGenie api key to be used when calling https://api.opsgenie.com/v2/alerts"
+  type        = string
+  sensitive   = true
+}
+
 variable "sqs_reliability_deadletter_queue_arn" {
   description = "ARN of the Reliability queue's SQS Dead Letter Queue"
   type        = string

--- a/aws/alarms/lambda.tf
+++ b/aws/alarms/lambda.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "notify_slack" {
     variables = {
       ENVIRONMENT   = title(var.env)
       SLACK_WEBHOOK = var.slack_webhook
+      OPSGENIE_API_KEY = var.opsgenie_api_key
     }
   }
 

--- a/aws/alarms/lambda.tf
+++ b/aws/alarms/lambda.tf
@@ -20,8 +20,8 @@ resource "aws_lambda_function" "notify_slack" {
 
   environment {
     variables = {
-      ENVIRONMENT   = title(var.env)
-      SLACK_WEBHOOK = var.slack_webhook
+      ENVIRONMENT      = title(var.env)
+      SLACK_WEBHOOK    = var.slack_webhook
       OPSGENIE_API_KEY = var.opsgenie_api_key
     }
   }

--- a/aws/alarms/lambda.tf
+++ b/aws/alarms/lambda.tf
@@ -1,5 +1,5 @@
 #
-# Lambda - Notify Slack
+# Lambda - Notify Slack and OpsGenie
 #
 data "archive_file" "notify_slack" {
   type        = "zip"

--- a/aws/alarms/lambda/notify_slack/notify_slack.js
+++ b/aws/alarms/lambda/notify_slack/notify_slack.js
@@ -204,7 +204,7 @@ exports.handler = function (input, context) {
           } else {
             // These are unhandled errors from the GCForms app only
             sendToSlack(parsedResult.logGroup, log.message, "error", context);
-            sendToOpsGenie(parsedResult.logGroup, log.message, "error", context);
+
             console.log(
               JSON.stringify({
                 msg: `Event Data for ${parsedResult.logGroup}: ${log.message}`,

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -173,8 +173,6 @@ variable "sqs_reprocess_submission_queue_id" {
   type        = string
 }
 
-
-
 variable "sqs_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
   type        = string

--- a/aws/lambdas/code/audit_logs/audit_logs.ts
+++ b/aws/lambdas/code/audit_logs/audit_logs.ts
@@ -153,9 +153,9 @@ export const handler: Handler = async (event: SQSEvent) => {
         return unprocessedItem.messageId;
       });
 
-      console.warn(
+      console.error(
         JSON.stringify({
-          level: "warn",
+          level: "error",
           severity: 1,
           msg: `Failed to process ${
             unprocessedIDs.length

--- a/aws/lambdas/code/submission/submission.ts
+++ b/aws/lambdas/code/submission/submission.ts
@@ -51,7 +51,7 @@ export const handler: Handler = async (submission: AnyObject) => {
     console.error(
       JSON.stringify({
         level: "error",
-        severity: 1,
+        severity: 1, // this will trigger an alert to on-call team
         status: "failed",
         submissionId: submissionId,
         msg: (error as Error).message,
@@ -80,7 +80,6 @@ const enqueueReliabilityProcessingRequest = async (submissionId: string): Promis
 
     return sendMessageCommandOutput.MessageId;
   } catch (error) {
-    console.error(JSON.stringify(error));
     throw new Error("Could not enqueue reliability processing request");
   }
 };
@@ -120,7 +119,6 @@ const saveSubmission = async (submissionId: string, formData: AnyObject): Promis
       })
     );
   } catch (error) {
-    console.error(JSON.stringify(error));
     throw new Error("Could not save submission to Reliability Temporary Storage");
   }
 };

--- a/aws/lambdas/code/submission/submission.ts
+++ b/aws/lambdas/code/submission/submission.ts
@@ -55,6 +55,7 @@ export const handler: Handler = async (submission: AnyObject) => {
         status: "failed",
         submissionId: submissionId,
         msg: (error as Error).message,
+        details: JSON.stringify(error),
       })
     );
 


### PR DESCRIPTION
# Summary | Résumé

We want to utilize the Lambda function that currently notifies our Slack channel to also route SEV1 events to OpsGenie.

# Test instructions | Instructions pour tester la modification

1. Drop a message with the word SEV1 on any SNS topic 
3. The lambda will be triggered and will analyse the log and create an alert in OpsGenie with some basic messaging

## CloudWatch Log Group Subscription Flow
<img width="367" alt="image" src="https://github.com/cds-snc/forms-terraform/assets/70960477/fadf47f8-3123-4a5c-88d1-bc73d553254a">

## SNS Topic Flow

<img width="368" alt="image" src="https://github.com/cds-snc/forms-terraform/assets/70960477/b04bddfa-8b74-4064-89b5-ef2e7982b00a">

