### PR TITLE
fix: use maximum CPU/memory stat for alarms

### DIFF
--- a/aws/alarms/cloudwatch_api.tf
+++ b/aws/alarms/cloudwatch_api.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "api_cpu_utilization_high_warn" {
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_cpu_utilization_high
   treat_missing_data  = "notBreaching"
 
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "api_memory_utilization_high_warn" {
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_memory_utilization_high
   treat_missing_data  = "notBreaching"
 

--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "forms_cpu_utilization_high_warn" {
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_cpu_utilization_high
   alarm_description   = "End User Forms Warning - High CPU usage has been detected."
 
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "forms_memory_utilization_high_warn" {
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_memory_utilization_high
   alarm_description   = "End User Forms Warning - High memory usage has been detected."
 

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_cpu_utilization_high_warn" {
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_cpu_utilization_high
   treat_missing_data  = "notBreaching"
 
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_memory_utilization_high_warn" {
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
   period              = "120"
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = var.threshold_ecs_memory_utilization_high
   treat_missing_data  = "notBreaching"
 


### PR DESCRIPTION
# Summary
Update the App, API and IdP ECS CPU and memory alarms to use the `Maximum` statistic rather than `Average`.

This will make the alarms more responsive to individual ECS tasks that are overloaded.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4233