### PR TITLE
fix: changed TTL field type from String to Number in ReliabilityQueue DynamoDB table

### DIFF
--- a/aws/lambdas/code/reliability/lib/dataLayer.ts
+++ b/aws/lambdas/code/reliability/lib/dataLayer.ts
@@ -58,7 +58,7 @@ export async function removeSubmission(submissionID: string) {
  */
 export async function notifyProcessed(submissionID: string) {
   try {
-    const expiringTime = (Math.floor(Date.now() / 1000) + 2592000).toString(); // expire after 30 days
+    const expiringTime = Math.floor(Date.now() / 1000) + 2592000; // expire after 30 days
     const DBParams = {
       TableName: "ReliabilityQueue",
       Key: {


### PR DESCRIPTION
# Summary | Résumé

- Fixed issue where TTL field in the ReliabilityQueue DynamoDB table had a wrong type (should be a Number but was a String). Because of that the TTL feature was not able to delete items from the table.