### PR TITLE
chore: update codeowners to protect version.txt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Users that are allowed to approve a release PR
 
-.release-please-manifest.json @bryan-robitaille @dsamojlenko @timarney @craigzour
+version.txt @bryan-robitaille @dsamojlenko @timarney @craigzour


### PR DESCRIPTION
# Summary
With the new process where production Terraform apply is triggered by changes to the `version.txt` file, the codeowners should be updated so that these PRs require specific approvers.

This is enforced with branch protection rules on the `develop` branch:
<img width="955" alt="image" src="https://github.com/cds-snc/forms-terraform/assets/2110107/be28fe95-1665-461c-b81d-a7cba8d8b15b">

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3590
- https://github.com/cds-snc/forms-terraform/pull/678