### PR TITLE
fix: add missing input variable for sentry api

### DIFF
--- a/env/cloud/secrets/terragrunt.hcl
+++ b/env/cloud/secrets/terragrunt.hcl
@@ -29,4 +29,5 @@ inputs = {
   zitadel_application_key      = local.zitadel_application_key
   # Overwritten in GitHub Actions by TFVARS
   rds_db_password              = local.rds_db_password
+  sentry_api_key               = local.sentry_api_key
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes a missing input variable for `secrets` when trying to initialize locally with LocalStack.


