### PR TITLE
feat: add API ECS service to the Forms cluster

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -24,6 +24,8 @@ env:
   TERRAFORM_VERSION: 1.9.2
   TERRAGRUNT_VERSION: 0.63.2
   TF_INPUT: false
+  # API
+  FF_API: true
   # App
   TF_VAR_ecs_secret_token: ${{ secrets.STAGING_TOKEN_SECRET }}
   TF_VAR_recaptcha_secret: ${{ secrets.STAGING_RECAPTCHA_SITE_SECRET }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -17,6 +17,8 @@ env:
   TERRAFORM_VERSION: 1.9.2
   TERRAGRUNT_VERSION: 0.63.2
   TF_INPUT: false
+  # API
+  FF_API: true
   # App
   TF_VAR_ecs_secret_token: ${{ secrets.STAGING_TOKEN_SECRET }}
   TF_VAR_recaptcha_secret: ${{ secrets.STAGING_RECAPTCHA_SITE_SECRET }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -26,6 +26,8 @@ env:
   TERRAFORM_VERSION: 1.9.2
   TERRAGRUNT_VERSION: 0.63.2
   TF_INPUT: false
+  # API
+  FF_API: true
   # App
   TF_VAR_ecs_secret_token: ${{ secrets.STAGING_TOKEN_SECRET }}
   TF_VAR_recaptcha_secret: ${{ secrets.STAGING_RECAPTCHA_SITE_SECRET }}

--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -1,0 +1,97 @@
+locals {
+  container_env     = [] # TODO: app api environment variables
+  container_secrets = [] # TODO: app api environment variables
+}
+
+module "api_ecs" {
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=50c0f631d2c8558e6eec44138ffc2e963a1dfa9a" # v9.6.0
+
+  create_cluster = false
+  cluster_name   = var.ecs_cluster_name
+  service_name   = "forms-api"
+  task_cpu       = 1024
+  task_memory    = 2048
+
+  # Scaling
+  enable_autoscaling       = true
+  desired_count            = 1
+  autoscaling_min_capacity = 1
+  autoscaling_max_capacity = 3
+
+  # Task definition
+  container_image       = "${var.api_image_ecr_url}:${var.api_image_tag}"
+  container_host_port   = 3000
+  container_port        = 3000
+  container_environment = local.container_env
+  container_secrets     = local.container_secrets
+
+  task_exec_role_policy_documents = [
+    data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,
+    data.aws_iam_policy_document.api_ecs_kms_vault.json,
+    data.aws_iam_policy_document.api_ecs_s3_vault.json,
+  ]
+
+  # Networking
+  lb_target_group_arn = var.lb_target_group_arn_api_ecs
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = [var.security_group_id_api_ecs]
+
+  billing_tag_key   = var.billing_tag_key
+  billing_tag_value = var.billing_tag_value
+}
+
+#
+# IAM policies
+#
+data "aws_iam_policy_document" "api_ecs_dynamodb_vault" {
+  statement {
+    sid    = "DynamoDBVault"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:Query",
+    ]
+
+    resources = [
+      var.dynamodb_vault_arn,
+      "${var.dynamodb_vault_arn}/index/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "api_ecs_kms_vault" {
+  statement {
+    sid    = "KMSVault"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Encrypt",
+      "kms:Decrypt"
+    ]
+    resources = [
+      var.kms_key_dynamodb_arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "api_ecs_s3_vault" {
+  statement {
+    sid    = "S3Vault"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging"
+    ]
+    resources = [
+      var.s3_vault_file_storage_arn,
+      "${var.s3_vault_file_storage_arn}/*"
+    ]
+  }
+}

--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -1,6 +1,6 @@
 locals {
   container_env     = [] # TODO: app api environment variables
-  container_secrets = [] # TODO: app api environment variables
+  container_secrets = [] # TODO: app api secrets
 }
 
 module "api_ecs" {

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -1,0 +1,44 @@
+variable "api_image_ecr_url" {
+  description = "URL of the ECR repository for the API image"
+  type        = string
+}
+
+variable "api_image_tag" {
+  description = "Tag of the API image in the ECR repository"
+  type        = string
+}
+
+variable "dynamodb_vault_arn" {
+  description = "ARN of the DynamoDB Vault table"
+  type        = string
+}
+
+variable "ecs_cluster_name" {
+  description = "ARN of the ECS cluster for the API"
+  type        = string
+}
+
+variable "kms_key_dynamodb_arn" {
+  description = "ARN of the KMS key used for encrypting the DynamoDB Vault table"
+  type        = string
+}
+
+variable "lb_target_group_arn_api_ecs" {
+  description = "ARN of the load balancer target group for the API ECS service"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for the ECS service"
+  type        = string
+}
+
+variable "s3_vault_file_storage_arn" {
+  description = "ARN of the S3 bucket used for the Vault's file storage"
+  type        = string
+}
+
+variable "security_group_id_api_ecs" {
+  description = "ID of the security group for the API ECS service"
+  type        = string
+}

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -87,3 +87,21 @@ resource "aws_ecr_lifecycle_policy" "idp" {
   repository = aws_ecr_repository.idp[0].name
   policy     = file("${path.module}/policy/lifecycle.json")
 }
+
+resource "aws_ecr_repository" "api" {
+  count = var.feature_flag_api ? 1 : 0
+
+  name                 = "forms/api"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  count = var.feature_flag_api ? 1 : 0
+
+  repository = aws_ecr_repository.api[0].name
+  policy     = file("${path.module}/policy/lifecycle.json")
+}

--- a/aws/ecr/outputs.tf
+++ b/aws/ecr/outputs.tf
@@ -72,3 +72,8 @@ output "ecr_repository_url_idp" {
   description = "URL of the Zitadel IdP's ECR"
   value       = var.feature_flag_idp ? aws_ecr_repository.idp[0].repository_url : ""
 }
+
+output "ecr_repository_url_api" {
+  description = "URL of the Forms API's ECR"
+  value       = var.feature_flag_api ? aws_ecr_repository.api[0].repository_url : ""
+}

--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -3,6 +3,11 @@ output "alb_security_group_id" {
   value       = aws_security_group.forms_load_balancer.id
 }
 
+output "api_ecs_security_group_id" {
+  description = "API ECS task security group ID"
+  value       = var.feature_flag_api ? aws_security_group.api_ecs[0].id : ""
+}
+
 output "ecs_security_group_id" {
   description = "ECS task security group ID"
   value       = aws_security_group.forms.id

--- a/aws/network/security_groups_api.tf
+++ b/aws/network/security_groups_api.tf
@@ -1,0 +1,82 @@
+# ECS
+resource "aws_security_group" "api_ecs" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description = "API ECS Tasks"
+  name        = "api_ecs"
+  vpc_id      = aws_vpc.forms.id
+}
+
+resource "aws_security_group_rule" "api_ecs_egress_internet" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description       = "Egress from API ECS task to internet (HTTPS)"
+  type              = "egress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.api_ecs[0].id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "api_ecs_egress_privatelink" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Egress from API ECS task to PrivateLink endpoints"
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.api_ecs[0].id
+  source_security_group_id = aws_security_group.privatelink.id
+}
+
+# Load balancer
+resource "aws_security_group_rule" "api_ecs_ingress_lb" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Ingress from load balancer to API ECS task"
+  type                     = "ingress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.api_ecs[0].id
+  source_security_group_id = aws_security_group.forms_load_balancer.id
+}
+
+resource "aws_security_group_rule" "lb_egress_api_ecs" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Egress from load balancer to API ECS task"
+  type                     = "egress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.forms_load_balancer.id
+  source_security_group_id = aws_security_group.api_ecs[0].id
+}
+
+# Database
+resource "aws_security_group_rule" "db_ingress_api_ecs" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Ingress to database from API ECS task"
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.forms_database.id
+  source_security_group_id = aws_security_group.api_ecs[0].id
+}
+
+resource "aws_security_group_rule" "api_ecs_egress_db" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Egress from API ECS task to database"
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.api_ecs[0].id
+  source_security_group_id = aws_security_group.forms_database.id
+}

--- a/aws/network/security_groups_app.tf
+++ b/aws/network/security_groups_app.tf
@@ -136,6 +136,18 @@ resource "aws_security_group_rule" "privatelink_idp_db_ingress" {
   source_security_group_id = aws_security_group.idp_db[0].id
 }
 
+resource "aws_security_group_rule" "privatelink_api_ecs_ingress" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Security group rule for API ECS task ingress"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.privatelink.id
+  source_security_group_id = aws_security_group.api_ecs[0].id
+}
+
 # Allow traffic from the app and from the lambdas
 resource "aws_security_group" "forms_database" {
   name        = "forms-database"

--- a/env/common/common_variables.tf
+++ b/env/common/common_variables.tf
@@ -33,6 +33,12 @@ variable "env" {
   type        = string
 }
 
+variable "feature_flag_api" {
+  description = "Feature flag that determines if the API infrastructure is deployed"
+  type        = bool
+  default     = false
+}
+
 variable "feature_flag_idp" {
   description = "Feature flag that determines if the IdP infrastructure is deployed"
   type        = bool

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -1,6 +1,7 @@
 locals {
   account_id       = get_env("AWS_ACCOUNT_ID", "")
   env              = get_env("APP_ENV", "local")
+  feature_flag_api = get_env("FF_API", "false")
   feature_flag_idp = get_env("FF_IDP", "false")
   domain_idp       = get_env("IDP_DOMAIN", "localhost:8080")
   domains          = get_env("APP_DOMAINS", "[\"localhost:3000\"]")
@@ -13,6 +14,7 @@ inputs = {
   domain_idp                = local.domain_idp   
   domains                   = local.domains
   env                       = "${local.env}"
+  feature_flag_api          = local.feature_flag_api
   feature_flag_idp          = local.feature_flag_idp
   region                    = "ca-central-1"
   cbs_satellite_bucket_name = "cbs-satellite-${local.account_id}"


### PR DESCRIPTION
# Summary
Add an API ECS service to the Forms cluster.  This also includes a new ECR to hold the API's Docker image.

As with the IdP, a feature flag has been added to control the creation of API infrastructure.  This will give us fine-grained control over when resources are created in each environment.

## ⚠️  Note
This PR will only create the ECR and API security group as the Terraform plan/apply workflows have not been updated yet to create the new API ECS service.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946