### PR TITLE
chore: Github workflow deployment script not working as intended

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -99,6 +99,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
+    if: always() && (needs.build-tag-push-lambda-images.result == 'success' || needs.build-tag-push-lambda-images.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -189,7 +190,7 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   update-lambda-function-image:
-    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-apply-all-modules]
+    needs: [detect-lambda-changes, terragrunt-apply-all-modules]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -106,7 +106,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop' && always() && (needs.build-tag-push-lambda-images.result == 'success' || needs.build-tag-push-lambda-images.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -203,7 +203,7 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   update-lambda-function-image:
-    needs: [detect-lambda-changes, build-tag-push-lambda-images, terragrunt-apply-all-modules]
+    needs: [detect-lambda-changes, terragrunt-apply-all-modules]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ cd lambda-code/
 $ ./deploy-lambda-images.sh
 ```
 
-**There is a `skip` argument you can pass to that script if you only want to deploy the Lambda images for which you have made changes. It uses the `git diff --cached -- .` command in every single Lambda folder to know whether the image should be deployed or skipped**
+**There is a `skip` argument you can pass to that script if you only want to deploy the Lambda images for which you have made changes. It uses the `git diff HEAD .` command in every single Lambda folder to know whether the image should be deployed or skipped**
 
 ## Dynamo Database Table Schemas
 


### PR DESCRIPTION
# Summary | Résumé

- Fixed issue with Github workflow Terraform apply actions. We found a scenario where the Terraform modules were not applied because no detected changes in Lambda functions.