### PR TITLE
fix: include the mfa endpoint for WAF detection

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -345,7 +345,11 @@ resource "aws_wafv2_regex_pattern_set" "cognito_login_paths" {
   }
 
   regular_expression {
-    regex_string = "^\\/(api\\/auth\\/(session|csrf))$"
+    regex_string = "^\\/(api\\/auth\\/csrf)$"
+  }
+
+  regular_expression {
+    regex_string = "^\\/(?:en|fr)?\\/auth\\/mfa$"
   }
 }
 


### PR DESCRIPTION
The /api/auth/session endpoint isn't significant enough to raise suspicion of an out-of-country login, but the MFA endpoint might be—even though it still doesn't necessarily indicate that someone has actually logged in.