### PR TITLE
Revert "fix: Container gets read-only access to its root file system."

### DIFF
--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -12,7 +12,6 @@
         "drop": ["ALL"]
       }
     },
-    "readonlyRootFilesystem": true,
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
Reverts cds-snc/forms-terraform#624

Found an issue that makes reference to why we need write access to local system when using yarn commands: https://github.com/nodejs/corepack/issues/183