### PR TITLE
fix: remove use of `always()` in the TF apply jobs

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -82,7 +82,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
-    if: always() && (needs.build-tag-push-lambda-images.result == 'success' || needs.build-tag-push-lambda-images.result == 'skipped')
+    if: !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -200,7 +200,7 @@ jobs:
         terragrunt-apply-all-modules,
         update-lambda-function-image,
       ]
-    if: always() && contains(needs.*.result, 'failure')
+    if: failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -82,7 +82,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
-    if: !failure() && !cancelled()
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -200,7 +200,7 @@ jobs:
         terragrunt-apply-all-modules,
         update-lambda-function-image,
       ]
-    if: failure() && !cancelled()
+    if: ${{ failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -41,7 +41,6 @@ env:
 jobs:
   # We deploy ECR first to make sure it is available for the 'build-tag-push-lambda-images' job which will be run in parallel with `terragrunt-apply-all-modules`
   terragrunt-apply-ecr-only:
-    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -106,7 +105,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
-    if: github.ref == 'refs/heads/develop' && always() && (needs.build-tag-push-lambda-images.result == 'success' || needs.build-tag-push-lambda-images.result == 'skipped')
+    if: !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -204,7 +203,7 @@ jobs:
 
   update-lambda-function-image:
     needs: [detect-lambda-changes, terragrunt-apply-all-modules]
-    if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
+    if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]' && !failure() && !cancelled()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -231,7 +230,7 @@ jobs:
         terragrunt-apply-all-modules,
         update-lambda-function-image,
       ]
-    if: always() && contains(needs.*.result, 'failure')
+    if: failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-tag-push-lambda-images:
     needs: detect-lambda-changes
-    if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
+    if: ${{ needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -105,7 +105,7 @@ jobs:
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
-    if: !failure() && !cancelled()
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -203,7 +203,7 @@ jobs:
 
   update-lambda-function-image:
     needs: [detect-lambda-changes, terragrunt-apply-all-modules]
-    if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]' && !failure() && !cancelled()
+    if: ${{ needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -230,7 +230,7 @@ jobs:
         terragrunt-apply-all-modules,
         update-lambda-function-image,
       ]
-    if: failure() && !cancelled()
+    if: ${{ failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Send error message on Slack


### PR DESCRIPTION
# Summary
The use of `always()` makes it impossible to cancel the workflow jobs. This change means that the workflow will still run as expected if jobs are skipped, but allow for cancel actions as well.

Additionally, the following changes have been. made: 
- The check on the `github.ref` has been removed from the Staging workflow as this workflow only triggers on push to the `develop` branch.
- Conditional `if: ${{ }}` syntax has been added back as GitHub is encountering a parsing error without it.

## Tests
The following are the test results showing which jobs will execute depending on how they are skipped, cancelled or fail:

### Cancel during Lambda build
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/37f8fc71-a545-4329-af02-ef315ccc8b10)

### Cancel during Terraform apply
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/a532efd6-c045-47a6-a811-f39064c4e6df)

### Lambda build has changes
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/05a7e215-c1dc-483f-963b-976582a1537f)

### Skipped Lambda build
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/2bfde581-ae56-4151-9871-6675d94f766b)

### Failed Lambda build
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/4a64f940-71dd-4ba6-83b2-e825150278c0)

### Failed Terraform apply
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/029425d1-fcfa-43df-be93-66845145ffb7)

### Failed Lambda update
![image](https://github.com/cds-snc/forms-terraform/assets/2110107/6933ae21-0bd9-43c2-9329-17405eed1458)


# Related
- https://github.com/cds-snc/platform-core-services/issues/574