### PR TITLE
feat: deploy API ECS service in Staging

### DIFF
--- a/.github/module-filter.yml
+++ b/.github/module-filter.yml
@@ -7,6 +7,10 @@ alarms:
   - *common
   - "aws/alarms/**"
   - "env/cloud/alarms/**"
+api:
+  - *common
+  - "aws/api/**"
+  - "env/cloud/api/**"
 app:
   - *common
   - "aws/app/**"

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -226,6 +226,10 @@ jobs:
         working-directory: env/cloud/app
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Terragrunt apply api
+        working-directory: env/cloud/api
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Terragrunt apply lambdas
         working-directory: env/cloud/lambdas
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -188,6 +188,13 @@ jobs:
           comment: "false"
           terragrunt: "true"
 
+      - name: Terragrunt plan api
+        uses: cds-snc/terraform-plan@4719878d72d1b0078e0bce2e7571e854e79903b8 # v3.2.2
+        with:
+          directory: "env/cloud/api"
+          comment: "false"
+          terragrunt: "true"
+
       - name: Terragrunt plan lambdas
         uses: cds-snc/terraform-plan@4719878d72d1b0078e0bce2e7571e854e79903b8 # v3.2.2
         with:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -317,6 +317,16 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
+      - name: Terragrunt plan api
+        if: steps.filter.outputs.api == 'true'
+        uses: cds-snc/terraform-plan@4719878d72d1b0078e0bce2e7571e854e79903b8 # v3.2.2
+        with:
+          directory: "env/cloud/api"
+          comment-delete: "true"
+          comment-title: "Staging: api"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
       - name: Terragrunt plan lambdas
         if: steps.filter.outputs.lambdas == 'true'
         uses: cds-snc/terraform-plan@4719878d72d1b0078e0bce2e7571e854e79903b8 # v3.2.2

--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -1,6 +1,6 @@
 locals {
-  container_env     = [] # TODO: app api environment variables
-  container_secrets = [] # TODO: app api secrets
+  container_env     = [] # TODO: add api environment variables
+  container_secrets = [] # TODO: add api secrets
 }
 
 module "api_ecs" {

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -30,7 +30,7 @@ variable "lb_target_group_arn_api_ecs" {
 
 variable "private_subnet_ids" {
   description = "IDs of the private subnets for the ECS service"
-  type        = string
+  type        = list(string)
 }
 
 variable "s3_vault_file_storage_arn" {

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -156,20 +156,9 @@ resource "aws_alb_listener_rule" "form_api" {
   priority     = 100
 
   action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "HEALTHY"
-      status_code  = "200"
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.form_api[0].arn
   }
-
-  # TODO: replace fixed response with forward action once API is running
-  # action {
-  #   type             = "forward"
-  #   target_group_arn = aws_lb_target_group.form_api.arn
-  # }
 
   condition {
     host_header {

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -1,0 +1,91 @@
+terraform {
+  source = "../../../aws//api"
+}
+
+dependencies {
+  paths = ["../kms", "../network", "../dynamodb", "../load_balancer", "../ecr", "../s3", "../app"]
+}
+
+dependency "app" {
+  config_path = "../app"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    ecs_cluster_name = "Forms"
+  }
+}
+
+dependency "dynamodb" {
+  config_path = "../dynamodb"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    dynamodb_vault_arn = "arn:aws:dynamodb:ca-central-1:123456789012:table/Vault"
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    ecr_repository_url_api = "123456789012.dkr.ecr.ca-central-1.amazonaws.com/forms/api"
+  }
+}
+
+dependency "kms" {
+  config_path                             = "../kms"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_dynamodb_arn = "arn:aws:kms:ca-central-1:123456789012:key/12345678-796a-461b-9f69-b0e0c40f5d0a"
+  }
+}
+
+dependency "load_balancer" {
+  config_path                             = "../load_balancer"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    lb_target_group_api_arn = "arn:aws:elasticloadbalancing:ca-central-1:123456789012:targetgroup/form-api/1234567890abcdef"
+  }
+}
+
+dependency "network" {
+  config_path                             = "../network"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    api_ecs_security_group_id = "sg-1234567890"
+    private_subnet_ids        = ["prv-1", "prv-2"]
+  }
+}
+
+dependency "s3" {
+  config_path                             = "../s3"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    vault_file_storage_arn = "arn:aws:s3:::forms-mock-vault-file-storage"
+  }
+}
+
+inputs = {
+  api_image_tag = "latest"
+
+  api_image_ecr_url           = dependency.ecr.outputs.ecr_repository_url_api
+  dynamodb_vault_arn          = dependency.dynamodb.outputs.dynamodb_vault_arn
+  ecs_cluster_name            = dependency.app.outputs.ecs_cluster_name
+  kms_key_dynamodb_arn        = dependency.kms.outputs.kms_key_dynamodb_arn
+  lb_target_group_arn_api_ecs = dependency.load_balancer.outputs.lb_target_group_api_arn
+  private_subnet_ids          = dependency.network.outputs.private_subnet_ids
+  security_group_id_api_ecs   = dependency.network.outputs.api_ecs_security_group_id
+  s3_vault_file_storage_arn   = dependency.s3.outputs.vault_file_storage_arn
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Update the Staging Terraform workflows to create the API's ECS service in the Form's cluster.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946