### PR TITLE
chore: added rds_connector_db_password variable to RDS terragrunt.hcl file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.tfstate.*
 
 # Terraform lock file
-.bootstrap/.terraform.lock.hcl
+.terraform.lock.hcl
 
 # Terragrunt
 .terragrunt-cache

--- a/env/cloud/rds/terragrunt.hcl
+++ b/env/cloud/rds/terragrunt.hcl
@@ -31,7 +31,8 @@ inputs = {
   rds_db_subnet_group_name = local.env == "staging" ? "forms-staging-db" : "forms-db"
 
   # Overwritten in GitHub Actions by TFVARS
-  rds_db_password = "chummy" # RDS database password used for local setup
+  rds_db_password           = "chummy" # RDS database password used for local setup
+  rds_connector_db_password = ""
 }
 
 include {


### PR DESCRIPTION
# Summary | Résumé

- Added `rds_connector_db_password` variable to RDS terragrunt.hcl file to avoid having to set it in our .env file