### PR TITLE
chore: Increase localstack snapshot delta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - PERSISTENCE=1
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
       - SNAPSHOT_LOAD_STRATEGY=ON_STARTUP
+      - SNAPSHOT_FLUSH_INTERVAL=60
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - localstack:/var/lib/localstack"


### PR DESCRIPTION
# Summary | Résumé

Increases the persistance snapshot window for localstack from 15 seconds to 60 seconds.

I found the 15 second window was causing a performance degradation when many actions (lambdas, DynamoDB queries, etc) were happening at once.  So far 60 seconds has been a good balance but we can definitely increase it again in the future if needed.
