### PR TITLE
fix: Remove CSRF regex pattern from WAF out-of-country rule

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -345,10 +345,6 @@ resource "aws_wafv2_regex_pattern_set" "cognito_login_paths" {
   }
 
   regular_expression {
-    regex_string = "^\\/(api\\/auth\\/csrf)$"
-  }
-
-  regular_expression {
     regex_string = "^\\/(?:en|fr)?\\/auth\\/mfa$"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

To mitigate the risk of a CSRF attack during form submission, a CSRF token is requested. Therefore, this is not an endpoint that needs to be monitored for sign-ins from outside the country.