### PR TITLE
fix: API Redis URL add protocol and port

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -10,7 +10,7 @@ locals {
     },
     {
       name  = "REDIS_URL"
-      value = var.redis_url
+      value = "redis://${var.redis_url}:${var.redis_port}"
     }
   ]
 

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -33,8 +33,13 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "redis_port" {
+  description = "Redis port used by the ECS task"
+  type        = number
+}
+
 variable "redis_url" {
-  description = "Redis URL used by the ECS task"
+  description = "Redis URL used by the ECS task.  This should not include the protocol or port."
   type        = string
 }
 

--- a/aws/redis/outputs.tf
+++ b/aws/redis/outputs.tf
@@ -1,3 +1,8 @@
+output "redis_port" {
+  description = "The Redis port"
+  value       = aws_elasticache_replication_group.redis.port
+}
+
 output "redis_url" {
   description = "The Redis endpoint URL"
   value       = aws_elasticache_replication_group.redis.primary_endpoint_address

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -69,7 +69,8 @@ dependency "redis" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    redis_url = "mock-redis-url.0001.cache.amazonaws.com"
+    redis_port = 6379
+    redis_url  = "mock-redis-url.0001.cache.amazonaws.com"
   }
 }
 
@@ -104,11 +105,12 @@ inputs = {
   lb_target_group_arn_api_ecs = dependency.load_balancer.outputs.lb_target_group_api_arn
   private_subnet_ids          = dependency.network.outputs.private_subnet_ids
   
-  kms_key_dynamodb_arn        = dependency.kms.outputs.kms_key_dynamodb_arn
-  dynamodb_vault_arn          = dependency.dynamodb.outputs.dynamodb_vault_arn
-  s3_vault_file_storage_arn   = dependency.s3.outputs.vault_file_storage_arn
+  kms_key_dynamodb_arn      = dependency.kms.outputs.kms_key_dynamodb_arn
+  dynamodb_vault_arn        = dependency.dynamodb.outputs.dynamodb_vault_arn
+  s3_vault_file_storage_arn = dependency.s3.outputs.vault_file_storage_arn
   
-  redis_url = dependency.redis.outputs.redis_url
+  redis_port = dependency.redis.outputs.redis_port
+  redis_url  = dependency.redis.outputs.redis_url
 
   zitadel_domain                     = local.zitadel_domain
   zitadel_application_key_secret_arn = dependency.secrets.outputs.zitadel_application_key_secret_arn


### PR DESCRIPTION
# Summary
Update the API ECS task's `REDIS_URL` environment variable to include the protocol and port.

# Related
- https://github.com/cds-snc/forms-api/pull/38
- https://github.com/cds-snc/platform-forms-client/issues/4215