### PR TITLE
fix: permission to use DynamoDB was not properly set in the ECS task configuration

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -41,10 +41,13 @@ module "api_ecs" {
   container_secrets                   = local.container_secrets
   container_read_only_root_filesystem = false # TODO: mount tmp filesystem for yarn cache and logs
 
-  task_exec_role_policy_documents = [
+  task_role_policy_documents = [
     data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,
+    data.aws_iam_policy_document.api_ecs_s3_vault.json
+  ]
+
+  task_exec_role_policy_documents = [
     data.aws_iam_policy_document.api_ecs_kms_vault.json,
-    data.aws_iam_policy_document.api_ecs_s3_vault.json,
     data.aws_iam_policy_document.api_ecs_secrets_manager.json
   ]
 


### PR DESCRIPTION
# Summary | Résumé

- Fixes permission to use DynamoDB not properly set in the ECS task configuration