### PR TITLE
feat: add CreatedAt field to Vault CONF# items

### DIFF
--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -149,6 +149,7 @@ export async function saveToVault(
             FormID: formID,
             NAME_OR_CONF: `CONF#${confirmationCode}`,
             Name: name,
+            CreatedAt: Number(createdAt),
             ConfirmationCode: confirmationCode,
           },
         },

--- a/lambda-code/submission/main.ts
+++ b/lambda-code/submission/main.ts
@@ -91,7 +91,7 @@ const saveSubmission = async (submissionId: string, formData: AnyObject): Promis
     const securityAttribute = formData.securityAttribute ?? "Protected A";
     delete formData.securityAttribute;
 
-    const timeStamp = Date.now().toString();
+    const timeStamp = Date.now();
 
     const alteredFormDataAsString = JSON.stringify(formData);
 
@@ -114,7 +114,7 @@ const saveSubmission = async (submissionId: string, formData: AnyObject): Promis
           SendReceipt: "unknown",
           FormSubmissionLanguage: formData.language,
           FormData: alteredFormDataAsString,
-          CreatedAt: Number(timeStamp),
+          CreatedAt: timeStamp,
           SecurityAttribute: securityAttribute,
           FormSubmissionHash: formResponsesAsHash,
         },


### PR DESCRIPTION
# Summary | Résumé

Part 1 of https://github.com/cds-snc/platform-forms-client/issues/4287

Context: With the addition of the new StatusCreatedAt GSI for the API we will need to get the submission `CreatedAt` value on `CONF#` items in DynamoDB for the web application to be able to get it and update the new `Status#CreatedAt` field during submission confirmation.

- Adds CreatedAt field to Vault `CONF#` items