### PR TITLE
feat: add HTTP2 IdP target group

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -46,7 +46,7 @@ locals {
 }
 
 module "idp_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=ee038ad0d42bbff42e073312af0720e691902e03" # PR test commit
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=16cbb8dc2a6bf05d77e8170a6b4794b14ea9afdb" # v9.6.2
 
   cluster_name   = "idp"
   service_name   = "zitadel"

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -74,7 +74,7 @@ module "idp_ecs" {
 
   # Networking
   lb_target_group_arns = [
-    for protocol_version in local.protocol_version : {
+    for protocol_version in local.protocol_versions : {
       target_group_arn = aws_lb_target_group.idp[protocol_version].arn
       container_name   = "zitadel"
       container_port   = 8080

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -46,7 +46,7 @@ locals {
 }
 
 module "idp_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=544060caeadb399c773247e2c25640e0c62fb0ed" # v9.5.3
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=ee038ad0d42bbff42e073312af0720e691902e03" # PR test commit
 
   cluster_name   = "idp"
   service_name   = "zitadel"

--- a/aws/idp/lb.tf
+++ b/aws/idp/lb.tf
@@ -70,7 +70,7 @@ resource "aws_lb_listener" "idp" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.idp.arn
+    target_group_arn = aws_lb_target_group.idp["HTTP2"].arn
   }
 
   depends_on = [

--- a/aws/idp/locals.tf
+++ b/aws/idp/locals.tf
@@ -1,6 +1,6 @@
 locals {
   hosted_zone_id    = var.hosted_zone_ids[0]
-  protocol_versions = ["HTTP1", "HTTP2"]
+  protocol_versions = toset(["HTTP1", "HTTP2"])
   common_tags = {
     Terraform             = "true"
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/idp/locals.tf
+++ b/aws/idp/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  hosted_zone_id = var.hosted_zone_ids[0]
+  hosted_zone_id    = var.hosted_zone_ids[0]
+  protocol_versions = ["HTTP1", "HTTP2"]
   common_tags = {
     Terraform             = "true"
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/idp/outputs.tf
+++ b/aws/idp/outputs.tf
@@ -18,9 +18,11 @@ output "lb_idp_arn_suffix" {
   value       = aws_lb.idp.arn_suffix
 }
 
+# TODO: add an output for both target groups
+# TODO: create a CloudWatch alarm for each target group
 output "lb_idp_target_group_arn_suffix" {
-  description = "IdP's load balancer target group ARN suffix"
-  value       = aws_lb_target_group.idp.arn_suffix
+  description = "IdP's HTTP1 load balancer target group ARN suffix"
+  value       = aws_lb_target_group.idp["HTTP1"].arn_suffix
 }
 
 output "rds_idp_cluster_identifier" {


### PR DESCRIPTION
# Summary
Update the IdP load balancer to include an HTTP1 and HTTP2 target group.  An ALB listener rule has also been added to send all REST API requests to the HTTP1 target group, while the HTTP2 target group is responsible for forwarding all other traffic.

The ECS service has also been updated to register both target groups.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3938
- https://github.com/cds-snc/terraform-modules/pull/543