### PR TITLE
feat: cache the Nagware overdue response form IDs

### DIFF
--- a/aws/lambdas/inputs.tf
+++ b/aws/lambdas/inputs.tf
@@ -193,3 +193,13 @@ variable "private_subnet_ids" {
   description = "Private subnet IDs"
   type        = list(string)
 }
+
+variable "redis_port" {
+  description = "Redis port used by the Nagware function"
+  type        = number
+}
+
+variable "redis_url" {
+  description = "Redis URL used by the Nagware function.  This should not include the protocol or port."
+  type        = string
+}

--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "nagware" {
       DB_SECRET                 = var.database_secret_arn
       DB_NAME                   = var.rds_db_name
       NOTIFY_API_KEY            = var.notify_api_key_secret_arn
+      REDIS_URL                 = "redis://${var.redis_url}:${var.redis_port}"
       TEMPLATE_ID               = var.gc_template_id
       LOCALSTACK                = var.localstack_hosted
     }

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -8,7 +8,7 @@ include {
 
 
 dependencies {
-  paths = ["../network", "../rds", "../sqs", "../sns", "../kms", "../dynamodb", "../secrets", "../app", "../s3", "../ecr"]
+  paths = ["../network", "../rds", "../redis", "../sqs", "../sns", "../kms", "../dynamodb", "../secrets", "../app", "../s3", "../ecr"]
 }
 
 locals {
@@ -43,6 +43,16 @@ dependency "rds" {
     rds_cluster_arn     = null
     rds_db_name         = null
     database_secret_arn = null
+  }
+}
+
+dependency "redis" {
+  config_path                             = "../redis"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    redis_port = 6379
+    redis_url  = "mock-redis-url.0001.cache.amazonaws.com"
   }
 }
 
@@ -156,6 +166,9 @@ inputs = {
   rds_cluster_arn     = dependency.rds.outputs.rds_cluster_arn
   rds_db_name         = dependency.rds.outputs.rds_db_name
   database_secret_arn = dependency.rds.outputs.database_secret_arn
+
+  redis_port = dependency.redis.outputs.redis_port
+  redis_url  = dependency.redis.outputs.redis_url
 
   sqs_reliability_queue_arn            = dependency.sqs.outputs.sqs_reliability_queue_arn
   sqs_reliability_queue_id             = dependency.sqs.outputs.sqs_reliability_queue_id

--- a/lambda-code/nagware/lib/overdueResponseCache.ts
+++ b/lambda-code/nagware/lib/overdueResponseCache.ts
@@ -8,8 +8,8 @@ import { RedisConnector } from "./redisConnector.js";
  * when loading the user's `/forms` page. 
  */
 
-const OVERDUE_CACHE_EXPIRE_SECONDS = process.env.OVERDUE_CACHE_EXPIRE_SECONDS ?? "259200"; // 3 day default
-const OVERDUE_CACHE_KEY = process.env.OVERDUE_CACHE_KEY ?? "overdue:responses:template-ids"
+const OVERDUE_CACHE_EXPIRE_SECONDS = 259200; // 3 days
+const OVERDUE_CACHE_KEY = "overdue:responses:template-ids";
 
 export async function setOverdueResponseCache(
   formResponses: { formID: string; createdAt: number }[],
@@ -19,6 +19,6 @@ export async function setOverdueResponseCache(
   await redisConnector.client.set(
     OVERDUE_CACHE_KEY,
     JSON.stringify(formIDs),
-    { EX: parseInt(OVERDUE_CACHE_EXPIRE_SECONDS, 10) },
+    { EX: OVERDUE_CACHE_EXPIRE_SECONDS },
   );
 }

--- a/lambda-code/nagware/lib/overdueResponseCache.ts
+++ b/lambda-code/nagware/lib/overdueResponseCache.ts
@@ -1,0 +1,24 @@
+import { RedisConnector } from "./redisConnector.js";
+
+/**
+ * Handles caching of overdue form responses.  The cache expiry should be at least
+ * as long as the interval between Nagware function runs.
+ * 
+ * This cache is used by the app to reduce the number of DynamoDB calls required
+ * when loading the user's `/forms` page. 
+ */
+
+const OVERDUE_CACHE_EXPIRE_SECONDS = process.env.OVERDUE_CACHE_EXPIRE_SECONDS ?? "259200"; // 3 day default
+const OVERDUE_CACHE_KEY = process.env.OVERDUE_CACHE_KEY ?? "overdue:responses:template-ids"
+
+export async function setOverdueResponseCache(
+  formResponses: { formID: string; createdAt: number }[],
+): Promise<void> {
+  const formIDs = formResponses.map((formResponse) => formResponse.formID);
+  const redisConnector = await RedisConnector.getInstance();
+  await redisConnector.client.set(
+    OVERDUE_CACHE_KEY,
+    JSON.stringify(formIDs),
+    { EX: parseInt(OVERDUE_CACHE_EXPIRE_SECONDS, 10) },
+  );
+}

--- a/lambda-code/nagware/lib/redisConnector.ts
+++ b/lambda-code/nagware/lib/redisConnector.ts
@@ -1,0 +1,42 @@
+import { type RedisClientType, createClient } from "redis";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+export class RedisConnector {
+  private static instance: RedisConnector | undefined = undefined;
+  private static RETRY_MAX = 10;
+  private static RETRY_DELAY_STEP = 500; // milliseconds
+
+  public client: RedisClientType;
+
+  private constructor() {
+    this.client = createClient({
+      url: REDIS_URL,
+      socket: {
+        // Reconnect strategy with exponential backoff
+        reconnectStrategy: (retries: number): number | Error =>
+          retries < RedisConnector.RETRY_MAX
+            ? RedisConnector.RETRY_DELAY_STEP * retries
+            : new Error("Failed to connect to Redis"),
+      },
+    });
+    this.client
+      .on("error", (err: Error) => console.error("Redis client error:", err))
+      .on("ready", () => console.log("Redis client ready!"))
+      .on("reconnecting", () => console.log("Redis client reconnecting..."));
+  }
+
+  /**
+   * Uses the singleton promise pattern to initialize the RedisConnector class instance.
+   * This ensures that only one connection is attempted to the Redis server when the
+   * instance is first initialized, even if multiple concurrent calls are made.
+   * @returns {Promise<RedisConnector>}
+   */
+  public static async getInstance(): Promise<RedisConnector> {
+    if (RedisConnector.instance === undefined) {
+      RedisConnector.instance = new RedisConnector();
+      await RedisConnector.instance.client.connect();
+    }
+    return RedisConnector.instance;
+  }
+}

--- a/lambda-code/nagware/main.ts
+++ b/lambda-code/nagware/main.ts
@@ -4,6 +4,7 @@ import {
 } from "./lib/dynamodbDataLayer.js";
 import { getTemplateInfo } from "./lib/templates.js";
 import { notifyFormOwner } from "./lib/emailNotification.js";
+import { setOverdueResponseCache } from "./lib/overdueResponseCache.js";
 import { Handler } from "aws-lambda";
 
 type NotificationSettings = {
@@ -28,6 +29,8 @@ export const handler: Handler = async () => {
       shouldSendEmail: isSunday == false,
       shouldSendSlackNotification: isSunday,
     });
+
+    await setOverdueResponseCache(oldestFormResponseByFormID);
 
     return {
       statusCode: "SUCCESS",

--- a/lambda-code/nagware/package.json
+++ b/lambda-code/nagware/package.json
@@ -12,10 +12,11 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.430.0",
-    "@aws-sdk/lib-dynamodb": "3.430.0",
     "@aws-sdk/client-rds-data": "3.430.0",
     "@aws-sdk/client-secrets-manager": "^3.478.0",
-    "axios": "^1.6.2"
+    "@aws-sdk/lib-dynamodb": "3.430.0",
+    "axios": "^1.6.2",
+    "redis": "^4.7.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.128",

--- a/lambda-code/nagware/yarn.lock
+++ b/lambda-code/nagware/yarn.lock
@@ -884,6 +884,40 @@
   dependencies:
     tslib "^2.3.1"
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.6.0.tgz#dcf4ae1319763db6fdddd6de7f0af68a352c30ea"
+  integrity sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
+  integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
+
+"@redis/json@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.7.tgz#016257fcd933c4cbcb9c49cde8a0961375c6893b"
+  integrity sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==
+
+"@redis/search@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.2.0.tgz#50976fd3f31168f585666f7922dde111c74567b8"
+  integrity sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==
+
+"@redis/time-series@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.1.0.tgz#cba454c05ec201bd5547aaf55286d44682ac8eb5"
+  integrity sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==
+
 "@smithy/abort-controller@^2.0.11":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-2.0.11.tgz#e1d96a2ecbf103d0b075a7456ce3afeeb9f76a87"
@@ -1590,6 +1624,11 @@ bowser@^2.11.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -1623,6 +1662,11 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -1651,6 +1695,18 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+redis@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.7.0.tgz#b401787514d25dd0cfc22406d767937ba3be55d6"
+  integrity sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.6.0"
+    "@redis/graph" "1.1.1"
+    "@redis/json" "1.0.7"
+    "@redis/search" "1.2.0"
+    "@redis/time-series" "1.1.0"
 
 strnum@^1.0.5:
   version "1.0.5"
@@ -1681,3 +1737,8 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+yallist@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
# Summary
Update the Nagware function so that it caches the overdue response form IDs in Redis.  

This is being done to reduce strain on the DynamoDB table when loading a user's `/forms` page.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4234