### PR TITLE
fix: Notify Callback Token using default

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -24,8 +24,8 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}
+  TF_VAR_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
-  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: 61cec9c4-64ca-4e4d-b4d2-a0e931c44422
   TF_VAR_gc_template_id: 92096ac6-1cc5-40ae-9052-fffdb8439a90
   TF_VAR_cognito_code_template_id: 8dde39b6-05b9-43ce-807f-c2364ed3bdb6

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -30,8 +30,8 @@ env:
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}
+  TF_VAR_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
 
-  TF_VAR_gc_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_gc_temp_token_template_id: b6885d06-d10a-422a-973f-05e274d9aa86
   TF_VAR_gc_template_id: 8d597a1b-a1d6-4e3c-8421-042a2b4158b7
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea


### PR DESCRIPTION
# Summary | Résumé

Default token was being used instead of token passed in through workflow
