### PR TITLE
feat: add workflow to catch release of reverted tags

### DIFF
--- a/.github/workflows/terragrunt-plan-production-warn-release-exists.yml
+++ b/.github/workflows/terragrunt-plan-production-warn-release-exists.yml
@@ -1,0 +1,28 @@
+name: "Terragrunt plan PRODUCTION warn release exists"
+
+on:
+  pull_request:
+    branches:
+      - "develop"
+    paths:
+      - "version.txt"  
+
+jobs:
+  warn-release-exists:
+    if: ${{ startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get version
+        run: echo "version=v$(cat version.txt)" >> $GITHUB_ENV
+
+      - name: Fail if release tag exists # this happens if there is a revert and the reverted release and tag is not deleted
+        run: |
+          git fetch --tags > /dev/null 2>&1
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "Tag $version exists..."
+            echo "Please delete the release and tag and try again."
+            exit 1
+          fi


### PR DESCRIPTION
# Summary
Add a workflow that runs for Release Please PRs that checks if the target release already exists.  This will happen if:

1. a revert is merged; and
2. the reverted release/tag is not deleted.