### PR TITLE
fix: missing permissions for the audit logs archiver lambda to access S3 bucket

### DIFF
--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -217,7 +217,9 @@ data "aws_iam_policy_document" "lambda_s3" {
       var.archive_storage_arn,
       "${var.archive_storage_arn}/*",
       var.lambda_code_arn,
-      "${var.lambda_code_arn}/*"
+      "${var.lambda_code_arn}/*",
+      var.audit_logs_archive_storage_arn,
+      "${var.audit_logs_archive_storage_arn}/*"
     ]
   }
 }


### PR DESCRIPTION
# Summary | Résumé

- Added missing permissions for the audit logs archiver lambda to access S3 bucket