### PR TITLE
chore: remove `forms-terraform-apply-release` OIDC role

### DIFF
--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -1,5 +1,4 @@
 locals {
-  forms_terraform_apply_release       = "forms-terraform-apply-release"
   platform_forms_client_pr_review_env = "platform-forms-client-pr-review-env"
   platform_forms_client_release       = "platform-forms-client-release"
 }
@@ -22,11 +21,6 @@ module "github_workflow_roles" {
   billing_tag_value = var.billing_tag_value
   roles = [
     {
-      name      = local.forms_terraform_apply_release
-      repo_name = "forms-terraform"
-      claim     = "ref:refs/tags/v*"
-    },
-    {
       name      = local.platform_forms_client_pr_review_env
       repo_name = "platform-forms-client"
       claim     = "pull_request"
@@ -43,15 +37,6 @@ module "github_workflow_roles" {
 # Attach polices to the OIDC roles to grant them permissions.  These
 # attachments are scoped to only the environments that require the role.
 #
-resource "aws_iam_role_policy_attachment" "forms_terraform_apply_release_admin" {
-  count      = var.env == "production" ? 1 : 0
-  role       = local.forms_terraform_apply_release
-  policy_arn = data.aws_iam_policy.admin.arn
-  depends_on = [
-    module.github_workflow_roles
-  ]
-}
-
 resource "aws_iam_role_policy_attachment" "platform_forms_client_pr_review_env" {
   count      = var.env == "staging" ? 1 : 0
   role       = local.platform_forms_client_pr_review_env


### PR DESCRIPTION
# Summary
Remove this role as it is no longer required.  Previously it was used to run Terraform apply against production when a release tag had triggered the workflow.

With the change to support release revert PRs, Terraform apply workflows against production are now triggered by pushes to the `develop` branch.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3590