### PR TITLE
feat: add API load balancer target group

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   APP_ENV: staging
   APP_DOMAINS: ${{ vars.STAGING_APP_DOMAINS }}
+  API_DOMAIN: ${{ vars.STAGING_API_DOMAIN }}
   IDP_DOMAIN: ${{ vars.STAGING_IDP_DOMAIN }}
   AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -10,6 +10,7 @@ permissions:
 env:
   APP_ENV: staging
   APP_DOMAINS: ${{ vars.STAGING_APP_DOMAINS }}
+  API_DOMAIN: ${{ vars.STAGING_API_DOMAIN }}
   IDP_DOMAIN: ${{ vars.STAGING_IDP_DOMAIN }}
   AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   APP_ENV: staging
   APP_DOMAINS: ${{ vars.STAGING_APP_DOMAINS }}
+  API_DOMAIN: ${{ vars.STAGING_API_DOMAIN }}
   IDP_DOMAIN: ${{ vars.STAGING_IDP_DOMAIN }}
   AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1

--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -20,8 +20,8 @@ module "api_ecs" {
 
   # Task definition
   container_image       = "${var.api_image_ecr_url}:${var.api_image_tag}"
-  container_host_port   = 3000
-  container_port        = 3000
+  container_host_port   = 3001
+  container_port        = 3001
   container_environment = local.container_env
   container_secrets     = local.container_secrets
 

--- a/aws/load_balancer/certificates.tf
+++ b/aws/load_balancer/certificates.tf
@@ -3,31 +3,25 @@
 #
 
 resource "aws_acm_certificate" "form_viewer" {
-  # First entry in domain list is the primary domain
-  domain_name               = var.domains[0]
+  domain_name               = local.app_primary_domain
   validation_method         = "DNS"
-  subject_alternative_names = length(var.domains) > 1 ? setsubtract(var.domains, [var.domains[0]]) : []
+  subject_alternative_names = local.cert_subject_alternative_names
 
   lifecycle {
     create_before_destroy = true
   }
-
-
 }
 
 resource "aws_acm_certificate" "form_viewer_maintenance_mode" {
-  # First entry in domain list is the primary domain
-  domain_name               = var.domains[0]
+  domain_name               = local.app_primary_domain
   validation_method         = "DNS"
-  subject_alternative_names = length(var.domains) > 1 ? setsubtract(var.domains, [var.domains[0]]) : []
+  subject_alternative_names = local.cert_subject_alternative_names
 
   provider = aws.us-east-1
 
   lifecycle {
     create_before_destroy = true
   }
-
-
 }
 
 resource "aws_acm_certificate_validation" "form_viewer_maintenance_mode_cloudfront_certificate" {

--- a/aws/load_balancer/certificates.tf
+++ b/aws/load_balancer/certificates.tf
@@ -3,9 +3,10 @@
 #
 
 resource "aws_acm_certificate" "form_viewer" {
-  domain_name               = local.app_primary_domain
+  # First entry in domain list is the primary domain
+  domain_name               = var.domains[0]
   validation_method         = "DNS"
-  subject_alternative_names = local.cert_subject_alternative_names
+  subject_alternative_names = length(var.domains) > 1 ? setsubtract(var.domains, [var.domains[0]]) : []
 
   lifecycle {
     create_before_destroy = true
@@ -13,11 +14,23 @@ resource "aws_acm_certificate" "form_viewer" {
 }
 
 resource "aws_acm_certificate" "form_viewer_maintenance_mode" {
-  domain_name               = local.app_primary_domain
+  # First entry in domain list is the primary domain
+  domain_name               = var.domains[0]
   validation_method         = "DNS"
-  subject_alternative_names = local.cert_subject_alternative_names
+  subject_alternative_names = length(var.domains) > 1 ? setsubtract(var.domains, [var.domains[0]]) : []
 
   provider = aws.us-east-1
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "form_api" {
+  count = var.feature_flag_api ? 1 : 0
+
+  domain_name       = var.domain_api
+  validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -120,6 +120,13 @@ resource "aws_lb_listener" "form_viewer_https" {
   }
 }
 
+resource "aws_lb_listener_certificate" "form_api_https" {
+  count = var.feature_flag_api ? 1 : 0
+
+  listener_arn    = aws_lb_listener.form_viewer_https.arn
+  certificate_arn = aws_acm_certificate.form_api[0].arn
+}
+
 resource "aws_lb_listener" "form_viewer_http" {
   load_balancer_arn = aws_lb.form_viewer.arn
   port              = "80"

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -149,9 +149,20 @@ resource "aws_alb_listener_rule" "form_api" {
   priority     = 100
 
   action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.form_api.arn
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "HEALTHY"
+      status_code  = "200"
+    }
   }
+
+  # TODO: replace fixed response with forward action once API is running
+  # action {
+  #   type             = "forward"
+  #   target_group_arn = aws_lb_target_group.form_api.arn
+  # }
 
   condition {
     host_header {

--- a/aws/load_balancer/locals.tf
+++ b/aws/load_balancer/locals.tf
@@ -1,3 +1,7 @@
 locals {
+  all_domains                    = var.feature_flag_api ? concat(var.domains, [var.domain_api]) : var.domains
+  app_primary_domain             = var.domains[0]
+  cert_subject_alternative_names = setsubtract(local.all_domains, [local.app_primary_domain])
+
   cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
 }

--- a/aws/load_balancer/locals.tf
+++ b/aws/load_balancer/locals.tf
@@ -1,7 +1,4 @@
 locals {
-  all_domains                    = var.feature_flag_api ? concat(var.domains, [var.domain_api]) : var.domains
-  app_primary_domain             = var.domains[0]
-  cert_subject_alternative_names = setsubtract(local.all_domains, [local.app_primary_domain])
-
+  all_domains              = var.feature_flag_api ? concat(var.domains, [var.domain_api]) : var.domains
   cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
 }

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -40,12 +40,12 @@ output "lb_target_group_2_name" {
 
 output "lb_target_group_api_arn" {
   description = "Load balancer target group ARN for the API"
-  value       = var.feature_flag_api ? aws_lb_target_group.form_api.arn : ""
+  value       = var.feature_flag_api ? aws_lb_target_group.form_api[0].arn : ""
 }
 
 output "lb_target_group_api_arn_suffix" {
   description = "Load balancer target group ARN suffix for the API"
-  value       = var.feature_flag_api ? aws_lb_target_group.form_api.arn_suffix : ""
+  value       = var.feature_flag_api ? aws_lb_target_group.form_api[0].arn_suffix : ""
 }
 
 output "kinesis_firehose_waf_logs_arn" {

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -38,6 +38,16 @@ output "lb_target_group_2_name" {
   value       = aws_lb_target_group.form_viewer_2.name
 }
 
+output "lb_target_group_api_arn" {
+  description = "Load balancer target group ARN for the API"
+  value       = var.feature_flag_api ? aws_lb_target_group.form_api.arn : ""
+}
+
+output "lb_target_group_api_arn_suffix" {
+  description = "Load balancer target group ARN suffix for the API"
+  value       = var.feature_flag_api ? aws_lb_target_group.form_api.arn_suffix : ""
+}
+
 output "kinesis_firehose_waf_logs_arn" {
   description = "Kinesis Firehose delivery stream ARN used to collect and write WAF ACL logs to an S3 bucket."
   value       = var.feature_flag_idp ? aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn : ""

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -103,3 +103,21 @@ resource "aws_route53_record" "form_viewer_maintenance_mode_certificate_validati
   type            = each.value.type
   zone_id         = local.domain_name_to_zone_id[each.value.domain]
 }
+
+resource "aws_route53_record" "form_api_certificate_validation" {
+  for_each = var.feature_flag_api ? {
+    for dvo in aws_acm_certificate.form_api[0].domain_validation_options : dvo.domain_name => {
+      domain = dvo.domain_name
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.hosted_zone_ids[0]
+}

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -41,6 +41,20 @@ resource "aws_route53_record" "form_viewer_maintenance" {
   set_identifier = "form_viewer_${var.domains[count.index]}_secondary"
 }
 
+resource "aws_route53_record" "form_api" {
+  count = var.feature_flag_api ? 1 : 0
+
+  zone_id = var.hosted_zone_ids[0]
+  name    = var.domain_api
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.form_viewer.dns_name
+    zone_id                = aws_lb.form_viewer.zone_id
+    evaluate_target_health = true
+  }
+}
+
 #
 # Certificate validation
 # 

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -405,7 +405,7 @@ resource "aws_wafv2_regex_pattern_set" "forms_base_url" {
   description = "Regex matching the root domain of GCForms"
   scope       = "REGIONAL"
   dynamic "regular_expression" {
-    for_each = var.domains
+    for_each = local.all_domains
     content {
       regex_string = "^${regular_expression.value}$"
     }

--- a/aws/network/security_groups_api.tf
+++ b/aws/network/security_groups_api.tf
@@ -37,8 +37,8 @@ resource "aws_security_group_rule" "api_ecs_ingress_lb" {
 
   description              = "Ingress from load balancer to API ECS task"
   type                     = "ingress"
-  from_port                = 3000
-  to_port                  = 3000
+  from_port                = 3001
+  to_port                  = 3001
   protocol                 = "tcp"
   security_group_id        = aws_security_group.api_ecs[0].id
   source_security_group_id = aws_security_group.forms_load_balancer.id
@@ -49,8 +49,8 @@ resource "aws_security_group_rule" "lb_egress_api_ecs" {
 
   description              = "Egress from load balancer to API ECS task"
   type                     = "egress"
-  from_port                = 3000
-  to_port                  = 3000
+  from_port                = 3001
+  to_port                  = 3001
   protocol                 = "tcp"
   security_group_id        = aws_security_group.forms_load_balancer.id
   source_security_group_id = aws_security_group.api_ecs[0].id

--- a/env/common/common_variables.tf
+++ b/env/common/common_variables.tf
@@ -18,6 +18,11 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "domain_api" {
+  description = "The API's domain"
+  type        = string
+}
+
 variable "domain_idp" {
   description = "The identity provider domain"
   type        = string

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -5,7 +5,7 @@ locals {
   feature_flag_idp = get_env("FF_IDP", "false")
   domain_api       = get_env("API_DOMAIN", "localhost:3001") 
   domain_idp       = get_env("IDP_DOMAIN", "localhost:8080")
-  domains          = get_env("APP_DOMAINS", "[\"localhost:3000\",\"localhost:3001\"]")
+  domains          = get_env("APP_DOMAINS", "[\"localhost:3000\"]")
 }
 
 inputs = {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -3,14 +3,16 @@ locals {
   env              = get_env("APP_ENV", "local")
   feature_flag_api = get_env("FF_API", "false")
   feature_flag_idp = get_env("FF_IDP", "false")
+  domain_api       = get_env("API_DOMAIN", "localhost:3001") 
   domain_idp       = get_env("IDP_DOMAIN", "localhost:8080")
-  domains          = get_env("APP_DOMAINS", "[\"localhost:3000\"]")
+  domains          = get_env("APP_DOMAINS", "[\"localhost:3000\",\"localhost:3001\"]")
 }
 
 inputs = {
   account_id                = "${local.account_id}"
   billing_tag_key           = "CostCentre"
   billing_tag_value         = "forms-platform-${local.env}"
+  domain_api                = local.domain_api  
   domain_idp                = local.domain_idp   
   domains                   = local.domains
   env                       = "${local.env}"


### PR DESCRIPTION
# Summary
- Add a load balancer target group and listener rule to route traffic to the API. 
- Add a dedicated certificate for API requests.
- Update the API's port to 3001.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946