### PR TITLE
fix: Attach files from fileInputs in a dynamicRow

### DIFF
--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -207,11 +207,6 @@ export function extractFileInputResponses(submission: FormSubmission) {
                 return [...acc, ...subElementFiles];
               }
 
-              // const fileInputPath = Array.isArray(response) && response[currentIndex];
-              // if (fileInputPath !== "" && typeof fileInputPath === "string") {
-              //   return [...acc, fileInputPath];
-              // }
-
               return [...acc];
             } else {
               return acc;

--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -198,10 +198,20 @@ export function extractFileInputResponses(submission: FormSubmission) {
             if (current.type === "fileInput") {
               const response = submission.responses[element.id];
 
-              const fileInputPath = Array.isArray(response) && response[currentIndex];
-              if (fileInputPath !== "" && typeof fileInputPath === "string") {
-                return [...acc, fileInputPath];
+              const subElementFiles: string[] = [];
+              if (Array.isArray(response)) {
+                response.forEach((element) => {
+                  // @ts-expect-error
+                  subElementFiles.push(element[0]);
+                });
+                return [...acc, ...subElementFiles];
               }
+
+              // const fileInputPath = Array.isArray(response) && response[currentIndex];
+              // if (fileInputPath !== "" && typeof fileInputPath === "string") {
+              //   return [...acc, fileInputPath];
+              // }
+
               return [...acc];
             } else {
               return acc;

--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -197,14 +197,18 @@ export function extractFileInputResponses(submission: FormSubmission) {
           (acc: string[], current: FormElement, currentIndex: number) => {
             if (current.type === "fileInput") {
               const response = submission.responses[element.id];
-
               const subElementFiles: string[] = [];
               if (Array.isArray(response)) {
                 response.forEach((element) => {
                   // @ts-expect-error
-                  if (element[0] && element[0] !== "" && typeof element[0] === "string") {
-                    // @ts-expect-error
-                    subElementFiles.push(element[0]);
+                  const answer = element[currentIndex];
+                  if (
+                    answer &&
+                    answer !== "" &&
+                    typeof answer === "string" &&
+                    answer.startsWith("form_attachments")
+                  ) {
+                    subElementFiles.push(answer);
                   }
                 });
                 return [...acc, ...subElementFiles];

--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -202,7 +202,10 @@ export function extractFileInputResponses(submission: FormSubmission) {
               if (Array.isArray(response)) {
                 response.forEach((element) => {
                   // @ts-expect-error
-                  subElementFiles.push(element[0]);
+                  if (element[0] && element[0] !== "" && typeof element[0] === "string") {
+                    // @ts-expect-error
+                    subElementFiles.push(element[0]);
+                  }
                 });
                 return [...acc, ...subElementFiles];
               }


### PR DESCRIPTION
# Summary | Résumé

The previous code was not attaching files from within a repeatingSet.


# Test instructions | Instructions pour tester la modification

- Create a form with a fileInput in a repeatingSet. ie: [multiple-file-uploads-2024-08-12.json](https://github.com/user-attachments/files/16591895/multiple-file-uploads-2024-08-12.json)
- Configure the form to send by email.
- Test the form in Preview and attach one or more files in the repeatingSet.
- Use small files as we are still adjusting the post size limit