### PR TITLE
fix: wrong job dependency name in Github Workflow

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -188,7 +188,7 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   update-lambda-function-image:
-    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-plan]
+    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-apply-all-modules]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -231,7 +231,7 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   update-lambda-function-image:
-    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-plan]
+    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-apply-all-modules]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
# Summary | Résumé

- Fixes wrong dependency name in Github workflow job