### PR TITLE
feat: add SPF, DKIM and DMARC DNS records

### DIFF
--- a/aws/idp/route53.tf
+++ b/aws/idp/route53.tf
@@ -42,3 +42,35 @@ resource "aws_route53_record" "idp_ses_verification_TXT" {
   ttl     = "600"
   records = [aws_ses_domain_identity.idp.verification_token]
 }
+
+# Email sending
+resource "aws_route53_record" "idp_spf_TXT" {
+  zone_id = local.hosted_zone_id
+  name    = var.domain_idp
+  type    = "TXT"
+  ttl     = "300"
+  records = [
+    "v=spf1 include:amazonses.com -all"
+  ]
+}
+
+resource "aws_route53_record" "idp_dkim_CNAME" {
+  count   = 3
+  zone_id = local.hosted_zone_id
+  name    = "${element(aws_ses_domain_dkim.idp.dkim_tokens, count.index)}._domainkey.${var.domain_idp}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "${element(aws_ses_domain_dkim.idp.dkim_tokens, count.index)}.dkim.amazonses.com",
+  ]
+}
+
+resource "aws_route53_record" "idp_dmarc_TXT" {
+  zone_id = local.hosted_zone_id
+  name    = "_dmarc.${var.domain_idp}"
+  type    = "TXT"
+  ttl     = "300"
+  records = [
+    "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:security@cds-snc.ca"
+  ]
+}

--- a/aws/idp/ses.tf
+++ b/aws/idp/ses.tf
@@ -5,6 +5,10 @@ resource "aws_ses_domain_identity" "idp" {
   domain = var.domain_idp
 }
 
+resource "aws_ses_domain_dkim" "idp" {
+  domain = aws_ses_domain_identity.idp.domain
+}
+
 resource "aws_ses_domain_identity_verification" "idp" {
   domain     = aws_ses_domain_identity.idp.id
   depends_on = [aws_route53_record.idp_ses_verification_TXT]


### PR DESCRIPTION
# Summary
Add email sending DNS records.  The purpose of each is as follows:

- `SPF`: specify which servers are authorized to send emails on behalf of the IdP domain.

- `DKIM`: verify that an email message was not altered during transit and that it came from the claimed sender.

- `DMARC`: specify how emails that fail SPF or DKIM checks should be handled. A report with emails that fail the checks will be sent to security@cds-snc.ca

# Related
- Closes cds-snc/platform-forms-client#3952