### PR TITLE
fix: exclude EC2MetaDataSSRF_Body WAF ACL rule

### DIFF
--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -1,4 +1,7 @@
-# TODO: add AWS Common Ruleset once service has been stood up
+locals {
+  excluded_common_rules = ["EC2MetaDataSSRF_Body"]
+}
+
 resource "aws_wafv2_web_acl" "idp" {
   name  = "idp"
   scope = "REGIONAL"
@@ -206,13 +209,25 @@ resource "aws_wafv2_web_acl" "idp" {
   rule {
     name     = "AWSManagedRulesCommonRuleSet"
     priority = 50
+
     override_action {
       none {}
     }
+
     statement {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        dynamic "rule_action_override" {
+          for_each = local.excluded_common_rules
+          content {
+            name = rule_action_override.value
+            action_to_use {
+              count {}
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# Summary
Update the IdP's WAf ACL to exclude the `EC2MetaDataSSRF_Body` rule as this is blocking the creation of new IdP apps.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3938
- https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html