### PR TITLE
chore: Rename nextauth_url variable

### DIFF
--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -32,7 +32,7 @@ data "template_file" "form_viewer_task" {
     token_secret                    = var.token_secret_arn
     database_url                    = var.database_url_secret_arn
     redis_url                       = var.redis_url
-    nextauth_url                    = "https://${var.domains[0]}"
+    host_url                        = "https://${var.domains[0]}"
     reliability_file_storage        = var.reliability_file_storage_id
     vault_file_storage              = var.vault_file_storage_id
     gc_temp_token_template_id       = var.gc_temp_token_template_id

--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -30,8 +30,8 @@
         "value": "${tracer_provider}"
       },
       {
-        "name": "NEXTAUTH_URL",
-        "value": "${nextauth_url}"
+        "name": "HOST_URL",
+        "value": "${host_url}"
       },
       {
         "name": "REDIS_URL",


### PR DESCRIPTION
# Summary | Résumé

Renames the NEXTAUTH_URL parameter to HOST_URL as it is used in other parts of the application.

Future versions of Next-Auth (v5) have an issue when the NEXTAUTH_URL is present. Our current version (V4) does not explicitly require the NEXTAUTH_URL and can operate without it.

Dependency on: https://github.com/cds-snc/platform-forms-client/pull/3288
