### PR TITLE
chore: rename ECS API task from form-api to forms-api

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -8,7 +8,7 @@ module "api_ecs" {
 
   create_cluster = false
   cluster_name   = var.ecs_cluster_name
-  service_name   = "form-api"
+  service_name   = "forms-api"
   task_cpu       = 1024
   task_memory    = 2048
 

--- a/aws/load_balancer/certificates.tf
+++ b/aws/load_balancer/certificates.tf
@@ -26,7 +26,7 @@ resource "aws_acm_certificate" "form_viewer_maintenance_mode" {
   }
 }
 
-resource "aws_acm_certificate" "form_api" {
+resource "aws_acm_certificate" "forms_api" {
   count = var.feature_flag_api ? 1 : 0
 
   domain_name       = var.domain_api
@@ -37,6 +37,11 @@ resource "aws_acm_certificate" "form_api" {
   }
 }
 
+moved {
+  from = aws_acm_certificate.form_api
+  to   = aws_acm_certificate.forms_api
+}
+
 resource "aws_acm_certificate_validation" "form_viewer_maintenance_mode_cloudfront_certificate" {
   certificate_arn         = aws_acm_certificate.form_viewer_maintenance_mode.arn
   validation_record_fqdns = [for record in aws_route53_record.form_viewer_maintenance_mode_certificate_validation : record.fqdn]
@@ -44,9 +49,14 @@ resource "aws_acm_certificate_validation" "form_viewer_maintenance_mode_cloudfro
   provider = aws.us-east-1
 }
 
-resource "aws_acm_certificate_validation" "form_api" {
+resource "aws_acm_certificate_validation" "forms_api" {
   count = var.feature_flag_api ? 1 : 0
 
-  certificate_arn         = aws_acm_certificate.form_api[0].arn
-  validation_record_fqdns = [for record in aws_route53_record.form_api_certificate_validation : record.fqdn]
+  certificate_arn         = aws_acm_certificate.forms_api[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.forms_api_certificate_validation : record.fqdn]
+}
+
+moved {
+  from = aws_acm_certificate_validation.form_api
+  to   = aws_acm_certificate_validation.forms_api
 }

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -71,10 +71,10 @@ resource "aws_lb_target_group" "form_viewer_2" {
   }
 }
 
-resource "aws_lb_target_group" "form_api" {
+resource "aws_lb_target_group" "forms_api" {
   count = var.feature_flag_api ? 1 : 0
 
-  name                 = "form-api"
+  name                 = "forms-api"
   port                 = 3001
   protocol             = "HTTP"
   target_type          = "ip"
@@ -93,8 +93,13 @@ resource "aws_lb_target_group" "form_api" {
   }
 
   tags = {
-    Name = "form_api"
+    Name = "forms_api"
   }
+}
+
+moved {
+  from = aws_lb_target_group.form_api
+  to   = aws_lb_target_group.forms_api
 }
 
 resource "aws_lb_listener" "form_viewer_https" {
@@ -120,11 +125,16 @@ resource "aws_lb_listener" "form_viewer_https" {
   }
 }
 
-resource "aws_lb_listener_certificate" "form_api_https" {
+resource "aws_lb_listener_certificate" "forms_api_https" {
   count = var.feature_flag_api ? 1 : 0
 
   listener_arn    = aws_lb_listener.form_viewer_https.arn
-  certificate_arn = aws_acm_certificate_validation.form_api[0].certificate_arn
+  certificate_arn = aws_acm_certificate_validation.forms_api[0].certificate_arn
+}
+
+moved {
+  from = aws_lb_listener_certificate.form_api_https
+  to   = aws_lb_listener_certificate.forms_api_https
 }
 
 resource "aws_lb_listener" "form_viewer_http" {
@@ -149,7 +159,7 @@ resource "aws_lb_listener" "form_viewer_http" {
   }
 }
 
-resource "aws_alb_listener_rule" "form_api" {
+resource "aws_alb_listener_rule" "forms_api" {
   count = var.feature_flag_api ? 1 : 0
 
   listener_arn = aws_lb_listener.form_viewer_https.arn
@@ -157,7 +167,7 @@ resource "aws_alb_listener_rule" "form_api" {
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.form_api[0].arn
+    target_group_arn = aws_lb_target_group.forms_api[0].arn
   }
 
   condition {
@@ -165,4 +175,9 @@ resource "aws_alb_listener_rule" "form_api" {
       values = [var.domain_api]
     }
   }
+}
+
+moved {
+  from = aws_alb_listener_rule.form_api
+  to   = aws_alb_listener_rule.forms_api
 }

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -40,12 +40,12 @@ output "lb_target_group_2_name" {
 
 output "lb_target_group_api_arn" {
   description = "Load balancer target group ARN for the API"
-  value       = var.feature_flag_api ? aws_lb_target_group.form_api[0].arn : ""
+  value       = var.feature_flag_api ? aws_lb_target_group.forms_api[0].arn : ""
 }
 
 output "lb_target_group_api_arn_suffix" {
   description = "Load balancer target group ARN suffix for the API"
-  value       = var.feature_flag_api ? aws_lb_target_group.form_api[0].arn_suffix : ""
+  value       = var.feature_flag_api ? aws_lb_target_group.forms_api[0].arn_suffix : ""
 }
 
 output "kinesis_firehose_waf_logs_arn" {

--- a/aws/load_balancer/route53.tf
+++ b/aws/load_balancer/route53.tf
@@ -41,7 +41,7 @@ resource "aws_route53_record" "form_viewer_maintenance" {
   set_identifier = "form_viewer_${var.domains[count.index]}_secondary"
 }
 
-resource "aws_route53_record" "form_api" {
+resource "aws_route53_record" "forms_api" {
   count = var.feature_flag_api ? 1 : 0
 
   zone_id = var.hosted_zone_ids[0]
@@ -54,6 +54,12 @@ resource "aws_route53_record" "form_api" {
     evaluate_target_health = true
   }
 }
+
+moved {
+  from = aws_route53_record.form_api
+  to   = aws_route53_record.forms_api
+}
+
 
 #
 # Certificate validation
@@ -104,9 +110,9 @@ resource "aws_route53_record" "form_viewer_maintenance_mode_certificate_validati
   zone_id         = local.domain_name_to_zone_id[each.value.domain]
 }
 
-resource "aws_route53_record" "form_api_certificate_validation" {
+resource "aws_route53_record" "forms_api_certificate_validation" {
   for_each = var.feature_flag_api ? {
-    for dvo in aws_acm_certificate.form_api[0].domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.forms_api[0].domain_validation_options : dvo.domain_name => {
       domain = dvo.domain_name
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
@@ -120,4 +126,9 @@ resource "aws_route53_record" "form_api_certificate_validation" {
   ttl             = 60
   type            = each.value.type
   zone_id         = var.hosted_zone_ids[0]
+}
+
+moved {
+  from = aws_route53_record.form_api_certificate_validation
+  to   = aws_route53_record.forms_api_certificate_validation
 }

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -133,9 +133,9 @@ dependency "api" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    ecs_api_cloudwatch_log_group_name = "/aws/ecs/Forms/form-api"
+    ecs_api_cloudwatch_log_group_name = "/aws/ecs/Forms/forms-api"
     ecs_api_cluster_name              = "Forms"
-    ecs_api_service_name              = "form-api"
+    ecs_api_service_name              = "forms-api"
   }
 }
 

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -50,7 +50,7 @@ dependency "load_balancer" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    lb_target_group_api_arn = "arn:aws:elasticloadbalancing:ca-central-1:123456789012:targetgroup/form-api/1234567890abcdef"
+    lb_target_group_api_arn = "arn:aws:elasticloadbalancing:ca-central-1:123456789012:targetgroup/forms-api/1234567890abcdef"
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Linked to https://github.com/cds-snc/forms-api/pull/18

- Renames ECS Task name from `form-api` to `forms-api` (also changes the name of some resources)