### PR TITLE
fix: ECS task to access to Sentry secret

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -39,7 +39,8 @@ data "aws_iam_policy_document" "forms_secrets_manager" {
       var.token_secret_arn,
       var.notify_callback_bearer_token_secret_arn,
       var.freshdesk_api_key_secret_arn,
-      var.zitadel_administration_key_secret_arn
+      var.zitadel_administration_key_secret_arn,
+      var.sentry_api_key_secret_arn
     ]
   }
 }

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -182,7 +182,7 @@ inputs = {
   notify_callback_bearer_token_secret_arn = dependency.secrets.outputs.notify_callback_bearer_token_secret_arn
   token_secret_arn                        = dependency.secrets.outputs.token_secret_arn
   zitadel_administration_key_secret_arn   = dependency.secrets.outputs.zitadel_administration_key_secret_arn
-  sentry_api_key_secret_arn  = dependency.secrets.outputs.sentry_api_key_secret_arn
+  sentry_api_key_secret_arn               = dependency.secrets.outputs.sentry_api_key_secret_arn
 
   vault_file_storage_arn = dependency.s3.outputs.vault_file_storage_arn
   vault_file_storage_id = dependency.s3.outputs.vault_file_storage_id


### PR DESCRIPTION
# Summary 
Update the app's ECS IAM permissions to allow it to access the Sentry API key secret.