### PR TITLE
fix: response archiver lambda will ignore confirmation code entries in the DynamoDB Vault table when scanning for items

### DIFF
--- a/lambda-code/response-archiver/main.ts
+++ b/lambda-code/response-archiver/main.ts
@@ -133,12 +133,14 @@ async function retrieveArchivableResponses(
         TableName: DYNAMODB_VAULT_TABLE_NAME,
         Limit: PROCESSING_CHUNK_SIZE,
         ExclusiveStartKey: lastEvaluatedKey,
-        FilterExpression: "attribute_exists(RemovalDate) AND RemovalDate <= :removalDate",
+        FilterExpression:
+          "begins_with(NAME_OR_CONF, :nameOrConfPrefix) AND RemovalDate <= :removalDate",
         ProjectionExpression: "FormID,#name,SubmissionID,FormSubmission,CreatedAt,ConfirmationCode",
         ExpressionAttributeNames: {
           "#name": "Name",
         },
         ExpressionAttributeValues: {
+          ":nameOrConfPrefix": "NAME#",
           ":removalDate": Date.now(),
         },
       })


### PR DESCRIPTION
# Summary | Résumé

- Fixed issue in response archiver lambda function. The scan operation should ignore confirmation code entries in the DynamoDB Vault table.