### PR TITLE
fix: notify slack lambda function had missing scripts in package.json

### DIFF
--- a/lambda-code/notify-slack/package.json
+++ b/lambda-code/notify-slack/package.json
@@ -5,7 +5,10 @@
   "main": "main.js",
   "type": "module",
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "tsc --project tsconfig.json",
+    "build:dev": "tsc --project tsconfig.json --watch",
+    "postbuild": "cp package.json dist/package.json && cp yarn.lock dist/yarn.lock && cd ./dist && yarn install --production",
     "test": "vitest --coverage"
   },
   "license": "MIT",


### PR DESCRIPTION
# Summary | Résumé

- Fixes Notify Slack lambda function which was not working because of missing scripts in package.json