### PR TITLE
fix: increase blanket WAF ACL rate limit

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -24,7 +24,7 @@ resource "aws_wafv2_rule_group" "rate_limiters_group" {
 
     statement {
       rate_based_statement {
-        limit              = 2000
+        limit              = 2500
         aggregate_key_type = "IP"
 
       }


### PR DESCRIPTION
# Summary
Update the global request limit to 2,500 requests in a 5 minute period for the app's load balancer.  This is being done to handle traffic from large networks where multiple people will share the same IP address.