### PR TITLE
fix: IdP listener rule for well-known config

### DIFF
--- a/aws/idp/lb.tf
+++ b/aws/idp/lb.tf
@@ -112,7 +112,7 @@ resource "aws_alb_listener_rule" "idp_protocol_version" {
 
   condition {
     path_pattern {
-      values = ["/*/v?/*"] # REST API endpoint pattern `/type/v1/some/endpoint/go/now`
+      values = ["/*/v?/*", "/.well-known/openid-configuration"] # REST API endpoints
     }
   }
 }


### PR DESCRIPTION
# Summary
Update the IdP load balancer listener rule to also send requests to the `/.well-known/openid-configuration` endpoint to the HTTP1 target group.

⚠️ This was applied through the console to test.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3938