### PR TITLE
feat: use RDS Proxy for IdP database connection pool

### DIFF
--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -79,6 +79,7 @@ resource "aws_ssm_parameter" "zitadel_database_user_password" {
 }
 
 resource "aws_secretsmanager_secret" "zidatel_database_proxy_auth" {
+  # checkov:skip=CKV2_AWS_57: automated rotation is not applicable to this secret
   name = "zidatel_database_proxy_auth"
   tags = local.common_tags
 }

--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -2,7 +2,7 @@
 # RDS Postgress cluster
 #
 module "idp_database" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=3628ac59c9e56f6fd7d2fe1b7f77e94c9137e922" # v9.6.0
+  source = "github.com/cds-snc/terraform-modules//rds?ref=63774b7bbea74205e90e173587da08193a6b85f7" # v9.6.5
   name   = "idp"
 
   database_name           = var.zitadel_database_name

--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -2,7 +2,7 @@
 # RDS Postgress cluster
 #
 module "idp_database" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=50c0f631d2c8558e6eec44138ffc2e963a1dfa9a" # v9.6.0
+  source = "github.com/cds-snc/terraform-modules//rds?ref=3628ac59c9e56f6fd7d2fe1b7f77e94c9137e922" # v9.6.0
   name   = "idp"
 
   database_name           = var.zitadel_database_name
@@ -12,7 +12,6 @@ module "idp_database" {
   instance_class          = "db.serverless"
   serverless_min_capacity = var.idp_database_min_acu
   serverless_max_capacity = var.idp_database_max_acu
-  use_proxy               = true
 
   username               = var.idp_database_cluster_admin_username
   password               = var.idp_database_cluster_admin_password

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -15,10 +15,6 @@ TLS:
 Database:
   postgres:
     Port: 5432
-    MaxOpenConns: 200
-    MaxIdleConns: 20
-    MaxConnLifetime: 1800
-    MaxConnIdleTime: 1800
     User:
       SSL:
         Mode: require


### PR DESCRIPTION
# Summary
Add an RDS Proxy to manage the database connections for Zitadel. This will help reduce strain on the IdP and database and allow for smoother load scaling.

# Related
- Closes https://github.com/cds-snc/platform-forms-client/issues/4216