### PR TITLE
feat: add IPv4 blocklist rule to App, IdP WAF ACLs

### DIFF
--- a/aws/idp/inputs.tf
+++ b/aws/idp/inputs.tf
@@ -55,6 +55,11 @@ variable "security_group_idp_lb_id" {
   type        = string
 }
 
+variable "waf_ipv4_blocklist_arn" {
+  description = "The WAF ACL IPv4 blocklist ARN."
+  type        = string
+}
+
 variable "zitadel_admin_password" {
   description = "Zitadel administrator password."
   type        = string

--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -290,6 +290,27 @@ resource "aws_wafv2_web_acl" "idp" {
     }
   }
 
+  rule {
+    name     = "BlockedIPv4"
+    priority = 70
+
+    action {
+      block {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = var.waf_ipv4_blocklist_arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockedIPv4"
+      sampled_requests_enabled   = true
+    }
+  }
+
   tags = local.common_tags
 }
 

--- a/aws/load_balancer/outputs.tf
+++ b/aws/load_balancer/outputs.tf
@@ -52,3 +52,8 @@ output "kinesis_firehose_waf_logs_arn" {
   description = "Kinesis Firehose delivery stream ARN used to collect and write WAF ACL logs to an S3 bucket."
   value       = var.feature_flag_idp ? aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn : ""
 }
+
+output "waf_ipv4_blocklist_arn" {
+  description = "WAF ACL IPv4 blocklist"
+  value       = aws_wafv2_ip_set.ipv4_blocklist.arn
+}

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -328,6 +328,27 @@ resource "aws_wafv2_web_acl" "forms_acl" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name     = "BlockedIPv4"
+    priority = 80
+
+    action {
+      block {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.ipv4_blocklist.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockedIPv4"
+      sampled_requests_enabled   = true
+    }
+  }
 }
 
 // Matches the login paths for cognito /api/auth/signin/cognito OR /api/auth/callback/cognito
@@ -538,5 +559,19 @@ resource "aws_wafv2_regex_pattern_set" "valid_maintenance_mode_uri_paths" {
 
   regular_expression {
     regex_string = "^\\/(index.html|index-fr.html|style.css|site-unavailable.svg|favicon.ico)?$"
+  }
+}
+
+resource "aws_wafv2_ip_set" "ipv4_blocklist" {
+  name               = "ipv4_blocklist"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+
+  addresses = []
+
+  lifecycle {
+    ignore_changes = [
+      addresses
+    ]
   }
 }

--- a/env/cloud/idp/terragrunt.hcl
+++ b/env/cloud/idp/terragrunt.hcl
@@ -47,6 +47,7 @@ dependency "load_balancer" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     kinesis_firehose_waf_logs_arn = "arn:aws:firehose:ca-central-1:123456789012:deliverystream/waf-logs"
+    waf_ipv4_blocklist_arn        = "arn:aws:wafv2:ca-central-1:123456789012:ipset/mock-ip-blocklist/abcd1234-efgh5678-ijkl9012"
   }
 }
 
@@ -64,6 +65,7 @@ inputs = {
   zitadel_image_tag     = "latest" # TODO: pin to specific tag for prod
 
   kinesis_firehose_waf_logs_arn = dependency.load_balancer.outputs.kinesis_firehose_waf_logs_arn
+  waf_ipv4_blocklist_arn        = dependency.load_balancer.outputs.waf_ipv4_blocklist_arn
 
   # 1 ACU ~= 2GB of memory and 1vCPU
   idp_database_min_acu = 1


### PR DESCRIPTION
# Summary
Add an IPv4 blocklist that will have malicious IPs temporarily added to it when attacks are detected.

Add a `block` rule to the App, API and IdP WAF ACLs that will block IP addresses that are part of this blocklist.

# TODO
The following will be added in a future PR:
- Lambda function that runs on a schedule to check the WAF ACL logs for malicious IP addresses.  The IP blocklist will then be updated with these IP addresses.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4256