### PR TITLE
Revert "chore: add permission for ECS task to call legacy submission Lambda function name (#643)"

### DIFF
--- a/aws/lambdas/submission.tf
+++ b/aws/lambdas/submission.tf
@@ -52,18 +52,6 @@ resource "aws_lambda_permission" "submission" {
   principal     = var.ecs_iam_role_arn
 }
 
-/*
- * This is a temporary change to allow the web application to call the legacy submission Lambda function name (see https://github.com/cds-snc/platform-forms-client/commit/48919e38b00c4ce591009f7dd076e3f8b4bbf5c3)
- * It can be removed once we have released https://github.com/cds-snc/forms-terraform/pull/626 in Production.
- */
-
-resource "aws_lambda_permission" "submission_option_2" {
-  statement_id  = "AllowInvokeECS"
-  action        = "lambda:InvokeFunction"
-  function_name = "submission" // This will be changed to Submission in the Lambda containerization pull request
-  principal     = var.ecs_iam_role_arn
-}
-
 resource "aws_cloudwatch_log_group" "submission" {
   name              = "/aws/lambda/${aws_lambda_function.submission.function_name}"
   kms_key_id        = var.kms_key_cloudwatch_arn


### PR DESCRIPTION
This reverts commit 66f98b92e41c52d0c2651fd11e9914d4cbc5517d.

# Summary | Résumé

- Change of plan! We are going to put back the old name for the Submission Lambda function as it is getting complicated to try to make that change happen smoothly in Production.