### PR TITLE
feat: add Redis URL to the API ECS task

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -7,6 +7,10 @@ locals {
     {
       name  = "ENVIRONMENT_MODE"
       value = var.env
+    },
+    {
+      name  = "REDIS_URL"
+      value = var.redis_url
     }
   ]
 

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -33,6 +33,11 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "redis_url" {
+  description = "Redis URL used by the ECS task"
+  type        = string
+}
+
 variable "s3_vault_file_storage_arn" {
   description = "ARN of the S3 bucket used for the Vault's file storage"
   type        = string

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../kms", "../network", "../dynamodb", "../load_balancer", "../ecr", "../s3", "../app", "../secrets"]
+  paths = ["../kms", "../network", "../dynamodb", "../load_balancer", "../ecr", "../redis", "../s3", "../app", "../secrets"]
 }
 
 dependency "app" {
@@ -64,6 +64,15 @@ dependency "network" {
   }
 }
 
+dependency "redis" {
+  config_path                             = "../redis"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    redis_url = "mock-redis-url.0001.cache.amazonaws.com"
+  }
+}
+
 dependency "s3" {
   config_path                             = "../s3"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
@@ -99,6 +108,8 @@ inputs = {
   dynamodb_vault_arn          = dependency.dynamodb.outputs.dynamodb_vault_arn
   s3_vault_file_storage_arn   = dependency.s3.outputs.vault_file_storage_arn
   
+  redis_url = dependency.redis.outputs.redis_url
+
   zitadel_domain                     = local.zitadel_domain
   zitadel_application_key_secret_arn = dependency.secrets.outputs.zitadel_application_key_secret_arn
   


### PR DESCRIPTION
# Summary
Update the `api` module to set the `REDIS_URL` environment variable on the ECS task.

# Related
- https://github.com/cds-snc/forms-api/pull/38
- https://github.com/cds-snc/platform-forms-client/issues/4215