### PR TITLE
fix: remove OK actions from critical alarms

### DIFF
--- a/aws/alarms/cloudwatch_api.tf
+++ b/aws/alarms/cloudwatch_api.tf
@@ -95,9 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "api_lb_healthy_host_count" {
   period              = "60"
   statistic           = "Maximum"
   treat_missing_data  = "notBreaching"
-
-  alarm_actions = [var.sns_topic_alert_warning_arn]
-  ok_actions    = [var.sns_topic_alert_ok_arn]
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   dimensions = {
     LoadBalancer = var.lb_api_arn_suffix

--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -66,7 +66,6 @@ resource "aws_cloudwatch_metric_alarm" "ELB_healthy_hosts" {
   evaluation_periods  = "1"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_topic_alert_critical_arn]
-  ok_actions          = [var.sns_topic_alert_ok_arn]
 
   metric_query {
     id          = "healthy_hosts"

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -95,9 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_healthy_host_count" {
   period              = "60"
   statistic           = "Maximum"
   treat_missing_data  = "notBreaching"
-
-  alarm_actions = [var.sns_topic_alert_warning_arn]
-  ok_actions    = [var.sns_topic_alert_ok_arn]
+  alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   dimensions = {
     LoadBalancer = var.lb_idp_arn_suffix


### PR DESCRIPTION
# Summary
Remove the `ok_action` from the HealthyHostCount critical alarms.  The notify Slack function currently treats the `SEV1` string as an indicator that an OpsGenie page should occur.

⚠️ Note that I've pre-emptively removed the `ok_action` from the API and IdP alarms since they will become `SEV1` alarms once they go to prod.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4233