### PR TITLE
revert: remove conventional commit lint from PRs

### DIFF
--- a/.github/workflows/conventional-commit-lint.yml
+++ b/.github/workflows/conventional-commit-lint.yml
@@ -1,20 +1,14 @@
 name: Conventional commit lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   conventional-commit-lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Get all PR commits
-      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: ${{ env.PR_FETCH_DEPTH }}      
 
     - name: Setup Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -25,10 +19,9 @@ jobs:
       run: |
         npm install -g @commitlint/config-conventional @commitlint/cli
 
-    - name: Validate all PR commits
+    - name: Validate last commit
       run: |
         npx commitlint \
           --extends '@commitlint/config-conventional' \
-          --from HEAD~${{ github.event.pull_request.commits }} \
-          --to HEAD \
+          --last \
           --verbose


### PR DESCRIPTION
# Summary
Remove the conventional commit lint from PRs until we've determined if merge queues can be used to enforce the desired squash commit message style.

The workflow is being converted to a `workflow_dispatch` trigger so that it is easy to reference if we go to merge queues.

# Related
- #663 