### PR TITLE
Fix: Updates global indexes to only project needed keys

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -69,14 +69,16 @@ resource "aws_dynamodb_table" "vault" {
     name            = "Archive"
     hash_key        = "Status"
     range_key       = "RemovalDate"
-    projection_type = "ALL"
+    projection_type = "INCLUDE"
+    non_key_attributes = ["FormID,Name,SubmissionID,FormSubmission,CreatedAt,ConfirmationCode"]
   }
 
   global_secondary_index {
     name            = "Nagware"
     hash_key        = "Status"
     range_key       = "CreatedAt"
-    projection_type = "ALL"
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["FormID"]
   }
 
   server_side_encryption {

--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -66,17 +66,17 @@ resource "aws_dynamodb_table" "vault" {
   }
 
   global_secondary_index {
-    name            = "Archive"
-    hash_key        = "Status"
-    range_key       = "RemovalDate"
-    projection_type = "INCLUDE"
+    name               = "Archive"
+    hash_key           = "Status"
+    range_key          = "RemovalDate"
+    projection_type    = "INCLUDE"
     non_key_attributes = ["FormID,Name,SubmissionID,FormSubmission,CreatedAt,ConfirmationCode"]
   }
 
   global_secondary_index {
-    name            = "Nagware"
-    hash_key        = "Status"
-    range_key       = "CreatedAt"
+    name               = "Nagware"
+    hash_key           = "Status"
+    range_key          = "CreatedAt"
     projection_type    = "INCLUDE"
     non_key_attributes = ["FormID"]
   }


### PR DESCRIPTION
# Summary | Résumé

Ensures that only required keys are projected into the global index for the Vault.
This will help reduce the volume of write requests when downloading and confirming responses.

