### PR TITLE
Fix: Allow API to access RDS connection url secret

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -139,7 +139,8 @@ data "aws_iam_policy_document" "api_ecs_secrets_manager" {
 
     resources = [
       var.zitadel_application_key_secret_arn,
-      var.freshdesk_api_key_secret_arn
+      var.freshdesk_api_key_secret_arn,
+      var.rds_connection_url_secret_arn
     ]
   }
 }

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -69,3 +69,9 @@ variable "freshdesk_api_key_secret_arn" {
   type        = string
   sensitive   = true
 }
+
+variable "rds_connection_url_secret_arn"{
+  description = "The RDS connection URL secret used by the ECS task"
+  type = string
+  sensitive = true
+}

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -70,8 +70,8 @@ variable "freshdesk_api_key_secret_arn" {
   sensitive   = true
 }
 
-variable "rds_connection_url_secret_arn"{
+variable "rds_connection_url_secret_arn" {
   description = "The RDS connection URL secret used by the ECS task"
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -53,9 +53,9 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    rds_cluster_identifier  = "forms-mock-db-cluster"
-    rds_cluster_endpoint    = "localhost"
-    rds_db_name             = "default"
+    rds_cluster_identifier = "forms-mock-db-cluster"
+    rds_cluster_endpoint   = "localhost"
+    rds_db_name            = "default"
   }
 }
 
@@ -149,11 +149,11 @@ dependency "idp" {
     ecs_idp_cloudwatch_log_group_name = "/aws/ecs/idp/zitadel"
     ecs_idp_service_name              = "zitadel"
     lb_idp_arn_suffix                 = "loadbalancer/app/idp/1234567890123456"
-    lb_idp_target_groups_arn_suffix   = {
+    lb_idp_target_groups_arn_suffix = {
       HTTP1 = "targetgroup/idp-tg-http1-abc/1234567890123456"
       HTTP2 = "targetgroup/idp-tg-http2-abc/1234567890123456"
     }
-    rds_idp_cluster_identifier        = "idp-cluster"
+    rds_idp_cluster_identifier = "idp-cluster"
   }
 }
 
@@ -163,7 +163,7 @@ dependency "dynamodb" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    dynamodb_audit_logs_arn        = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
+    dynamodb_audit_logs_arn = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
   }
 }
 
@@ -197,9 +197,9 @@ inputs = {
   sqs_reliability_deadletter_queue_arn = dependency.sqs.outputs.sqs_reliability_deadletter_queue_arn
   sqs_audit_log_deadletter_queue_arn   = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn
 
-  ecs_cloudwatch_log_group_name                    = dependency.app.outputs.ecs_cloudwatch_log_group_name
-  ecs_cluster_name                                 = dependency.app.outputs.ecs_cluster_name
-  ecs_service_name                                 = dependency.app.outputs.ecs_service_name
+  ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
+  ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name
+  ecs_service_name              = dependency.app.outputs.ecs_service_name
 
   lambda_audit_logs_log_group_name               = dependency.lambdas.outputs.lambda_audit_logs_log_group_name
   lambda_audit_logs_archiver_log_group_name      = dependency.lambdas.outputs.lambda_audit_logs_archiver_log_group_name
@@ -239,13 +239,13 @@ inputs = {
   rds_idp_cluster_identifier        = local.feature_flag_idp == "true" ? dependency.idp.outputs.rds_idp_cluster_identifier : ""
   rds_idp_cpu_maxiumum              = 80
 
-  dynamodb_audit_logs_arn           = dependency.dynamodb.outputs.dynamodb_audit_logs_arn
-  kms_key_dynamodb_arn              = dependency.kms.outputs.kms_key_dynamodb_arn
+  dynamodb_audit_logs_arn = dependency.dynamodb.outputs.dynamodb_audit_logs_arn
+  kms_key_dynamodb_arn    = dependency.kms.outputs.kms_key_dynamodb_arn
 
-  private_subnet_ids                = dependency.network.outputs.private_subnet_ids
-  connector_security_group_id       = dependency.network.outputs.connector_security_group_id
-  rds_cluster_endpoint              = dependency.rds.outputs.rds_cluster_endpoint
-  rds_db_name                       = dependency.rds.outputs.rds_db_name
+  private_subnet_ids          = dependency.network.outputs.private_subnet_ids
+  connector_security_group_id = dependency.network.outputs.connector_security_group_id
+  rds_cluster_endpoint        = dependency.rds.outputs.rds_cluster_endpoint
+  rds_db_name                 = dependency.rds.outputs.rds_db_name
 
 }
 

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -102,6 +102,10 @@ dependency "rds" {
   }
 }
 
+locals {
+  zitadel_domain = get_env("ZITADEL_PROVIDER", "https://localhost")
+}
+
 inputs = {
   api_image_tag               = "latest"
   api_image_ecr_url           = dependency.ecr.outputs.ecr_repository_url_api

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -100,10 +100,6 @@ dependency "rds" {
   mock_outputs = {
   database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:database_url"
   }
-
-  locals {
-    zitadel_domain = get_env("ZITADEL_PROVIDER", "https://localhost")
-  }
 }
 
 inputs = {

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../kms", "../network", "../dynamodb", "../load_balancer", "../ecr", "../redis", "../s3", "../app", "../secrets"]
+  paths = ["../kms", "../network", "../dynamodb", "../load_balancer", "../ecr", "../redis", "../s3", "../app", "../secrets", "../rds"]
 }
 
 dependency "app" {
@@ -93,6 +93,14 @@ dependency "secrets" {
   }
 }
 
+dependency "rds" {
+config_path =" ../rds"
+mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+mock_outputs_merge_strategy_with_state = "shallow"
+mock_outputs = {
+  database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:database_url"
+}
+
 locals {
   zitadel_domain = get_env("ZITADEL_PROVIDER", "https://localhost")
 }
@@ -116,6 +124,8 @@ inputs = {
   zitadel_application_key_secret_arn = dependency.secrets.outputs.zitadel_application_key_secret_arn
   
   freshdesk_api_key_secret_arn = dependency.secrets.outputs.freshdesk_api_key_secret_arn
+
+  rds_connection_url_secret_arn = dependency.rds.outputs.database_url_secret_arn
 }
 
 include {

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -88,17 +88,17 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-      zitadel_application_key_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:zitadel_application_key"
-      freshdesk_api_key_secret_arn       = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:freshdesk_api_key_secret"
+    zitadel_application_key_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:zitadel_application_key"
+    freshdesk_api_key_secret_arn       = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:freshdesk_api_key_secret"
   }
 }
 
 dependency "rds" {
-  config_path = "../rds"
+  config_path                             = "../rds"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs_merge_strategy_with_state = "shallow"
+  mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-  database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:database_url"
+    database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:database_url"
   }
 }
 
@@ -113,17 +113,17 @@ inputs = {
   security_group_id_api_ecs   = dependency.network.outputs.api_ecs_security_group_id
   lb_target_group_arn_api_ecs = dependency.load_balancer.outputs.lb_target_group_api_arn
   private_subnet_ids          = dependency.network.outputs.private_subnet_ids
-  
+
   kms_key_dynamodb_arn      = dependency.kms.outputs.kms_key_dynamodb_arn
   dynamodb_vault_arn        = dependency.dynamodb.outputs.dynamodb_vault_arn
   s3_vault_file_storage_arn = dependency.s3.outputs.vault_file_storage_arn
-  
+
   redis_port = dependency.redis.outputs.redis_port
   redis_url  = dependency.redis.outputs.redis_url
 
   zitadel_domain                     = local.zitadel_domain
   zitadel_application_key_secret_arn = dependency.secrets.outputs.zitadel_application_key_secret_arn
-  
+
   freshdesk_api_key_secret_arn = dependency.secrets.outputs.freshdesk_api_key_secret_arn
 
   rds_connection_url_secret_arn = dependency.rds.outputs.database_url_secret_arn

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -94,7 +94,7 @@ dependency "secrets" {
 }
 
 dependency "rds" {
-  config_path =" ../rds"
+  config_path = "../rds"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state = "shallow"
   mock_outputs = {

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -94,15 +94,16 @@ dependency "secrets" {
 }
 
 dependency "rds" {
-config_path =" ../rds"
-mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-mock_outputs_merge_strategy_with_state = "shallow"
-mock_outputs = {
+  config_path =" ../rds"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state = "shallow"
+  mock_outputs = {
   database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:123456789012:secret:database_url"
-}
+  }
 
-locals {
-  zitadel_domain = get_env("ZITADEL_PROVIDER", "https://localhost")
+  locals {
+    zitadel_domain = get_env("ZITADEL_PROVIDER", "https://localhost")
+  }
 }
 
 inputs = {

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -128,7 +128,7 @@ dependency "s3" {
 }
 
 locals {
-  zitadel_provider                            = get_env("ZITADEL_PROVIDER", "https://localhost")
+  zitadel_provider = get_env("ZITADEL_PROVIDER", "https://localhost")
 }
 
 inputs = {
@@ -184,10 +184,10 @@ inputs = {
   zitadel_administration_key_secret_arn   = dependency.secrets.outputs.zitadel_administration_key_secret_arn
   sentry_api_key_secret_arn               = dependency.secrets.outputs.sentry_api_key_secret_arn
 
-  vault_file_storage_arn = dependency.s3.outputs.vault_file_storage_arn
-  vault_file_storage_id = dependency.s3.outputs.vault_file_storage_id
+  vault_file_storage_arn       = dependency.s3.outputs.vault_file_storage_arn
+  vault_file_storage_id        = dependency.s3.outputs.vault_file_storage_id
   reliability_file_storage_arn = dependency.s3.outputs.reliability_file_storage_arn
-  reliability_file_storage_id = dependency.s3.outputs.reliability_file_storage_id
+  reliability_file_storage_id  = dependency.s3.outputs.reliability_file_storage_id
 
   zitadel_provider = local.zitadel_provider
 }

--- a/env/cloud/idp/terragrunt.hcl
+++ b/env/cloud/idp/terragrunt.hcl
@@ -23,7 +23,7 @@ dependency "network" {
   mock_outputs = {
     idp_db_security_group_id  = "sg-db"
     idp_ecs_security_group_id = "sg-ecs"
-    idp_lb_security_group_id  = "sg-lb"    
+    idp_lb_security_group_id  = "sg-lb"
     private_subnet_ids        = ["prv-1", "prv-2"]
     public_subnet_ids         = ["pub-1", "pub-2"]
     vpc_id                    = "vpc-id"

--- a/env/cloud/network/terragrunt.hcl
+++ b/env/cloud/network/terragrunt.hcl
@@ -3,8 +3,8 @@ terraform {
 }
 
 inputs = {
-  vpc_cidr_block         = "172.16.0.0/16"
-  vpc_name               = "forms"
+  vpc_cidr_block = "172.16.0.0/16"
+  vpc_name       = "forms"
 }
 
 include {

--- a/env/cloud/pr_review/terragrunt.hcl
+++ b/env/cloud/pr_review/terragrunt.hcl
@@ -7,7 +7,7 @@ dependencies {
 }
 
 dependency "lambdas" {
-  config_path = "../lambdas"
+  config_path                             = "../lambdas"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs_merge_strategy_with_state  = "shallow"

--- a/env/cloud/secrets/terragrunt.hcl
+++ b/env/cloud/secrets/terragrunt.hcl
@@ -28,6 +28,6 @@ inputs = {
   zitadel_administration_key   = local.zitadel_administration_key
   zitadel_application_key      = local.zitadel_application_key
   # Overwritten in GitHub Actions by TFVARS
-  rds_db_password              = local.rds_db_password
-  sentry_api_key               = local.sentry_api_key
+  rds_db_password = local.rds_db_password
+  sentry_api_key  = local.sentry_api_key
 }


### PR DESCRIPTION
# Summary | Résumé
Allow API to access the RDS connection URL stored in secrets manager