### PR TITLE
feat: health check alarm for submission lambda invocations

### DIFF
--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -43,6 +43,16 @@ variable "lambda_response_archiver_log_group_name" {
   type        = string
 }
 
+variable "lambda_submission_expect_invocation_in_period" {
+  description = "Submission Lambda period (minutes) during which it is expected at least one function invocation will occur.  This is used for the healthcheck alarms."
+  type        = number
+}
+
+variable "lambda_submission_function_name" {
+  description = "Submission Lambda function name"
+  type        = string
+}
+
 variable "lambda_submission_log_group_name" {
   description = "Submission Lambda CloudWatch log group name"
   type        = string

--- a/aws/alarms/locals.tf
+++ b/aws/alarms/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  lambda_submission_expect_invocation_in_period = var.env == "production" ? var.lambda_submission_expect_invocation_in_period : 60 * 24 * 7 # expect once a week in non-prod envs
+  lambda_submission_expect_invocation_in_period = var.env == "production" ? var.lambda_submission_expect_invocation_in_period : 60 * 24 # expect once a day in non-prod envs
 }

--- a/aws/alarms/locals.tf
+++ b/aws/alarms/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  lambda_submission_expect_invocation_in_period = var.env == "production" ? var.lambda_submission_expect_invocation_in_period : 60 * 24 * 7 # expect once a week in non-prod envs
+}

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -88,6 +88,7 @@ dependency "lambdas" {
     lambda_reliability_log_group_name              = "/aws/lambda/Reliability"
     lambda_reliability_dlq_consumer_log_group_name = "/aws/lambda/Reliability_DLQ_Consumer"
     lambda_response_archiver_log_group_name        = "/aws/lambda/Response_Archiver"
+    lambda_submission_function_name                = "Submission"
     lambda_submission_log_group_name               = "/aws/lambda/Submission"
     lambda_vault_integrity_log_group_name          = "/aws/lambda/Vault_Data_Integrity_Check"
     lambda_vault_integrity_function_name           = "vault-integrity"
@@ -146,6 +147,8 @@ inputs = {
   lambda_reliability_log_group_name              = dependency.lambdas.outputs.lambda_reliability_log_group_name
   lambda_reliability_dlq_consumer_log_group_name = dependency.lambdas.outputs.lambda_reliability_dlq_consumer_log_group_name
   lambda_response_archiver_log_group_name        = dependency.lambdas.outputs.lambda_response_archiver_log_group_name
+  lambda_submission_expect_invocation_in_period  = 30
+  lambda_submission_function_name                = dependency.lambdas.outputs.lambda_submission_function_name
   lambda_submission_log_group_name               = dependency.lambdas.outputs.lambda_submission_log_group_name
   lambda_vault_integrity_log_group_name          = dependency.lambdas.outputs.lambda_vault_integrity_log_group_name
   lambda_vault_integrity_function_name           = dependency.lambdas.outputs.lambda_vault_integrity_function_name


### PR DESCRIPTION
# Summary
Add alarms that will trigger if no submission lambda function invocations have been seen in an expected period.

- `SubmissionLambdaNoInvocationsCoreHours`: triggers if there has not been at least one invocation between 9am UTC and 6am UTC the next day.  Between 6am and 9am, the alarm will always be in a non-breaching state.
- `SubmissionLambdaInvocationsAnomaly`: uses anomaly detection and will trigger if the invocations are low for a given period.

Neither alarm has an SNS action defined.  This will allow us to observe and adjust their behaviour before they begin posting to Slack for a breaching state.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3585