### PR TITLE
fix: Athena load balancer create table query

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -2,7 +2,7 @@
 # Create Athena queries to view the WAF and load balancer access logs
 #
 module "athena" {
-  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=bd904d01094f196fd3e8ff5c46e73838f1f1be26"
+  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=c8c77df64ea8ddf2937f1c79c8b0299158655090" # v4.9.10
 
   athena_bucket_name = module.athena_bucket.s3_bucket_id
 


### PR DESCRIPTION
# Summary
Update the Terraform module to the version with a fix for how the Athena load balancer logs table is created.

# Related
- https://github.com/cds-snc/terraform-modules/pull/513