### PR TITLE
chore: add OpenAPI doc route to WAF

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -387,7 +387,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_app_uri_paths" {
 
   # API paths
   regular_expression {
-    regex_string = "^\\/(?:v1)?\\/?(?:(status))(?:\\/)?$"
+    regex_string = "^\\/(?:v1)?\\/?(?:(docs|status))(?:\\/)?$"
   }
 
   # This is a temporary rule to allow search engines tools to access ownership verification files


### PR DESCRIPTION
# Summary
Update the WAF ACLs allowed paths to include the OpenAPI `/v1/docs` route.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946