### PR TITLE
feat: run Nagware every day

### DIFF
--- a/aws/lambdas/cloudwatch.tf
+++ b/aws/lambdas/cloudwatch.tf
@@ -28,8 +28,8 @@ resource "aws_cloudwatch_event_rule" "form_archiver_lambda_trigger" {
 
 resource "aws_cloudwatch_event_rule" "nagware_lambda_trigger" {
   name                = "nagware-lambda-trigger"
-  description         = "Fires every Tuesday, Thursday and Sunday at 5am EST"
-  schedule_expression = "cron(0 10 ? * TUE,THU,SUN *)" # 5 AM EST = 10 AM UTC ; every Tuesday, Thursday and Sunday
+  description         = "Fires every day at 5am EST"
+  schedule_expression = "cron(0 10 * * ? *)" # 5 AM EST = 10 AM UTC
 }
 
 resource "aws_cloudwatch_event_target" "audit_logs_archiver_lambda_trigger" {

--- a/lambda-code/nagware/lib/overdueResponseCache.ts
+++ b/lambda-code/nagware/lib/overdueResponseCache.ts
@@ -8,7 +8,7 @@ import { RedisConnector } from "./redisConnector.js";
  * when loading the user's `/forms` page. 
  */
 
-const OVERDUE_CACHE_EXPIRE_SECONDS = 259200; // 3 days
+const OVERDUE_CACHE_EXPIRE_SECONDS = 86400; // 1 day
 const OVERDUE_CACHE_KEY = "overdue:responses:template-ids";
 
 export async function setOverdueResponseCache(

--- a/lambda-code/nagware/main.ts
+++ b/lambda-code/nagware/main.ts
@@ -23,10 +23,12 @@ export const handler: Handler = async () => {
   try {
     const oldestFormResponseByFormID = await findOldestFormResponseByFormID();
 
-    const isSunday = new Date().getDay() == 0; // 0 is Sunday
+    const dayOfWeek = new Date().getDay();
+    const isSunday = dayOfWeek == 0;
+    const isTuesdayOrThursday = dayOfWeek == 2 || dayOfWeek == 4;
 
     await nagOrDelete(oldestFormResponseByFormID, {
-      shouldSendEmail: isSunday == false,
+      shouldSendEmail: isTuesdayOrThursday,
       shouldSendSlackNotification: isSunday,
     });
 


### PR DESCRIPTION
# Summary
Update the Nagware function schedule so that it run everyday. This is being done so that the Redis cache of overdue responses is kept more up-to-date.

The logic of the Nagware has also been updated so that emails are still only sent Tuesday/Thursday and Slack messages posted on Sunday.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4234