### PR TITLE
feat: update IdP WAF to block large requests

### DIFF
--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -8,6 +8,79 @@ resource "aws_wafv2_web_acl" "idp" {
   }
 
   rule {
+    name     = "BlockLargeRequests"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              cookies {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              headers {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockLargeRequests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "InvalidHost"
     priority = 5
 
@@ -130,6 +203,25 @@ resource "aws_wafv2_web_acl" "idp" {
     }
   }
 
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 50
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "idp"


### PR DESCRIPTION
# Summary
Add large request block rule that will block any request with cookies, headers or a request body larger than 8kb.  This is the maximum size that WAF ACLs can inspect, and so this rule prevents padding attacks.

Add the AWS common rule set.