### PR TITLE
fix: Athena-DynamoDB connector policy

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -134,13 +134,19 @@ resource "aws_iam_role_policy" "athena_dynamodb_policy" {
       {
         "Action" : [
           "dynamodb:DescribeTable",
-          "dynamodb:ListSchemas",
           "dynamodb:ListTables",
           "dynamodb:Query",
           "dynamodb:Scan",
           "dynamodb:PartiQLSelect"
         ],
-        "Resource" : "${var.dynamodb_audit_logs_arn}",
+        "Resource" : ["${var.dynamodb_audit_logs_arn}", "${lower(var.dynamodb_audit_logs_arn)}"]
+        "Effect" : "Allow"
+      },
+      {
+        "Action" : [
+          "dynamodb:ListTables",
+        ],
+        "Resource" : "*",
         "Effect" : "Allow"
       },
       {

--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -125,6 +125,7 @@ resource "aws_iam_role_policy" "athena_dynamodb_policy" {
           "glue:GetTable",
           "glue:GetPartition",
           "glue:GetDatabase",
+          "glue:ListSchemas",
           "athena:GetQueryExecution",
           "s3:ListAllMyBuckets"
         ],


### PR DESCRIPTION
The Athena-DynamoDB connector infers the DynamoDB schema and stores the metadata in lowercase (because it eventually works with Glue to sync the metadata if needed). However, the IAM role policy is case-sensitive, so we need to allow it to permit lowercase table names. This is one of the workarounds we found. (h/t @patheard )