### PR TITLE
chore: upgrade Zitadel to v2.55.6

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -8,6 +8,7 @@ on:
       - "aws/**"
       - "env/common/**"
       - "env/cloud/**"
+      - "idp/**"
       - "lambda-code/**"
       - ".github/workflows/terragrunt-apply-staging.yml"
 

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -8,6 +8,7 @@ on:
       - "aws/**"
       - "env/common/**"
       - "env/cloud/**"
+      - "idp/**"
       - "lambda-code/**"
       - ".github/workflows/terragrunt-plan-staging.yml"
 

--- a/idp/docker/Dockerfile
+++ b/idp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zitadel/zitadel:v2.55.0@sha256:91f6c14d44247c7c575536a0ca6228fc0f7f6b59d8368c122f69ac9d39cd3eec
+FROM ghcr.io/zitadel/zitadel:v2.55.6@sha256:8089e7649ccae5d034581c86a2d47639c8c45d35673f4124fa01b7f0de08b06d
 
 # Copy configuration and certificates
 COPY ./*.yaml ./certificate.crt ./private.key /app/


### PR DESCRIPTION
# Summary
Upgrade to the latest patch of the 2.55.x releases: 
https://github.com/zitadel/zitadel/releases/tag/v2.55.6

Additionally, the Staging Terraform workflows have been updated to trigger when there is an `idp` folder change so that the new image can be tested and deployed.

# Related
- https://github.com/cds-snc/forms-terraform/pull/805