### PR TITLE
feat: allow API to access Redis

### DIFF
--- a/aws/network/security_groups_api.tf
+++ b/aws/network/security_groups_api.tf
@@ -94,7 +94,7 @@ resource "aws_security_group_rule" "redis_ingress_api_ecs" {
   source_security_group_id = aws_security_group.api_ecs[0].id
 }
 
-resource "aws_security_group_rule" "api_ecs_egress_db" {
+resource "aws_security_group_rule" "api_ecs_egress_redis" {
   count = var.feature_flag_api ? 1 : 0
 
   description              = "Egress from API ECS task to Redis"

--- a/aws/network/security_groups_api.tf
+++ b/aws/network/security_groups_api.tf
@@ -80,3 +80,28 @@ resource "aws_security_group_rule" "api_ecs_egress_db" {
   security_group_id        = aws_security_group.api_ecs[0].id
   source_security_group_id = aws_security_group.forms_database.id
 }
+
+# Redis
+resource "aws_security_group_rule" "redis_ingress_api_ecs" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Ingress to Redis from API ECS task"
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.forms_redis.id
+  source_security_group_id = aws_security_group.api_ecs[0].id
+}
+
+resource "aws_security_group_rule" "api_ecs_egress_db" {
+  count = var.feature_flag_api ? 1 : 0
+
+  description              = "Egress from API ECS task to Redis"
+  type                     = "egress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.api_ecs[0].id
+  source_security_group_id = aws_security_group.forms_redis.id
+}


### PR DESCRIPTION
# Summary
Update the the security groups to allow the API to connect to the ElasitCache Redis cluster.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4215