### PR TITLE
fix: attach permission to retrieve secrets to API ECS task

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -45,6 +45,7 @@ module "api_ecs" {
     data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,
     data.aws_iam_policy_document.api_ecs_kms_vault.json,
     data.aws_iam_policy_document.api_ecs_s3_vault.json,
+    data.aws_iam_policy_document.api_ecs_secrets_manager.json
   ]
 
   # Networking


### PR DESCRIPTION
# Summary | Résumé

- Attaches permission to retrieve secrets to API ECS task