### PR TITLE
feat: add TF_VAR check and conventional commit lint workflows

### DIFF
--- a/.github/workflows/conventional-commit-lint.yml
+++ b/.github/workflows/conventional-commit-lint.yml
@@ -7,11 +7,14 @@ jobs:
   conventional-commit-lint:
     runs-on: ubuntu-latest
     steps:
+    - name: Get all PR commits
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: ${{ github.event.pull_request.commits }}
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}      
 
     - name: Setup Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/conventional-commit-lint.yml
+++ b/.github/workflows/conventional-commit-lint.yml
@@ -1,0 +1,34 @@
+name: Conventional commit lint
+
+on:
+  pull_request:
+
+jobs:
+  conventional-commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get all PR commits + 1
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}      
+
+    - name: Setup Node.js
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
+        node-version: '20.x'
+
+    - name: Setup commitlint
+      run: |
+        npm install -g @commitlint/config-conventional @commitlint/cli
+
+    - name: Validate all PR commits
+      run: |
+        npx commitlint \
+          --extends '@commitlint/config-conventional' \
+          --from HEAD~${{ github.event.pull_request.commits }} \
+          --to HEAD \
+          --verbose

--- a/.github/workflows/conventional-commit-lint.yml
+++ b/.github/workflows/conventional-commit-lint.yml
@@ -7,14 +7,11 @@ jobs:
   conventional-commit-lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Get all PR commits + 1
-      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: ${{ env.PR_FETCH_DEPTH }}      
+        fetch-depth: ${{ github.event.pull_request.commits }}
 
     - name: Setup Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/scripts/terraform-variable-check.sh
+++ b/.github/workflows/scripts/terraform-variable-check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#
+# This script checks that all the GitHub workflow Terraform variables defined as `TF_VAR_` prefixed
+# environment variables have a matching `variable` definition in the codebase.  This is being done
+# to prevent accidental mismatches between the GitHub workflow and the Terraform codebase. 
+#
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORKFLOW_VARS="$(grep -r "^\s*TF_VAR" $SCRIPT_DIR/../ | awk -F ':' '{print $2}' | sort | uniq | sed 's/^[[:blank:]]*TF_VAR_//')"
+
+# Loop through all the variables in the workflow and check if they are defined in the *.tf code
+for VAR in $WORKFLOW_VARS; do
+    echo "🔎 Checking variable: \"$VAR\""
+    grep -r "variable \"$VAR\"" "$SCRIPT_DIR/../../../" || (echo "❌ Variable \"$VAR\" is not defined as a Terraform variable" && exit 1)
+done

--- a/.github/workflows/scripts/terraform-variable-check.sh
+++ b/.github/workflows/scripts/terraform-variable-check.sh
@@ -15,5 +15,5 @@ WORKFLOW_VARS="$(grep -r "^\s*TF_VAR" $SCRIPT_DIR/../ | awk -F ':' '{print $2}' 
 # Loop through all the variables in the workflow and check if they are defined in the *.tf code
 for VAR in $WORKFLOW_VARS; do
     echo "🔎 Checking variable: \"$VAR\""
-    grep -r "variable \"$VAR\"" "$SCRIPT_DIR/../../../" || (echo "❌ Variable \"$VAR\" is not defined as a Terraform variable" && exit 1)
+    grep -r --include="*.tf" "variable \"$VAR\"" "$SCRIPT_DIR/../../../" || (echo "❌ Variable \"$VAR\" is not defined as a Terraform variable" && exit 1)
 done

--- a/.github/workflows/terraform-variable-check.yml
+++ b/.github/workflows/terraform-variable-check.yml
@@ -1,0 +1,21 @@
+name: Terraform variable check
+
+on:
+  pull_request:
+    branches:
+      - "develop"
+    paths:
+      - "aws/**"
+      - "env/**"
+      - ".github/workflows/**"
+
+jobs:
+  terraform-variable-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Check Terraform variables are defined correctly
+      run: |
+        ./.github/workflows/scripts/terraform-variable-check.sh


### PR DESCRIPTION
# Summary

Adds the following two workflows:

1. `conventional-commit-lint`: check all commits follow the conventional commit style.  This will help ensure that the Release Please changelog contains all PRs.

2. `terraform-variable-check`: checks that the GitHub workflow Terraform variables defined as `TF_VAR_` prefixed environment variables have a matching `variable` definition in the codebase.  This will help prevent accidental misconfigurations between the workflows and Terraform code.

## ⚠️ Note
Once this merges, if a PR contains any commits that do not follow the conventional commit style, those commit messages will need to be rewritten with `git rebase` or `git commit --amend`.