### PR TITLE
fix: missing runs on property in Github workflow

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -217,6 +217,7 @@ jobs:
         update-lambda-function-image,
       ]
     if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack
         env:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -260,6 +260,7 @@ jobs:
         update-lambda-function-image,
       ]
     if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack
         env:


### PR DESCRIPTION
# Summary | Résumé

- Adds missing `runs-on` property to Github workflow