### PR TITLE
fix: Update Notify error handling across lambdas

### DIFF
--- a/lambda-code/cognito-email-sender/main.ts
+++ b/lambda-code/cognito-email-sender/main.ts
@@ -88,7 +88,7 @@ export const handler: Handler = async (event) => {
         console.error(
           JSON.stringify({
             status: "failed",
-            message: "Failed to send Notify Email.",
+            message: `Failed to send password reset email to ${userEmail}`,
             error: (err as Error).message,
           })
         );

--- a/lambda-code/cognito-email-sender/package.json
+++ b/lambda-code/cognito-email-sender/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-crypto/client-node": "4.0.0",
     "@aws-sdk/client-secrets-manager": "^3.478.0",
+    "axios": "^1.6.8",
     "notifications-node-client": "^5.1.0"
   },
   "devDependencies": {

--- a/lambda-code/cognito-email-sender/yarn.lock
+++ b/lambda-code/cognito-email-sender/yarn.lock
@@ -1035,12 +1035,26 @@ asn1.js@^5.3.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 axios@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
   integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
     follow-redirects "^1.14.7"
+
+axios@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 bn.js@^4.0.0:
   version "4.12.0"
@@ -1061,6 +1075,18 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 duplexify@^4.1.1:
   version "4.1.2"
@@ -1097,6 +1123,20 @@ follow-redirects@^1.14.7:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 inherits@^2.0.1, inherits@^2.0.3:
   version "2.0.4"
@@ -1178,6 +1218,18 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -1202,6 +1254,11 @@ once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.2"

--- a/lambda-code/nagware/lib/emailNotification.ts
+++ b/lambda-code/nagware/lib/emailNotification.ts
@@ -66,7 +66,8 @@ Si les réponses ne sont toujours pas traitées après 45 jours, un processus d'
       console.error(
         JSON.stringify({
           status: "failed",
-          message: "Failed to send Notify Email.",
+          message:
+            "Failed to send nagware email to form owner: ${formOwnerEmailAddress} for form ID ${formID}",
           error: (error as Error).message,
         })
       );

--- a/lambda-code/nagware/lib/emailNotification.ts
+++ b/lambda-code/nagware/lib/emailNotification.ts
@@ -6,7 +6,10 @@ const client = new SecretsManagerClient();
 const command = new GetSecretValueCommand({ SecretId: process.env.NOTIFY_API_KEY });
 console.log("Retrieving Notify API Key from Secrets Manager");
 const notifyApiKey = await client.send(command);
-const notifyClient = new NotifyClient("https://api.notification.canada.ca", notifyApiKey.SecretString);
+const notifyClient = new NotifyClient(
+  "https://api.notification.canada.ca",
+  notifyApiKey.SecretString
+);
 
 export async function notifyFormOwner(
   formID: string,
@@ -49,16 +52,6 @@ Si les réponses ne sont toujours pas traitées après 45 jours, un processus d'
     });
   } catch (error) {
     if (error instanceof AxiosError) {
-      if (process.env.ENVIRONMENT === "staging") {
-        if (error.response?.data?.errors) {
-          if (
-            error.response.data.errors.find((e: Error) =>
-              e.message.includes("Can’t send to this recipient using a team-only API key")
-            ) !== undefined
-          )
-            return;
-        }
-      }
       // Error Message will be sent to slack
       console.error(
         JSON.stringify({
@@ -67,6 +60,14 @@ Si les réponses ne sont toujours pas traitées après 45 jours, un processus d'
           error: error.response?.data?.errors
             ? JSON.stringify(error.response.data.errors)
             : error.message,
+        })
+      );
+    } else {
+      console.error(
+        JSON.stringify({
+          status: "failed",
+          message: "Failed to send Notify Email.",
+          error: (error as Error).message,
         })
       );
     }

--- a/lambda-code/nagware/package.json
+++ b/lambda-code/nagware/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.128",
-    "@types/node": "^20.9.4",
+    "@types/node": "^20.12.8",
     "typescript": "^5.3.2"
   }
 }

--- a/lambda-code/nagware/yarn.lock
+++ b/lambda-code/nagware/yarn.lock
@@ -1549,10 +1549,10 @@
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.128.tgz#1c26e3e062e33961b250355cb4c9b6b3544b74a9"
   integrity sha512-bw4+ORfyywsj9Tq3WJA9j6HG4EbYy+dz+k8LN73ApmwjTdf82ZCSELz3b7BJQzeG5HE8IaTy9SXTHmruIK5ZlQ==
 
-"@types/node@^20.9.4":
-  version "20.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.4.tgz#cc8f970e869c26834bdb7ed480b30ede622d74c7"
-  integrity sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==
+"@types/node@^20.12.8":
+  version "20.12.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.8.tgz#35897bf2bfe3469847ab04634636de09552e8256"
+  integrity sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==
   dependencies:
     undici-types "~5.26.4"
 

--- a/lambda-code/reliability/lib/notifyProcessing.ts
+++ b/lambda-code/reliability/lib/notifyProcessing.ts
@@ -10,7 +10,10 @@ const client = new SecretsManagerClient();
 const command = new GetSecretValueCommand({ SecretId: process.env.NOTIFY_API_KEY });
 console.log("Retrieving Notify API Key from Secrets Manager");
 const notifyApiKey = await client.send(command);
-const notifyClient = new NotifyClient("https://api.notification.canada.ca", notifyApiKey.SecretString);
+const notifyClient = new NotifyClient(
+  "https://api.notification.canada.ca",
+  notifyApiKey.SecretString
+);
 
 export default async (
   submissionID: string,
@@ -50,8 +53,8 @@ export default async (
           ? formSubmission.deliveryOption.emailSubjectFr
           : formSubmission.form.titleFr
         : formSubmission.deliveryOption.emailSubjectEn
-          ? formSubmission.deliveryOption.emailSubjectEn
-          : formSubmission.form.titleEn;
+        ? formSubmission.deliveryOption.emailSubjectEn
+        : formSubmission.form.titleEn;
 
     await notifyClient.sendEmail(templateID, formSubmission.deliveryOption.emailAddress, {
       personalisation: {
@@ -94,9 +97,8 @@ export default async (
          */
         errorMessage = `${error.request}.`;
       }
-    }
-    if (error instanceof Error) {
-      errorMessage = `${error.message}.`;
+    } else if (error instanceof Error) {
+      errorMessage = `${(error as Error).message}.`;
     }
 
     console.error(


### PR DESCRIPTION
# Summary | Résumé

Enhances the Notify error handling to be more consistent across the different Lambdas.

Also fixes a logic bug that may have resulted in less verbose information being presented in the logs after an Axios Error in the Reliability Queue / Notify Processing lib.

Logic issue:
```js
class AxiosError extends Error;

const notifyError = new AxiosError;

let errorMessage = "";

if (notifyError instanceof AxiosError) /* true */ {  
  errorMessage = "I'm a detailed Notify Error message";
}

if (notifyError instanceof Error) /* true */ {
  errorMessage = "I'm a generic error message";
}

console.log(errorMessage);
/* I'm a generic error message */ 
/* Desired behavior is "I'm a detailed Notify Error message" */




```