### PR TITLE
fix: Change the Archive Index key projection back to All

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -66,11 +66,10 @@ resource "aws_dynamodb_table" "vault" {
   }
 
   global_secondary_index {
-    name               = "Archive"
-    hash_key           = "Status"
-    range_key          = "RemovalDate"
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["FormID,Name,SubmissionID,FormSubmission,CreatedAt,ConfirmationCode"]
+    name            = "Archive"
+    hash_key        = "Status"
+    range_key       = "RemovalDate"
+    projection_type = "ALL"
   }
 
   global_secondary_index {


### PR DESCRIPTION
# Summary | Résumé
Modifies the Archive Global Index to project 'All' attributes instead of only those required by the function.  This is due to a seemingly impossible way to project a key that uses a reserved word.

This is also temporary as step 2 is to modify the Lambda functions to not use the indexes.