### PR TITLE
fix: ECS task definition constant change on TF plan

### DIFF
--- a/aws/app/ecs_task/form_viewer.json
+++ b/aws/app/ecs_task/form_viewer.json
@@ -4,11 +4,16 @@
     "image": "${image}",
     "portMappings": [
       {
-        "containerPort": 3000
+        "containerPort": 3000,
+        "hostPort": 3000,
+        "protocol": "tcp"
       }
     ],
+    "cpu": 0,
+    "essential": true,
     "linuxParameters": {
       "capabilities": {
+        "add": [],
         "drop": ["ALL"]
       }
     },
@@ -111,6 +116,9 @@
         "name": "FRESHDESK_API_KEY",
         "valueFrom": "${freshdesk_api_key}"
       }
-    ]
+    ],
+    "mountPoints": [],
+    "volumesFrom": [],
+    "systemControls": []
   }
 ]


### PR DESCRIPTION
# Summary
Update the ECS task definition to include the default values that are added by AWS when the ECS task definition is created.

This will stop our TF plans from always showing an app change on all PRs.