### PR TITLE
fix: deploy new IdP image if changes

### DIFF
--- a/.github/workflows/request-ecs-service-to-use-new-image/action.yml
+++ b/.github/workflows/request-ecs-service-to-use-new-image/action.yml
@@ -1,0 +1,64 @@
+name: Request ECS service to use new image
+
+inputs:
+  aws-role-to-assume:
+    required: true
+  aws-role-session-name:
+    required: true
+  aws-region:
+    required: true
+  ecs-cluster-name:
+    required: true
+  ecs-service-name:
+    required: true
+  ecs-task-def-name:
+    required: true
+  image-tag:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: ${{ inputs.aws-role-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Login to Staging Amazon ECR
+      id: login-ecr-staging
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+    - name: Download ECS task definition
+      shell: bash
+      run: |
+        aws ecs describe-task-definition \
+        --task-definition ${{ inputs.ecs-service-name }} \
+        --query taskDefinition > task-definition.json
+
+    - name: Update ECS task image
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@9933bf0d77b7f6d52e3886fbb8aae95a677db1ab # v1.5.0
+      with:
+        task-definition: task-definition.json
+        container-name: ${{ inputs.ecs-service-name }}
+        image: "${{ steps.login-ecr-staging.outputs.registry }}/${{ inputs.image-tag }}"
+
+    - name: Create the new ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@0a9a8fb7b39516cf53cc01d453b05c67c6fc7a2c # v2.0.0
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        cluster: ${{ inputs.ecs-cluster-name }}
+
+    - name: Deploy the new ECS task definition
+      shell: bash
+      run: |
+        aws ecs update-service \
+          --cluster ${{ inputs.ecs-cluster-name }} \
+          --service ${{ inputs.ecs-service-name }} \
+          --task-definition ${{ inputs.ecs-task-def-name }} \
+          --force-new-deployment > /dev/null 2>&1
+        aws ecs wait services-stable \
+          --cluster ${{ inputs.ecs-cluster-name }} \
+          --services ${{ inputs.ecs-service-name }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -95,6 +95,23 @@ jobs:
         with:
           filters: .github/lambda-filter.yml
 
+  detect-idp-changes:
+    needs: terragrunt-apply-ecr-only
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Filter
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            idp:
+              - 'idp/**'
+
   build-tag-push-lambda-images:
     needs: detect-lambda-changes
     if: ${{ needs.detect-lambda-changes.outputs.lambda-to-rebuild != '[]' }}
@@ -124,7 +141,8 @@ jobs:
           image-tag: ${{ github.sha }}
 
   build-tag-push-idp-image:
-    needs: terragrunt-apply-ecr-only
+    needs: detect-idp-changes
+    if: ${{ needs.detect-idp-changes.outputs.changes != '[]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -272,6 +290,25 @@ jobs:
           lambda-name: ${{ matrix.image }}
           image-tag: ${{ github.sha }}
 
+  update-idp-ecs-service-image:
+    needs: [detect-idp-changes, terragrunt-apply-all-modules]
+    if: ${{ needs.detect-idp-changes.outputs.changes != '[]' && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Update IdP ESC service to use new image
+        uses: ./.github/workflows/request-ecs-service-to-use-new-image
+        with:
+          aws-role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply
+          aws-role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+          ecs-cluster-name: idp
+          ecs-service-name: zitadel
+          ecs-task-def-name: zitadel
+          image-tag: "idp/zitadel:${{ github.sha }}"
+
   notify-on-error:
     needs:
       [
@@ -280,6 +317,7 @@ jobs:
         build-tag-push-idp-image,
         terragrunt-apply-all-modules,
         update-lambda-function-image,
+        update-idp-ecs-service-image,
       ]
     if: ${{ failure() && !cancelled() }}
     runs-on: ubuntu-latest

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -54,6 +54,8 @@ module "idp_ecs" {
   task_cpu       = 1024
   task_memory    = 2048
 
+  service_use_latest_task_def = true
+
   # Scaling
   enable_autoscaling       = true
   desired_count            = 1


### PR DESCRIPTION
# Summary
Update the Staging Terraform apply workflow so that a new IdP image is only built, pushed and deployed if there have been changes to the `idp` folder.  This will fix the error we saw where the ECR image deletion policy removed an image that was in use.

Also updates the IdP service to always use the latest available task definition so that both Terraform and the ECS deploy job can manage the same ECS task definition without conflicts.