### PR TITLE
chore: add alarms for all IdP LB target groups

### DIFF
--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -60,10 +60,10 @@ resource "aws_cloudwatch_log_subscription_filter" "idp_error_detection" {
 # Load balancer
 #
 resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
-  count = var.feature_flag_idp ? 1 : 0
+  for_each = var.feature_flag_idp ? var.lb_idp_target_groups_arn_suffix : {}
 
-  alarm_name          = "IdP-UnhealthyHostCount" # TODO: bump to SEV1 once this is in production
-  alarm_description   = "IdP ELB Warning - unhealthy host count >= 1 in a 1 minute period"
+  alarm_name          = "IdP-UnhealthyHostCount-${each.key}" # TODO: bump to SEV1 once this is in production
+  alarm_description   = "IdP ELB Warning - unhealthy ${each.key} host count >= 1 in a 1 minute period"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "1"
   evaluation_periods  = "1"
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
 
   dimensions = {
     LoadBalancer = var.lb_idp_arn_suffix
-    TargetGroup  = var.lb_idp_target_group_arn_suffix
+    TargetGroup  = each.value
   }
 }
 

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -163,9 +163,9 @@ variable "lb_api_target_group_arn_suffix" {
   type        = string
 }
 
-variable "lb_idp_target_group_arn_suffix" {
-  description = "IdP's load balancer target group ARN suffix, used by response time alarms"
-  type        = string
+variable "lb_idp_target_groups_arn_suffix" {
+  description = "IdP's load balancer target groups ARN suffixes, used by response time alarms"
+  type        = map(string)
 }
 
 variable "slack_webhook" {

--- a/aws/idp/outputs.tf
+++ b/aws/idp/outputs.tf
@@ -18,11 +18,11 @@ output "lb_idp_arn_suffix" {
   value       = aws_lb.idp.arn_suffix
 }
 
-# TODO: add an output for both target groups
-# TODO: create a CloudWatch alarm for each target group
-output "lb_idp_target_group_arn_suffix" {
-  description = "IdP's HTTP1 load balancer target group ARN suffix"
-  value       = aws_lb_target_group.idp["HTTP1"].arn_suffix
+output "lb_idp_target_groups_arn_suffix" {
+  description = "IdP's load balancer target groups ARN suffixes"
+  value = {
+    for version in local.protocol_versions : version => aws_lb_target_group.idp[version].arn_suffix
+  }
 }
 
 output "rds_idp_cluster_identifier" {

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -235,7 +235,7 @@ inputs = {
   ecs_idp_cloudwatch_log_group_name = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_cloudwatch_log_group_name : ""
   ecs_idp_service_name              = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_service_name : ""
   lb_idp_arn_suffix                 = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_arn_suffix : ""
-  lb_idp_target_group_arn_suffix    = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_target_groups_arn_suffix : {}
+  lb_idp_target_groups_arn_suffix   = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_target_groups_arn_suffix : {}
   rds_idp_cluster_identifier        = local.feature_flag_idp == "true" ? dependency.idp.outputs.rds_idp_cluster_identifier : ""
   rds_idp_cpu_maxiumum              = 80
 

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -149,7 +149,10 @@ dependency "idp" {
     ecs_idp_cloudwatch_log_group_name = "/aws/ecs/idp/zitadel"
     ecs_idp_service_name              = "zitadel"
     lb_idp_arn_suffix                 = "loadbalancer/app/idp/1234567890123456"
-    lb_idp_target_group_arn_suffix    = "targetgroup/idp-tg-abc/1234567890123456"
+    lb_idp_target_groups_arn_suffix   = {
+      HTTP1 = "targetgroup/idp-tg-http1-abc/1234567890123456"
+      HTTP2 = "targetgroup/idp-tg-http2-abc/1234567890123456"
+    }
     rds_idp_cluster_identifier        = "idp-cluster"
   }
 }
@@ -232,7 +235,7 @@ inputs = {
   ecs_idp_cloudwatch_log_group_name = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_cloudwatch_log_group_name : ""
   ecs_idp_service_name              = local.feature_flag_idp == "true" ? dependency.idp.outputs.ecs_idp_service_name : ""
   lb_idp_arn_suffix                 = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_arn_suffix : ""
-  lb_idp_target_group_arn_suffix    = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_target_group_arn_suffix : ""
+  lb_idp_target_group_arn_suffix    = local.feature_flag_idp == "true" ? dependency.idp.outputs.lb_idp_target_groups_arn_suffix : {}
   rds_idp_cluster_identifier        = local.feature_flag_idp == "true" ? dependency.idp.outputs.rds_idp_cluster_identifier : ""
   rds_idp_cpu_maxiumum              = 80
 


### PR DESCRIPTION
# Summary
Update the IdP load balancer alarms to include unhealthy host alarms for both the HTTP1 and HTTP2 target groups.

# Related
- https://github.com/cds-snc/forms-terraform/pull/762