### PR TITLE
feat: Enable Amazon Athena to communicate with DynamoDB

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -39,7 +39,31 @@ module "athena_bucket" {
 #
 
 resource "aws_s3_bucket" "athena_spill_bucket" {
+  # checkov:skip=CKV2_AWS_62: Event notifications not required
+  # checkov:skip=CKV_AWS_18: Access logging not required
+  # checkov:skip=CKV_AWS_21: Versioning not required
   bucket = "gc-forms-${var.env}-athena-spill-bucket"
+}
+
+resource "aws_s3_bucket_ownership_controls" "athena_spill_bucket" {
+  bucket = aws_s3_bucket.athena_spill_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "athena_spill_bucket" {
+  bucket = aws_s3_bucket.athena_spill_bucket.id
+
+  rule {
+    id     = "Clear spill bucket after 1 day"
+    status = "Enabled"
+
+    expiration {
+      days = 1
+    }
+  }
 }
 
 #

--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -33,3 +33,42 @@ module "athena_bucket" {
     },
   ]
 }
+
+#
+# Enable Athena Federated Query
+#
+
+resource "aws_s3_bucket" "athena_spill_bucket" {
+  bucket = "gc-forms-${var.env}-athena-spill-bucket"
+}
+
+#
+# Enables Amazon Athena to communicate with DynamoDB
+#
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "dynamodb_connector" {
+  name           = "dynamodb-connector"
+  application_id = "arn:aws:serverlessrepo:us-east-1:292517598671:applications/AthenaDynamoDBConnector"
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_RESOURCE_POLICY",
+  ]
+  parameters = {
+    AthenaCatalogName = "dynamodb-lambda-connector"
+    SpillBucket       = aws_s3_bucket.athena_spill_bucket.id
+  }
+}
+
+data "aws_lambda_function" "existing" {
+  function_name = "dynamodb-lambda-connector"
+  depends_on    = [aws_serverlessapplicationrepository_cloudformation_stack.dynamodb_connector]
+}
+
+resource "aws_athena_data_catalog" "dynamodb_data_catalog" {
+  name        = "dynamodb-data-catalog"
+  description = "Athena dynamodb data catalog"
+  type        = "LAMBDA"
+
+  parameters = {
+    "function" = data.aws_lambda_function.existing.arn
+  }
+}

--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -63,8 +63,8 @@ data "aws_lambda_function" "existing" {
   depends_on    = [aws_serverlessapplicationrepository_cloudformation_stack.dynamodb_connector]
 }
 
-resource "aws_athena_data_catalog" "dynamodb_data_catalog" {
-  name        = "dynamodb-data-catalog"
+resource "aws_athena_data_catalog" "dynamodb" {
+  name        = "dynamodb"
   description = "Athena dynamodb data catalog"
   type        = "LAMBDA"
 

--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -45,15 +45,16 @@ resource "aws_s3_bucket" "athena_spill_bucket" {
   bucket = "gc-forms-${var.env}-athena-spill-bucket"
 }
 
-resource "aws_s3_bucket_ownership_controls" "athena_spill_bucket" {
-  bucket = aws_s3_bucket.athena_spill_bucket.id
-
-  rule {
-    object_ownership = "BucketOwnerEnforced"
-  }
+resource "aws_s3_bucket_public_access_block" "athena_spill_bucket" {
+  bucket                  = aws_s3_bucket.athena_spill_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena_spill_bucket" {
+  # checkov:skip=CKV_AWS_300: Lifecycle configuration for aborting failed (multipart) upload not required
   bucket = aws_s3_bucket.athena_spill_bucket.id
 
   rule {


### PR DESCRIPTION
# Summary | Résumé

Amazon Athena federated queries allow us to run SQL queries across data stored in various data sources without the need to move the data. This PR enables the integration between Athena and DynamoDB.

e.g. 
```select * from dynamodb.default.vault```


