### PR TITLE
fix: convert LB security rules to standalone

### DIFF
--- a/aws/network/security_groups_app.tf
+++ b/aws/network/security_groups_app.tf
@@ -99,12 +99,12 @@ import {
 
 import {
   to = aws_security_group_rule.forms_lb_ingress_internet_80
-  id = "${aws_security_group.forms_load_balancer.id}__ingress_tcp_80_80_0.0.0.0/0"
+  id = "${aws_security_group.forms_load_balancer.id}_ingress_tcp_80_80_0.0.0.0/0"
 }
 
 import {
   to = aws_security_group_rule.forms_lb_egress_vpc
-  id = "${aws_security_group.forms_load_balancer.id}__egress_tcp_3000_3000_${var.vpc_cidr_block}"
+  id = "${aws_security_group.forms_load_balancer.id}_egress_tcp_3000_3000_${var.vpc_cidr_block}"
 }
 
 resource "aws_security_group" "forms_egress" {

--- a/aws/network/security_groups_app.tf
+++ b/aws/network/security_groups_app.tf
@@ -70,6 +70,7 @@ resource "aws_security_group_rule" "forms_lb_ingress_internet_443" {
 }
 
 resource "aws_security_group_rule" "forms_lb_ingress_internet_80" {
+  # checkov:skip=CKV_AWS_260: Ingress from 0.0.0.0:0 to port 80 is required by the load balancer to redirect users from HTTP to HTTPS
   description       = "Ingress to the Load Balancer from the internet on port 80"
   type              = "ingress"
   from_port         = 80


### PR DESCRIPTION
# Summary 
Update the Forms load balancer security group rules so that they are standalone rather than inline blocks.

This will make rule management more consistent and prevent the rules from flip-flopping through Terraform applies.

As part of this change, `import` blocks have been added to ensure there is no downtime.