### PR TITLE
feat: simplify production release reverts

### DIFF
--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -29,6 +29,11 @@ runs:
       run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.version }}
       shell: bash
 
+    - name: Fail if no version set
+      if: env.version == ''   
+      run: exit 1
+      shell: bash
+
     - name: Output version
       id: output-version
       run: echo "version=${{ env.version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -10,14 +10,16 @@ outputs:
     value: ${{ steps.output-version.outputs.version }}
 
 runs:
-  using: "composite" 
+  using: "composite"
   steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Get version, release PR branch
       if: inputs.is-tagged == 'false'
-      run: echo "version=${{ github.head_ref }}" >> $GITHUB_ENV
+      env:
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
+      run: echo "version=$GITHUB_HEAD_REF" >> $GITHUB_ENV
 
     - name: Get version, perform release of tag
       if: inputs.is-tagged == 'true'

--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -12,23 +12,24 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
     - name: Get version, release PR branch
-      if: inputs.is-tagged == 'false'
+      if: inputs.is-tagged == 'false' && startsWith(github.head_ref, 'release-please--')
       env:
         GITHUB_HEAD_REF: ${{ github.head_ref }}
       run: echo "version=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+      shell: bash
 
     - name: Get version, perform release of tag
       if: inputs.is-tagged == 'true'
       run: echo "version=v$(cat version.txt)" >> $GITHUB_ENV
+      shell: bash
 
     - name: Wait for tag to exist
       if: inputs.is-tagged == 'true'
       run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.version }}
+      shell: bash
 
     - name: Output version
       id: output-version
       run: echo "version=${{ env.version }}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -1,0 +1,32 @@
+name: Get infrastructure version to deploy
+
+inputs:
+  is-tagged:
+    description: "Is this for the release of a tagged version?  This action will wait for the tag to exist if so."
+    required: true
+outputs:
+  version:
+    description: "Infrastructure version to deploy"
+    value: ${{ steps.output-version.outputs.version }}
+
+runs:
+  using: "composite" 
+  steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Get version, release PR branch
+      if: inputs.is-tagged == 'false'
+      run: echo "version=${{ github.head_ref }}" >> $GITHUB_ENV
+
+    - name: Get version, perform release of tag
+      if: inputs.is-tagged == 'true'
+      run: echo "version=v$(cat version.txt)" >> $GITHUB_ENV
+
+    - name: Wait for tag to exist
+      if: inputs.is-tagged == 'true'
+      run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.version }}
+
+    - name: Output version
+      id: output-version
+      run: echo "version=${{ env.version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/scripts/wait-for-tag.sh
+++ b/.github/workflows/scripts/wait-for-tag.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+# Given a git tag name as an argument, this script will wait until the tag is available in the remote repository.
+# The wait is based on the values of CHECK_INTERVAL and MAX_CHECKS.
+# 
+# Usage:
+#   ./wait-for-tag.sh v1.2.3
+#
+
+set -euo pipefail
+IFS=$'\n\t'
+
+TAG_NAME="$1"
+CHECK_INTERVAL=5
+MAX_CHECKS=20
+
+for ((i=1; i<=MAX_CHECKS; i++)); do
+  git fetch --tags > /dev/null 2>&1
+  if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+    echo "🎉 Tag $TAG_NAME exists!"
+    exit 0
+  fi
+  echo "Tag $TAG_NAME not found. Checking again in $CHECK_INTERVAL seconds... (Attempt $i/$MAX_CHECKS)"
+  sleep $CHECK_INTERVAL
+done
+
+echo "💀 Tag $TAG_NAME does not exist after $MAX_CHECKS attempts..."
+exit 1

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -3,7 +3,7 @@ name: "Terragrunt apply PRODUCTION"
 on:
   push:
     branches:
-      - develop
+      - "develop"
     paths:
       - "version.txt"
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get version
-        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
+        run: echo "VERSION=v$(cat version.txt)" >> $GITHUB_ENV
 
       - name: Wait for tag to exist
         run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.VERSION }}

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -40,6 +40,9 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}    
     steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version to deploy
         id: get-version
         uses: ./.github/workflows/get-version

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -37,20 +37,21 @@ env:
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}    
     steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Get version
-        run: echo "VERSION=v$(cat version.txt)" >> $GITHUB_ENV
-
-      - name: Wait for tag to exist
-        run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.VERSION }}
+      - name: Get version to deploy
+        id: get-version
+        uses: ./.github/workflows/get-version
+        with:
+          is-tagged: 'true'
 
   # We deploy ECR first to make sure it is available for the 'build-tag-push-lambda-images' job which will be run in parallel with `terragrunt-apply-all-modules`
   terragrunt-apply-ecr-only:
     needs: get-version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}    
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -73,8 +74,10 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   build-tag-push-lambda-images:
-    needs: terragrunt-apply-ecr-only
+    needs: [get-version, terragrunt-apply-ecr-only]
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix:
@@ -101,9 +104,11 @@ jobs:
           image-tag: ${{ env.VERSION }}
 
   terragrunt-apply-all-modules:
-    needs: build-tag-push-lambda-images
+    needs: [get-version, build-tag-push-lambda-images]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -195,8 +200,10 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   update-lambda-function-image:
-    needs: terragrunt-apply-all-modules
+    needs: [get-version, terragrunt-apply-all-modules]
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -1,8 +1,11 @@
 name: "Terragrunt apply PRODUCTION"
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - develop
+    paths:
+      - "version.txt"
 
 permissions:
   id-token: write
@@ -32,12 +35,27 @@ env:
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
 
 jobs:
-  # We deploy ECR first to make sure it is available for the 'build-tag-push-lambda-images' job which will be run in parallel with `terragrunt-apply-all-modules`
-  terragrunt-apply-ecr-only:
+  get-version:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get version
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
+
+      - name: Wait for tag to exist
+        run: ./.github/workflows/scripts/wait-for-tag.sh ${{ env.VERSION }}
+
+  # We deploy ECR first to make sure it is available for the 'build-tag-push-lambda-images' job which will be run in parallel with `terragrunt-apply-all-modules`
+  terragrunt-apply-ecr-only:
+    needs: get-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
@@ -64,6 +82,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       - name: Build Lambda images
         uses: ./.github/workflows/build-lambda-images
@@ -78,7 +98,7 @@ jobs:
           aws-role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
           lambda-name: ${{ matrix.image }}
-          image-tag: ${{ github.ref_name }}
+          image-tag: ${{ env.VERSION }}
 
   terragrunt-apply-all-modules:
     needs: build-tag-push-lambda-images
@@ -87,6 +107,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools
@@ -180,9 +202,6 @@ jobs:
       matrix:
         image: [audit-logs, audit-logs-archiver, cognito-email-sender, cognito-pre-sign-up, form-archiver, nagware, notify-slack, reliability, reliability-dlq-consumer, response-archiver, submission, vault-integrity]
     steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
       - name: Request Lambda functions to use new image
         uses: ./.github/workflows/request-lambda-functions-to-use-new-image
         with:
@@ -190,11 +209,12 @@ jobs:
           aws-role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
           lambda-name: ${{ matrix.image }}
-          image-tag: ${{ github.ref_name }}
+          image-tag: ${{ env.VERSION }}
 
   notify-on-error:
     needs:
       [
+        get-version,
         terragrunt-apply-ecr-only,
         build-tag-push-lambda-images,
         terragrunt-apply-all-modules,

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -210,9 +210,6 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.detect-lambda-changes.outputs.lambda-to-rebuild) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
       - name: Request Lambda functions to use new image
         uses: ./.github/workflows/request-lambda-functions-to-use-new-image
         with:

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -39,21 +39,20 @@ env:
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}    
     steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Release please PR, use branch
-        if: ${{ startsWith(github.head_ref, 'release-please--') }}
-        run: echo "VERSION=${{ github.head_ref }}" >> $GITHUB_ENV
-
-      - name: Revert PR, use tag
-        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
-        run: echo "VERSION=v$(cat version.txt)" >> $GITHUB_ENV        
+      - name: Get version to deploy
+        id: get-version
+        uses: ./.github/workflows/get-version
+        with:
+          is-tagged: ${{ !startsWith(github.head_ref, 'release-please--') }} # If not the release PR branch, assume it is a revert PR
 
   detect-lambda-changes:
     needs: get-version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}  
     outputs:
       lambda-to-rebuild: ${{ steps.filter.outputs.changes }}
     steps:
@@ -69,9 +68,11 @@ jobs:
           filters: .github/lambda-filter.yml
 
   test-lambda-code:
-    needs: detect-lambda-changes
+    needs: [get-version, detect-lambda-changes]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,9 +90,11 @@ jobs:
           lambda-name: ${{ matrix.image }}
 
   build-lambda-images:
-    needs: detect-lambda-changes
+    needs: [get-version, detect-lambda-changes]
     if: needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]'
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +112,10 @@ jobs:
           lambda-name: ${{ matrix.image }}
 
   terragrunt-plan:
+    needs: get-version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -42,6 +42,9 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}    
     steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version to deploy
         id: get-version
         uses: ./.github/workflows/get-version

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -3,7 +3,7 @@ name: "Terragrunt plan PRODUCTION"
 on:
   pull_request:
     branches:
-      - develop
+      - "develop"
     paths:
       - "version.txt"   
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Revert PR, use tag
         if: ${{ !startsWith(github.head_ref, 'release-please--') }}
-        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV        
+        run: echo "VERSION=v$(cat version.txt)" >> $GITHUB_ENV        
 
   detect-lambda-changes:
     needs: get-version

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -3,7 +3,9 @@ name: "Terragrunt plan PRODUCTION"
 on:
   pull_request:
     branches:
-      - "develop"
+      - develop
+    paths:
+      - "version.txt"   
 
 permissions:
   id-token: write
@@ -35,14 +37,30 @@ env:
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Release please PR, use branch
+        if: ${{ startsWith(github.head_ref, 'release-please--') }}
+        run: echo "VERSION=${{ github.head_ref }}" >> $GITHUB_ENV
+
+      - name: Revert PR, use tag
+        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV        
+
   detect-lambda-changes:
-    if: startsWith(github.head_ref, 'release-please--')
+    needs: get-version
     runs-on: ubuntu-latest
     outputs:
       lambda-to-rebuild: ${{ steps.filter.outputs.changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       - name: Filter
         id: filter
@@ -61,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       - name: Test Lambda code
         uses: ./.github/workflows/test-lambda-code
@@ -79,6 +99,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       - name: Build Lambda images
         uses: ./.github/workflows/build-lambda-images
@@ -92,6 +114,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.VERSION }}
 
       # Setup Terraform, Terragrunt, and Conftest
       - name: Setup terraform tools

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -109,7 +109,6 @@ jobs:
           lambda-name: ${{ matrix.image }}
 
   terragrunt-plan:
-    if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Summary
Update the Production Terraform workflows so that a release can more easily be reverted.  Now all that will be required to rollback a failed release is to revert the Release Please PR.

The way this works is as follows:
1. When a PR that updates `version.txt` is opened, the TF plan workflow will check if it's a Release Please branch.  If yes, the branch is used to perform the TF plan.  Otherwise it is assumed to be a revert PR and the tag specified in `version.txt` is used for the TF plan operation.

2. On merge of a PR with a `version.txt` change, the TF apply workflow will wait for the git tag it specifies to exist.  For a normal release flow, this will be once the `release_generator` workflow finished.  For a revert PR, the tag will already exist.

Additionally, the code checkout step has been removed from the `update-lambda-function-image` job as it is not needed.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3590