### PR TITLE
feat: add API CloudWatch alarms

### DIFF
--- a/aws/alarms/cloudwatch_api.tf
+++ b/aws/alarms/cloudwatch_api.tf
@@ -1,0 +1,112 @@
+#
+# ECS resource usage alarms
+#
+resource "aws_cloudwatch_metric_alarm" "api_cpu_utilization_high_warn" {
+  count = var.feature_flag_api ? 1 : 0
+
+  alarm_name          = "API-CpuUtilizationWarn"
+  alarm_description   = "API ECS Warning - High CPU usage has been detected."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = var.threshold_ecs_cpu_utilization_high
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    ClusterName = var.ecs_api_cluster_name
+    ServiceName = var.ecs_api_service_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_memory_utilization_high_warn" {
+  count = var.feature_flag_api ? 1 : 0
+
+  alarm_name          = "API-MemoryUtilizationWarn"
+  alarm_description   = "API ECS Warning - High memory usage has been detected."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = var.threshold_ecs_memory_utilization_high
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    ClusterName = var.ecs_api_cluster_name
+    ServiceName = var.ecs_api_service_name
+  }
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "api_error_detection" {
+  count = var.feature_flag_api ? 1 : 0
+
+  name            = "error_detection_in_api_logs"
+  log_group_name  = var.ecs_api_cloudwatch_log_group_name
+  filter_pattern  = "level=error"
+  destination_arn = aws_lambda_function.notify_slack.arn
+}
+
+#
+# Load balancer
+#
+resource "aws_cloudwatch_metric_alarm" "api_lb_unhealthy_host_count" {
+  count = var.feature_flag_api ? 1 : 0
+
+  alarm_name          = "API-UnhealthyHostCount" # TODO: bump to SEV1 once this is in production
+  alarm_description   = "API LB Warning - unhealthy host count >= 1 in a 1 minute period"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+  evaluation_periods  = "1"
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alert_warning_arn]
+  ok_actions    = [var.sns_topic_alert_ok_arn]
+
+  dimensions = {
+    LoadBalancer = var.lb_api_arn_suffix
+    TargetGroup  = var.lb_api_target_group_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_response_time_warn" {
+  count = var.feature_flag_api ? 1 : 0
+
+  alarm_name          = "API-ResponseTimeWarn"
+  alarm_description   = "API LB Warning - The latency of response times from the API are abnormally high."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "5"
+  datapoints_to_alarm = "2"
+  threshold           = var.threshold_lb_response_time
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
+  ok_actions          = [var.sns_topic_alert_ok_arn]
+
+  metric_query {
+    id          = "response_time"
+    return_data = "true"
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "60"
+      stat        = "Average"
+      dimensions = {
+        LoadBalancer = var.lb_api_arn_suffix
+        TargetGroup  = var.lb_api_target_group_arn_suffix
+      }
+    }
+  }
+}

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -8,6 +8,11 @@ variable "ecs_cloudwatch_log_group_name" {
   type        = string
 }
 
+variable "ecs_api_cloudwatch_log_group_name" {
+  description = "ECS API CloudWatch log group name, used by API error metric alarms"
+  type        = string
+}
+
 variable "ecs_idp_cloudwatch_log_group_name" {
   description = "ECS IdP CloudWatch log group name, used by IdP error metric alarms"
   type        = string
@@ -93,6 +98,11 @@ variable "ecs_cluster_name" {
   type        = string
 }
 
+variable "ecs_api_cluster_name" {
+  description = "API's ECS cluster name, used by CPU/memory threshold alarms"
+  type        = string
+}
+
 variable "ecs_idp_cluster_name" {
   description = "IdP's ECS cluster name, used by CPU/memory threshold alarms"
   type        = string
@@ -100,6 +110,11 @@ variable "ecs_idp_cluster_name" {
 
 variable "ecs_service_name" {
   description = "ECS service name, used by CPU/memory threshold alarms"
+  type        = string
+}
+
+variable "ecs_api_service_name" {
+  description = "API's ECS service name, used by CPU/memory threshold alarms"
   type        = string
 }
 
@@ -123,6 +138,11 @@ variable "lb_arn_suffix" {
   type        = string
 }
 
+variable "lb_api_arn_suffix" {
+  description = "API's load balancer ARN suffix, used by response time alarms"
+  type        = string
+}
+
 variable "lb_idp_arn_suffix" {
   description = "IdP's load balancer ARN suffix, used by response time alarms"
   type        = string
@@ -135,6 +155,11 @@ variable "lb_target_group_1_arn_suffix" {
 
 variable "lb_target_group_2_arn_suffix" {
   description = "Load balancer target group 2 ARN suffix, used by response time alarms"
+  type        = string
+}
+
+variable "lb_api_target_group_arn_suffix" {
+  description = "API's load balancer target group ARN suffix, used by response time alarms"
   type        = string
 }
 

--- a/aws/api/outputs.tf
+++ b/aws/api/outputs.tf
@@ -1,0 +1,14 @@
+output "ecs_api_cluster_name" {
+  description = "API's ECS cluster name"
+  value       = module.api_ecs.cluster_name
+}
+
+output "ecs_api_cloudwatch_log_group_name" {
+  description = "API's ECS CloudWatch log group name"
+  value       = module.api_ecs.cloudwatch_log_group_name
+}
+
+output "ecs_api_service_name" {
+  description = "API's ECS service name"
+  value       = module.api_ecs.service_name
+}

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -226,7 +226,7 @@ inputs = {
 
   ecs_api_cluster_name              = local.feature_flag_api == "true" ? dependency.api.outputs.ecs_api_cluster_name : ""
   ecs_api_cloudwatch_log_group_name = local.feature_flag_api == "true" ? dependency.api.outputs.ecs_api_cloudwatch_log_group_name : ""
-  ecs_api_service_name              = local.feature_flag_api == "true" ? dependency.iapip.outputs.ecs_api_service_name : ""
+  ecs_api_service_name              = local.feature_flag_api == "true" ? dependency.api.outputs.ecs_api_service_name : ""
 
   ecs_idp_cluster_name              = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_cluster_name : ""
   ecs_idp_cloudwatch_log_group_name = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_cloudwatch_log_group_name : ""


### PR DESCRIPTION
# Summary
Add API CloudWatch alarms for errors, high resource use and slow load balancer response times.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946