### PR TITLE
fix: add API paths to WAF and fix healthcheck

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -8,7 +8,7 @@ module "api_ecs" {
 
   create_cluster = false
   cluster_name   = var.ecs_cluster_name
-  service_name   = "forms-api"
+  service_name   = "form-api"
   task_cpu       = 1024
   task_memory    = 2048
 
@@ -19,11 +19,12 @@ module "api_ecs" {
   autoscaling_max_capacity = 3
 
   # Task definition
-  container_image       = "${var.api_image_ecr_url}:${var.api_image_tag}"
-  container_host_port   = 3001
-  container_port        = 3001
-  container_environment = local.container_env
-  container_secrets     = local.container_secrets
+  container_image                     = "${var.api_image_ecr_url}:${var.api_image_tag}"
+  container_host_port                 = 3001
+  container_port                      = 3001
+  container_environment               = local.container_env
+  container_secrets                   = local.container_secrets
+  container_read_only_root_filesystem = false # TODO: mount tmp filesystem for yarn cache and logs
 
   task_exec_role_policy_documents = [
     data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -85,7 +85,7 @@ resource "aws_lb_target_group" "form_api" {
     enabled             = true
     interval            = 10
     port                = 3001
-    path                = "/"
+    path                = "/status"
     matcher             = "200"
     timeout             = 5
     healthy_threshold   = 2


### PR DESCRIPTION
# Summary
Update the WAF ACL to allow the API's valid paths.

Update the load balancer target group's health check path.

Update the name of the API's ECS service to be consistent with the form-viewer naming convention.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946