### PR TITLE
feat: send IdP emails using SES SMTP server

### DIFF
--- a/aws/idp/route53.tf
+++ b/aws/idp/route53.tf
@@ -10,6 +10,7 @@ resource "aws_route53_record" "idp" {
   }
 }
 
+# ACM certification validation
 resource "aws_route53_record" "idp_validation" {
   zone_id = local.hosted_zone_id
 
@@ -31,4 +32,13 @@ resource "aws_route53_record" "idp_validation" {
 resource "aws_acm_certificate_validation" "idp" {
   certificate_arn         = aws_acm_certificate.idp.arn
   validation_record_fqdns = [for record in aws_route53_record.idp_validation : record.fqdn]
+}
+
+# SES domain validation
+resource "aws_route53_record" "idp_ses_verification_TXT" {
+  zone_id = local.hosted_zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.idp.id}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [aws_ses_domain_identity.idp.verification_token]
 }

--- a/aws/idp/ses.tf
+++ b/aws/idp/ses.tf
@@ -1,0 +1,41 @@
+#
+# Send email using a SES SMTP server
+#
+resource "aws_ses_domain_identity" "idp" {
+  domain = var.domain_idp
+}
+
+resource "aws_ses_domain_identity_verification" "idp" {
+  domain     = aws_ses_domain_identity.idp.id
+  depends_on = [aws_route53_record.idp_ses_verification_TXT]
+}
+
+resource "aws_iam_user" "idp_send_email" {
+  name = "idp_send_email"
+}
+
+data "aws_iam_policy_document" "idp_send_email" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ses:SendRawEmail"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "idp_send_email" {
+  name   = "idp_send_email"
+  policy = data.aws_iam_policy_document.idp_send_email.json
+}
+
+resource "aws_iam_user_policy_attachment" "idp_send_email" {
+  user       = aws_iam_user.idp_send_email.name
+  policy_arn = aws_iam_policy.idp_send_email.arn
+}
+
+resource "aws_iam_access_key" "idp_send_email" {
+  user = aws_iam_user.idp_send_email.name
+}

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -15,6 +15,10 @@ TLS:
 Database:
   postgres:
     Port: 5432
+    MaxOpenConns: 200
+    MaxIdleConns: 20
+    MaxConnLifetime: 1800
+    MaxConnIdleTime: 1800
     User:
       SSL:
         Mode: require


### PR DESCRIPTION
# Summary
Add SES configuration and an IAM user so that the IdP can send email using the SES SMTP server.

Also updates the database configuration to add connection pool settings as we are currently not using an RDS proxy to manage the connection pooling.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3927
- https://github.com/cds-snc/platform-forms-client/issues/3925