### PR TITLE
fix: create API certificate validation resource

### DIFF
--- a/aws/load_balancer/certificates.tf
+++ b/aws/load_balancer/certificates.tf
@@ -43,3 +43,10 @@ resource "aws_acm_certificate_validation" "form_viewer_maintenance_mode_cloudfro
 
   provider = aws.us-east-1
 }
+
+resource "aws_acm_certificate_validation" "form_api" {
+  count = var.feature_flag_api ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.form_api[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.form_api_certificate_validation : record.fqdn]
+}

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -124,7 +124,7 @@ resource "aws_lb_listener_certificate" "form_api_https" {
   count = var.feature_flag_api ? 1 : 0
 
   listener_arn    = aws_lb_listener.form_viewer_https.arn
-  certificate_arn = aws_acm_certificate.form_api[0].arn
+  certificate_arn = aws_acm_certificate_validation.form_api[0].certificate_arn
 }
 
 resource "aws_lb_listener" "form_viewer_http" {


### PR DESCRIPTION
# Summary
Add a certification validation resource for the API so that the load balancer waits to add the new certificate until it is fully validated.

This will prevent timing failures when the API infrastructure is released to a new environment.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946