### PR TITLE
chore: upgrade to latest Terraform AWS provider

### DIFF
--- a/env/cloud/dynamodb/.terraform.lock.hcl
+++ b/env/cloud/dynamodb/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/ecr/.terraform.lock.hcl
+++ b/env/cloud/ecr/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/kms/.terraform.lock.hcl
+++ b/env/cloud/kms/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/lambdas/.terraform.lock.hcl
+++ b/env/cloud/lambdas/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/network/.terraform.lock.hcl
+++ b/env/cloud/network/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/rds/.terraform.lock.hcl
+++ b/env/cloud/rds/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/redis/.terraform.lock.hcl
+++ b/env/cloud/redis/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/s3/.terraform.lock.hcl
+++ b/env/cloud/s3/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/secrets/.terraform.lock.hcl
+++ b/env/cloud/secrets/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/sns/.terraform.lock.hcl
+++ b/env/cloud/sns/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/cloud/sqs/.terraform.lock.hcl
+++ b/env/cloud/sqs/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.0"
-  constraints = "5.32.0"
+  version     = "5.59.0"
+  constraints = "5.59.0"
   hashes = [
-    "h1:qSmmUkarI43k7bQ1+Wh8ubx6lNzISXDVONr/sv+Gi3g=",
-    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
-    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
-    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
-    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
-    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
-    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
-    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
-    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
+    "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
+    "zh:130b112c85b67413bc65e95e5927188d8e41b45abd75350690b93d95771a587c",
+    "zh:16e97f1af67a5d4c6bf4f2df824a6a332b446be4516dd85a2e097317c959a174",
+    "zh:1cd7b0946eaf0fb11090710e9c774d22d90de0ca4516485253be96e332ebaf73",
+    "zh:2591d8a269014fb59111793cb8a175aafa12e370cd856fe2522577efbb72e5be",
+    "zh:3db5387ecc7da4e6a55a34877ea426ae87d10238bdbdf284a52e16b4be83302c",
+    "zh:78169400a85912d7f05fe99d4f3ba9a56871411442bdc133083dd657b18fae4e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
-    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
-    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
-    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
-    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
-    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
+    "zh:ad93fedbf1d2694faab6d793c6697ff5732449cdebacaa49acf6452c0c8e2ea0",
+    "zh:b8a2884858dde9d204dc6855903e3078a1c402485ae85b41c28e667f99a2a777",
+    "zh:bd3d4bd51172d08c0df277673a25fb3f0818ef47ef9f491b0c41e880b1dedce3",
+    "zh:d8e132bcafee2e69e21173fac409e4b99d8c81d60a7d25c58c379c67067dbf36",
+    "zh:eee5113ff29a42c5a75c83e9853e99a9b5c0ed066e36d6fe251083b19d38c7eb",
+    "zh:f0d8bcdb01d0fa0c9ed2ca8c198d4f11aabfd9d42fa239286b65ddcc6f606dfd",
+    "zh:f8ae46d14ec54c275e20f71d052f1b6af0cf948819b0667016045a6244edf292",
   ]
 }
 
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/env/common/local-provider.tf
+++ b/env/common/local-provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.32.0"
+      version = "5.59.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/env/common/provider.tf
+++ b/env/common/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.32.0"
+      version = "5.59.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Summary
Upgrade to the AWS 5.59.0 provider version.
