### PR TITLE
fix: add missing subscription filter to audit logs archiver lambda logs

### DIFF
--- a/aws/alarms/cloudwatch.tf
+++ b/aws/alarms/cloudwatch.tf
@@ -401,7 +401,8 @@ locals {
     dlq_consumer               = var.lambda_dlq_consumer_log_group_name,
     audit_log                  = var.lambda_audit_log_group_name,
     nagware                    = var.lambda_nagware_log_group_name,
-    vault_data_integrity_check = var.lambda_vault_data_integrity_check_log_group_name
+    vault_data_integrity_check = var.lambda_vault_data_integrity_check_log_group_name,
+    audit_logs_archiver        = var.lambda_audit_logs_archiver_group_name
   }
 }
 

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -53,6 +53,11 @@ variable "lambda_vault_data_integrity_check_log_group_name" {
   type        = string
 }
 
+variable "lambda_audit_logs_archiver_group_name" {
+  description = "Audit logs archiver Lambda CloudWatch log group name"
+  type        = string
+}
+
 variable "ecs_cluster_name" {
   description = "ECS cluster name, used by CPU/memory threshold alarms"
   type        = string

--- a/aws/lambdas/outputs.tf
+++ b/aws/lambdas/outputs.tf
@@ -47,3 +47,8 @@ output "lambda_vault_data_integrity_check_log_group_name" {
   description = "Vault data integrity check Lambda CloudWatch log group name"
   value       = aws_cloudwatch_log_group.vault_integrity.name
 }
+
+output "lambda_audit_logs_archiver_group_name" {
+  description = "Audit logs archiver Lambda CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.audit_logs_archiver.name
+}

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -78,6 +78,7 @@ dependency "lambdas" {
     lambda_nagware_log_group_name                    = "/aws/lambda/Nagware"
     lambda_vault_data_integrity_check_log_group_name = "/aws/lambda/Vault_Data_Integrity_Check"
     lambda_vault_data_integrity_check_function_name  = "Vault_Data_Integrity_Check"
+    lambda_audit_logs_archiver_group_name            = "/aws/lambda/Audit_Logs_Archiver"
   }
 }
 
@@ -123,6 +124,7 @@ inputs = {
   lambda_nagware_log_group_name                    = dependency.lambdas.outputs.lambda_nagware_log_group_name
   lambda_vault_data_integrity_check_log_group_name = dependency.lambdas.outputs.lambda_vault_data_integrity_check_log_group_name
   lambda_vault_data_integrity_check_function_name  = dependency.lambdas.outputs.lambda_vault_data_integrity_check_function_name
+  lambda_audit_logs_archiver_group_name            = dependency.lambdas.outputs.lambda_audit_logs_archiver_group_name
 
   sns_topic_alert_critical_arn        = dependency.sns.outputs.sns_topic_alert_critical_arn
   sns_topic_alert_warning_arn         = dependency.sns.outputs.sns_topic_alert_warning_arn


### PR DESCRIPTION
# Summary | Résumé

- Adds missing subscription filter to audit logs archiver lambda logs