### PR TITLE
feat: add read-only user for RDS connector

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -25,6 +25,7 @@ env:
   TF_VAR_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
+  TF_VAR_rds_connector_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD_RDS_CONNECTOR }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -34,6 +34,7 @@ env:
   TF_VAR_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
+  TF_VAR_rds_connector_db_password: ${{ secrets.STAGING_DB_PASSWORD_RDS_CONNECTOR }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -27,6 +27,7 @@ env:
   TF_VAR_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
+  TF_VAR_rds_connector_db_password: ${{ secrets.STAGING_DB_PASSWORD_RDS_CONNECTOR }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -27,6 +27,7 @@ env:
   TF_VAR_notify_callback_bearer_token: ${{ secrets.PRODUCTION_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_notify_api_key: ${{ secrets.PRODUCTION_NOTIFY_API_KEY }}
   TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
+  TF_VAR_rds_connector_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD_RDS_CONNECTOR }}
   TF_VAR_rds_db_password: ${{ secrets.PRODUCTION_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.PRODUCTION_OPSGENIE_API_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -36,6 +36,7 @@ env:
   TF_VAR_notify_callback_bearer_token: ${{ secrets.STAGING_GC_NOTIFY_CALLBACK_BEARER_TOKEN }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_freshdesk_api_key: ${{ secrets.STAGING_FRESHDESK_API_KEY }}
+  TF_VAR_rds_connector_db_password: ${{ secrets.STAGING_DB_PASSWORD_RDS_CONNECTOR }}
   TF_VAR_rds_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
   TF_VAR_slack_webhook: ${{ secrets.STAGING_SLACK_WEBHOOK }}
   TF_VAR_opsgenie_api_key: ${{ secrets.STAGING_OPSGENIE_API_KEY }}

--- a/aws/rds/inputs.tf
+++ b/aws/rds/inputs.tf
@@ -8,6 +8,17 @@ variable "rds_db_name" {
   type        = string
 }
 
+variable "rds_connector_db_user" {
+  description = "The username the RDS connector uses to connect to the database"
+  type        = string
+}
+
+variable "rds_connector_db_password" {
+  description = "The password the RDS connector uses to connect to the database"
+  type        = string
+  sensitive   = true
+}
+
 variable "rds_db_user" {
   description = "The username of the RDS database"
   type        = string

--- a/aws/rds/secrets.tf
+++ b/aws/rds/secrets.tf
@@ -33,7 +33,5 @@ resource "aws_secretsmanager_secret" "rds_connector" {
 resource "aws_secretsmanager_secret_version" "rds_connector" {
   depends_on    = [aws_rds_cluster.forms]
   secret_id     = aws_secretsmanager_secret.rds_connector.id
-  secret_string = "{\"username\": \"${var.rds_db_user}\",\"password\": \"${var.rds_db_password}\"}"
+  secret_string = "{\"username\": \"${var.rds_connector_db_user}\",\"password\": \"${var.rds_connector_db_password}\"}"
 }
-
-

--- a/env/cloud/rds/terragrunt.hcl
+++ b/env/cloud/rds/terragrunt.hcl
@@ -24,6 +24,7 @@ inputs = {
   private_subnet_ids    = dependency.network.outputs.private_subnet_ids
   rds_security_group_id = dependency.network.outputs.rds_security_group_id
 
+  rds_connector_db_user    = "rds_connector_read"
   rds_db_user              = local.env == "local" ? "localstack_postgres" : "postgres" # We cannot use `postgres` as a username in Localstack
   rds_db_name              = "forms"
   rds_name                 = local.env == "staging" ? "forms-staging-db" : "forms-db"


### PR DESCRIPTION
# Summary
Update the RDS connector to use a read-only user to query the database.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3586