### PR TITLE
fix: block invalid `host` requests to the IdP

### DIFF
--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -8,6 +8,45 @@ resource "aws_wafv2_web_acl" "idp" {
   }
 
   rule {
+    name     = "InvalidHost"
+    priority = 5
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "host"
+              }
+            }
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "EXACTLY"
+            search_string         = var.domain_idp
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "InvalidHost"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "AWSManagedRulesAmazonIpReputationList"
     priority = 10
 


### PR DESCRIPTION
# Summary
Update the IdP's WAF ACL to block all requests that do not have the expected `host` header.

This header value is used by Zitadel to lookup an instance that can process a given request.  If the value is incorrect, the lookup fails:
![image](https://github.com/user-attachments/assets/5dba966b-6142-4b2f-9369-b719e3b27588)

Request like the above can occur during fuzzing attacks when a script is checking to see if it can bypass controls by using the IP address directly.

## :warning: Note
This was applied locally to test.