### PR TITLE
feat: add IdP CloudWatch alarms

### DIFF
--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -552,38 +552,6 @@ resource "aws_cloudwatch_metric_alarm" "healthcheck_lambda_submission_invocation
   }
 }
 
-# Submission lambda: anomaly detection, trigger when invocations are below lower threshold
-resource "aws_cloudwatch_metric_alarm" "healthcheck_lambda_submission_invocations_anomaly" {
-  alarm_name          = "SubmissionLambdaInvocationsAnomaly"
-  alarm_description   = "HealthCheck - `submission` invocations in ${local.lambda_submission_expect_invocation_in_period} minutes is low."
-  comparison_operator = "LessThanLowerThreshold"
-  evaluation_periods  = 1
-  threshold_metric_id = "invocations_expected"
-  treat_missing_data  = "notBreaching"
-
-  metric_query {
-    id          = "invocations_expected"
-    expression  = "ANOMALY_DETECTION_BAND(invocations)"
-    label       = "Invocations (expected)"
-    return_data = "true"
-  }
-
-  metric_query {
-    id          = "invocations"
-    return_data = "true"
-    metric {
-      metric_name = "Invocations"
-      namespace   = "AWS/Lambda"
-      period      = local.lambda_submission_expect_invocation_in_period * 60
-      stat        = "Sum"
-      unit        = "Count"
-      dimensions = {
-        FunctionName = var.lambda_submission_function_name
-      }
-    }
-  }
-}
-
 # Nagware lambda: no invocations on a Tuesday, Thursday or Sunday
 resource "aws_cloudwatch_metric_alarm" "healthcheck_lambda_nagware_invocations_schedule" {
   alarm_name          = "NagwareLambdaNoInvocationsSchedule"

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -83,6 +83,8 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "idp_response_time_warn" {
+  count = var.feature_flag_idp ? 1 : 0
+
   alarm_name          = "IdP-ResponseTimeWarn"
   alarm_description   = "IdP LB Warning - The latency of response times from the IdP are abnormally high."
   comparison_operator = "GreaterThanThreshold"

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -129,29 +129,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_rds_cpu_utilization" {
   ok_actions    = [var.sns_topic_alert_ok_arn]
 
   dimensions = {
-    DBClusterIdentifier = var.rds_idp_cluster_id
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "idp_rds_acu_utilization" {
-  count = var.feature_flag_idp ? 1 : 0
-
-  alarm_name          = "IdP-RDSAcuUtilization"
-  alarm_description   = "IdP RDS Warning - high ACU use for RDS cluster in a 5 minute period"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "ACUUtilization"
-  namespace           = "AWS/RDS"
-  period              = "300"
-  statistic           = "Average"
-  threshold           = var.rds_idp_acu_maximum
-
-
-  alarm_actions = [aws_sns_topic.alert_warning.arn]
-  ok_actions    = [aws_sns_topic.alert_warning.arn]
-
-  dimensions = {
-    DBClusterIdentifier = var.rds_idp_cluster_id
+    DBClusterIdentifier = var.rds_idp_cluster_identifier
   }
 }
 

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -1,0 +1,195 @@
+#
+# ECS resource usage alarms
+#
+resource "aws_cloudwatch_metric_alarm" "idp_cpu_utilization_high_warn" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-CpuUtilizationWarn"
+  alarm_description   = "IdP ECS Warning - High CPU usage has been detected."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = var.threshold_ecs_cpu_utilization_high
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    ClusterName = var.ecs_idp_cluster_name
+    ServiceName = var.ecs_idp_service_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "idp_memory_utilization_high_warn" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-MemoryUtilizationWarn"
+  alarm_description   = "IdP ECS Warning - High memory usage has been detected."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = var.threshold_ecs_memory_utilization_high
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    ClusterName = var.ecs_idp_cluster_name
+    ServiceName = var.ecs_idp_service_name
+  }
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "idp_error_detection" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  name            = "error_detection_in_idp_logs"
+  log_group_name  = var.ecs_idp_cloudwatch_log_group_name
+  filter_pattern  = "level=error"
+  destination_arn = aws_lambda_function.notify_slack.arn
+}
+
+#
+# Load balancer
+#
+resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-UnhealthyHostCount" # TODO: bump to SEV1 once this is in production
+  alarm_description   = "IdP ELB Warning - unhealthy host count >= 1 in a 1 minute period"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+  evaluation_periods  = "1"
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    LoadBalancer = var.lb_idp_arn_suffix
+    TargetGroup  = var.lb_idp_target_group_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "idp_response_time_warn" {
+  alarm_name          = "IdP-ResponseTimeWarn"
+  alarm_description   = "IdP LB Warning - The latency of response times from the IdP are abnormally high."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "5"
+  datapoints_to_alarm = "2"
+  threshold           = var.threshold_lb_response_time
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
+  ok_actions          = [var.sns_topic_alert_ok_arn]
+
+  metric_query {
+    id          = "response_time"
+    return_data = "true"
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "60"
+      stat        = "Average"
+      dimensions = {
+        LoadBalancer = var.lb_idp_arn_suffix
+      }
+    }
+  }
+}
+
+#
+# RDS
+#
+resource "aws_cloudwatch_metric_alarm" "idp_rds_cpu_utilization" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-RDSCpuUtilization"
+  alarm_description   = "IdP RDS Warning - high CPU use for RDS cluster in a 5 minute period"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.rds_idp_cpu_maxiumum
+
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_idp_cluster_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "idp_rds_acu_utilization" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-RDSAcuUtilization"
+  alarm_description   = "IdP RDS Warning - high ACU use for RDS cluster in a 5 minute period"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ACUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.rds_idp_acu_maximum
+
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn]
+  ok_actions    = [aws_sns_topic.alert_warning.arn]
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_idp_cluster_id
+  }
+}
+
+#
+# SES bounces and complaints
+#
+resource "aws_cloudwatch_metric_alarm" "idp_bounce_rate_high" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-SESBounceRate"
+  alarm_description   = "IdP SES Warning - bounce rate >=7% over the last 12 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Reputation.BounceRate"
+  namespace           = "AWS/SES"
+  period              = 60 * 60 * 12
+  statistic           = "Average"
+  threshold           = 7 / 100
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "idp_complaint_rate_high" {
+  count = var.feature_flag_idp ? 1 : 0
+
+  alarm_name          = "IdP-SESComplaintRate"
+  alarm_description   = "IdP SES Warning - complaint rate >=0.4% over the last 12 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Reputation.ComplaintRate"
+  namespace           = "AWS/SES"
+  period              = 60 * 60 * 12
+  statistic           = "Average"
+  threshold           = 0.4 / 100
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+}

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -4,7 +4,12 @@ variable "kms_key_cloudwatch_arn" {
 }
 
 variable "ecs_cloudwatch_log_group_name" {
-  description = "ECS Forms CloudWatch log group name, used by app error metric alarms"
+  description = "ECS App Forms CloudWatch log group name, used by app error metric alarms"
+  type        = string
+}
+
+variable "ecs_idp_cloudwatch_log_group_name" {
+  description = "ECS IdP CloudWatch log group name, used by IdP error metric alarms"
   type        = string
 }
 

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -93,8 +93,18 @@ variable "ecs_cluster_name" {
   type        = string
 }
 
+variable "ecs_idp_cluster_name" {
+  description = "IdP's ECS cluster name, used by CPU/memory threshold alarms"
+  type        = string
+}
+
 variable "ecs_service_name" {
   description = "ECS service name, used by CPU/memory threshold alarms"
+  type        = string
+}
+
+variable "ecs_idp_service_name" {
+  description = "IdP's ECS service name, used by CPU/memory threshold alarms"
   type        = string
 }
 
@@ -113,6 +123,11 @@ variable "lb_arn_suffix" {
   type        = string
 }
 
+variable "lb_idp_arn_suffix" {
+  description = "IdP's load balancer ARN suffix, used by response time alarms"
+  type        = string
+}
+
 variable "lb_target_group_1_arn_suffix" {
   description = "Load balancer target group 1 ARN suffix, used by response time alarms"
   type        = string
@@ -120,6 +135,11 @@ variable "lb_target_group_1_arn_suffix" {
 
 variable "lb_target_group_2_arn_suffix" {
   description = "Load balancer target group 2 ARN suffix, used by response time alarms"
+  type        = string
+}
+
+variable "lb_idp_target_group_arn_suffix" {
+  description = "IdP's load balancer target group ARN suffix, used by response time alarms"
   type        = string
 }
 
@@ -138,6 +158,17 @@ variable "opsgenie_api_key" {
 variable "rds_cluster_identifier" {
   description = "RDS cluster identifier used for alarms and dashboards"
   type        = string
+}
+
+variable "rds_idp_cluster_identifier" {
+  description = "The IdP's RDS cluster identifier used for alarms and dashboards"
+  type        = string
+}
+
+variable "rds_idp_cpu_maxiumum" {
+  description = "The maximum CPU utilization percentage threshold for the IdP's RDS cluster"
+  type        = number
+
 }
 
 variable "sqs_reliability_deadletter_queue_arn" {

--- a/aws/idp/outputs.tf
+++ b/aws/idp/outputs.tf
@@ -1,0 +1,29 @@
+output "ecs_idp_cluster_name" {
+  description = "IdP's ECS cluster name"
+  value       = module.idp_ecs.cluster_name
+}
+
+output "ecs_idp_cloudwatch_log_group_name" {
+  description = "IdP's ECS CloudWatch log group name"
+  value       = module.idp_ecs.cloudwatch_log_group_name
+}
+
+output "ecs_idp_service_name" {
+  description = "IdP's ECS service name"
+  value       = module.idp_ecs.service_name
+}
+
+output "lb_idp_arn_suffix" {
+  description = "IdP's load balancer ARN suffix"
+  value       = aws_lb.idp.arn_suffix
+}
+
+output "lb_idp_target_group_arn_suffix" {
+  description = "IdP's load balancer target group ARN suffix"
+  value       = aws_lb_target_group.idp.arn_suffix
+}
+
+output "rds_idp_cluster_identifier" {
+  description = "IdP's RDS cluster identifier"
+  value       = module.idp_database.rds_cluster_id
+}

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../hosted_zone", "../kms", "../load_balancer", "../rds", "../sqs", "../app", "../sns", "../lambdas", "../ecr"]
+  paths = ["../hosted_zone", "../kms", "../load_balancer", "../rds", "../sqs", "../app", "../sns", "../lambdas", "../ecr", "../idp"]
 }
 
 locals {
@@ -121,6 +121,20 @@ dependency "ecr" {
   }
 }
 
+dependency "idp" {
+  config_path                             = "../idp"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    ecs_idp_cluster_name              = "idp"
+    ecs_idp_cloudwatch_log_group_name = "/aws/ecs/idp/zitadel"
+    ecs_idp_service_name              = "zitadel"
+    lb_idp_arn_suffix                 = "loadbalancer/app/idp/1234567890123456"
+    lb_idp_target_group_arn_suffix    = "targetgroup/idp-tg-abc/1234567890123456"
+    rds_idp_cluster_identifier        = "idp-cluster"
+  }
+}
+
 inputs = {
   threshold_ecs_cpu_utilization_high    = "50"
   threshold_ecs_memory_utilization_high = "50"
@@ -168,6 +182,14 @@ inputs = {
   sns_topic_alert_ok_us_east_arn      = dependency.sns.outputs.sns_topic_alert_ok_us_east_arn
 
   ecr_repository_url_notify_slack_lambda = dependency.ecr.outputs.ecr_repository_url_notify_slack_lambda
+
+  ecs_idp_cluster_name              = dependency.idp.outputs.ecs_idp_cluster_name
+  ecs_idp_cloudwatch_log_group_name = dependency.idp.outputs.ecs_idp_cloudwatch_log_group_name
+  ecs_idp_service_name              = dependency.idp.outputs.ecs_idp_service_name
+  lb_idp_arn_suffix                 = dependency.idp.outputs.lb_idp_arn_suffix
+  lb_idp_target_group_arn_suffix    = dependency.idp.outputs.lb_idp_target_group_arn_suffix
+  rds_idp_cluster_identifier        = dependency.idp.outputs.rds_idp_cluster_identifier
+  rds_idp_cpu_maxiumum              = 80
 }
 
 include {


### PR DESCRIPTION
# Summary
Add alarms for the IdP that trigger for:

- High resource use in the ECS and RDS clusters.
- Load balancer unhealthy hosts or slow responses.
- Errors logged by the IdP.
- SES bounce and complain rates.

Also removes the Submission lambda anomaly detection alarm as this will not meet our needs.  The predicted invocations is not accurate enough and would only result in a noisy alarm.

# Related
- cds-snc/platform-forms-client#3954