### PR TITLE
feature: API Audit Logs

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -140,7 +140,7 @@ resource "aws_iam_role_policy" "athena_dynamodb_policy" {
           "dynamodb:Scan",
           "dynamodb:PartiQLSelect"
         ],
-        "Resource" : ["${var.dynamodb_audit_logs_arn}", "${lower(var.dynamodb_audit_logs_arn)}"]
+        "Resource" : ["${var.dynamodb_app_audit_logs_arn}", "${lower(var.dynamodb_app_audit_logs_arn)}"]
         "Effect" : "Allow"
       },
       {

--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -174,7 +174,7 @@ resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
       unit        = "Count"
 
       dimensions = {
-        QueueName = var.sqs_audit_log_deadletter_queue_arn
+        QueueName = var.sqs_app_audit_log_deadletter_queue_arn
       }
     }
   }
@@ -190,7 +190,7 @@ resource "aws_cloudwatch_metric_alarm" "audit_log_dead_letter_queue_warn" {
       unit        = "Count"
 
       dimensions = {
-        QueueName = var.sqs_audit_log_deadletter_queue_arn
+        QueueName = var.sqs_app_audit_log_deadletter_queue_arn
       }
     }
   }

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -251,7 +251,7 @@ variable "ecr_repository_url_notify_slack_lambda" {
   type        = string
 }
 
-variable "dynamodb_audit_logs_arn" {
+variable "dynamodb_app_audit_logs_arn" {
   description = "Audit Logs table ARN"
   type        = string
 }

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -201,7 +201,7 @@ variable "sqs_reliability_deadletter_queue_arn" {
   type        = string
 }
 
-variable "sqs_audit_log_deadletter_queue_arn" {
+variable "sqs_app_audit_log_deadletter_queue_arn" {
   description = "ARN of the Audit Log queue's SQS Dead Letter Queue"
   type        = string
 }

--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -58,7 +58,8 @@ module "api_ecs" {
     data.aws_iam_policy_document.api_ecs_kms_vault.json,
     data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,
     data.aws_iam_policy_document.api_ecs_s3_vault.json,
-    data.aws_iam_policy_document.api_ecs_secrets_manager_runtime.json
+    data.aws_iam_policy_document.api_ecs_secrets_manager_runtime.json,
+    data.aws_iam_policy_document.api_sqs.json
   ]
 
   task_exec_role_policy_documents = [
@@ -155,6 +156,19 @@ data "aws_iam_policy_document" "api_ecs_secrets_manager" {
     resources = [
       var.zitadel_application_key_secret_arn,
       var.freshdesk_api_key_secret_arn
+    ]
+  }
+}
+data "aws_iam_policy_document" "api_sqs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      var.sqs_api_audit_log_queue_arn
     ]
   }
 }

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -75,3 +75,8 @@ variable "rds_connection_url_secret_arn" {
   type        = string
   sensitive   = true
 }
+variable "sqs_api_audit_log_queue_arn" {
+  description = "SQS audit log queue ARN"
+  type        = string
+}
+

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -42,7 +42,7 @@ data "template_file" "form_viewer_task" {
     email_address_contact_us        = var.email_address_contact_us
     email_address_support           = var.email_address_support
     reprocess_submission_queue      = var.sqs_reprocess_submission_queue_id
-    audit_log_queue_url             = var.sqs_audit_log_queue_id
+    audit_log_queue_url             = var.sqs_app_audit_log_queue_id
     zitadel_provider                = var.zitadel_provider
     zitadel_administration_key      = var.zitadel_administration_key_secret_arn
     sentry_api_key                  = var.sentry_api_key_secret_arn

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -142,7 +142,7 @@ data "aws_iam_policy_document" "forms_sqs" {
 
     resources = [
       var.sqs_reprocess_submission_queue_arn,
-      var.sqs_audit_log_queue_arn
+      var.sqs_app_audit_log_queue_arn
     ]
   }
 }

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -173,12 +173,12 @@ variable "sqs_reprocess_submission_queue_id" {
   type        = string
 }
 
-variable "sqs_audit_log_queue_arn" {
+variable "sqs_app_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
   type        = string
 }
 
-variable "sqs_audit_log_queue_id" {
+variable "sqs_app_audit_log_queue_id" {
   description = "SQS audit log queue URL"
   type        = string
 }

--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -129,3 +129,56 @@ resource "aws_dynamodb_table" "audit_logs" {
     enabled = var.env == "local" ? false : true
   }
 }
+
+resource "aws_dynamodb_table" "api_audit_logs" {
+  name                        = "ApiAuditLogs"
+  billing_mode                = "PAY_PER_REQUEST"
+  hash_key                    = "UserID"
+  range_key                   = "Event#SubjectID#TimeStamp"
+  deletion_protection_enabled = true
+  stream_enabled              = false # Can be removed in the future when this gets applied to production
+
+  attribute {
+    name = "UserID"
+    type = "S"
+  }
+
+  attribute {
+    name = "Event#SubjectID#TimeStamp"
+    type = "S"
+  }
+
+  attribute {
+    name = "TimeStamp"
+    type = "N"
+  }
+
+  attribute {
+    name = "Status"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "UserByTime"
+    hash_key        = "UserID"
+    range_key       = "TimeStamp"
+    projection_type = "KEYS_ONLY"
+  }
+
+  global_secondary_index {
+    name            = "StatusByTimestamp"
+    hash_key        = "Status"
+    range_key       = "TimeStamp"
+    projection_type = "ALL"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_dynamodb_arn
+  }
+
+  point_in_time_recovery {
+    enabled = var.env == "local" ? false : true
+  }
+}
+

--- a/aws/dynamodb/outputs.tf
+++ b/aws/dynamodb/outputs.tf
@@ -18,12 +18,22 @@ output "dynamodb_vault_stream_arn" {
   value       = aws_dynamodb_table.vault.stream_arn
 }
 
-output "dynamodb_audit_logs_arn" {
+output "dynamodb_app_audit_logs_arn" {
   description = "Audit Logs table ARN"
   value       = aws_dynamodb_table.audit_logs.arn
 }
 
-output "dynamodb_audit_logs_table_name" {
+output "dynamodb_app_audit_logs_table_name" {
   description = "Audit Logs table name"
   value       = aws_dynamodb_table.audit_logs.name
+}
+
+output "dynamodb_api_audit_logs_arn" {
+  description = "Audit Logs table ARN"
+  value       = aws_dynamodb_table.api_audit_logs.arn
+}
+
+output "dynamodb_api_audit_logs_table_name" {
+  description = "Audit Logs table name"
+  value       = aws_dynamodb_table.api_audit_logs.name
 }

--- a/aws/lambdas/audit_log.tf
+++ b/aws/lambdas/audit_log.tf
@@ -18,6 +18,8 @@ resource "aws_lambda_function" "audit_logs" {
     variables = {
       REGION     = var.region
       LOCALSTACK = var.localstack_hosted
+      APP_AUDIT_LOGS_SQS_ARN = var.sqs_app_audit_log_queue_arn
+      API_AUDIT_LOGS_SQS_ARN = var.sqs_api_audit_log_queue_arn
     }
   }
 
@@ -31,8 +33,17 @@ resource "aws_lambda_function" "audit_logs" {
   }
 }
 
-resource "aws_lambda_event_source_mapping" "audit_logs" {
+resource "aws_lambda_event_source_mapping" "app_audit_logs" {
   event_source_arn                   = var.sqs_app_audit_log_queue_arn
+  function_name                      = aws_lambda_function.audit_logs.arn
+  function_response_types            = ["ReportBatchItemFailures"]
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 30
+  enabled                            = true
+}
+
+resource "aws_lambda_event_source_mapping" "api_audit_logs" {
+  event_source_arn                   = var.sqs_api_audit_log_queue_arn
   function_name                      = aws_lambda_function.audit_logs.arn
   function_response_types            = ["ReportBatchItemFailures"]
   batch_size                         = 10

--- a/aws/lambdas/audit_log.tf
+++ b/aws/lambdas/audit_log.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "audit_logs" {
 }
 
 resource "aws_lambda_event_source_mapping" "audit_logs" {
-  event_source_arn                   = var.sqs_audit_log_queue_arn
+  event_source_arn                   = var.sqs_app_audit_log_queue_arn
   function_name                      = aws_lambda_function.audit_logs.arn
   function_response_types            = ["ReportBatchItemFailures"]
   batch_size                         = 10

--- a/aws/lambdas/audit_logs_archiver.tf
+++ b/aws/lambdas/audit_logs_archiver.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "audit_logs_archiver" {
     variables = {
       REGION                               = var.region
       LOCALSTACK                           = var.localstack_hosted
-      AUDIT_LOGS_DYNAMODB_TABLE_NAME       = var.dynamodb_audit_logs_table_name
+      AUDIT_LOGS_DYNAMODB_TABLE_NAME       = var.dynamodb_app_audit_logs_table_name
       AUDIT_LOGS_ARCHIVE_STORAGE_S3_BUCKET = var.audit_logs_archive_storage_id
     }
   }

--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -135,8 +135,10 @@ data "aws_iam_policy_document" "lambda_dynamodb" {
       var.dynamodb_vault_arn,
       "${var.dynamodb_vault_arn}/index/*",
       var.dynamodb_vault_stream_arn,
-      var.dynamodb_audit_logs_arn,
-      "${var.dynamodb_audit_logs_arn}/index/*"
+      var.dynamodb_app_audit_logs_arn,
+      "${var.dynamodb_app_audit_logs_arn}/index/*",
+      var.dynamodb_api_audit_logs_arn,
+      "${var.dynamodb_api_audit_logs_arn}/index/*"
     ]
   }
 }

--- a/aws/lambdas/inputs.tf
+++ b/aws/lambdas/inputs.tf
@@ -44,7 +44,7 @@ variable "sqs_reprocess_submission_queue_arn" {
   type        = string
 }
 
-variable "sqs_audit_log_queue_arn" {
+variable "sqs_app_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
   type        = string
 }

--- a/aws/lambdas/inputs.tf
+++ b/aws/lambdas/inputs.tf
@@ -49,6 +49,11 @@ variable "sqs_app_audit_log_queue_arn" {
   type        = string
 }
 
+variable "sqs_api_audit_log_queue_arn" {
+  description = "SQS Api audit log queue ARN"
+  type        = string
+}
+
 variable "kms_key_cloudwatch_arn" {
   description = "CloudWatch KMS key ARN, used by the ECS task's CloudWatch log group"
   type        = string
@@ -79,13 +84,23 @@ variable "dynamodb_relability_queue_arn" {
   type        = string
 }
 
-variable "dynamodb_audit_logs_arn" {
+variable "dynamodb_app_audit_logs_arn" {
   description = "Audit Logs table ARN"
   type        = string
 }
 
-variable "dynamodb_audit_logs_table_name" {
+variable "dynamodb_app_audit_logs_table_name" {
   description = "Audit Logs DynamodDB table name"
+  type        = string
+}
+
+variable "dynamodb_api_audit_logs_arn" {
+  description = "API Audit Logs table ARN"
+  type        = string
+}
+
+variable "dynamodb_api_audit_logs_table_name" {
+  description = "API Audit Logs DynamodDB table name"
   type        = string
 }
 

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -28,14 +28,24 @@ output "sqs_reliability_deadletter_queue_arn" {
   value       = aws_sqs_queue.reliability_deadletter_queue.name
 }
 
-output "sqs_audit_log_queue_arn" {
+output "sqs_app_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
-  value       = aws_sqs_queue.audit_log_queue.arn
+  value       = aws_sqs_queue.app_audit_log_queue.arn
 }
 
-output "sqs_audit_log_queue_id" {
+output "sqs_app_audit_log_queue_id" {
   description = "SQS audit log queue URL"
-  value       = aws_sqs_queue.audit_log_queue.id
+  value       = aws_sqs_queue.app_audit_log_queue.id
+}
+
+output "sqs_api_audit_log_queue_arn" {
+  description = "SQS audit log queue ARN"
+  value       = aws_sqs_queue.api_audit_log_queue.arn
+}
+
+output "sqs_api_audit_log_queue_id" {
+  description = "SQS audit log queue URL"
+  value       = aws_sqs_queue.api_audit_log_queue.id
 }
 
 output "sqs_audit_log_deadletter_queue_arn" {

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -30,12 +30,12 @@ output "sqs_reliability_deadletter_queue_arn" {
 
 output "sqs_app_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
-  value       = aws_sqs_queue.app_audit_log_queue.arn
+  value       = aws_sqs_queue.audit_log_queue.arn
 }
 
 output "sqs_app_audit_log_queue_id" {
   description = "SQS audit log queue URL"
-  value       = aws_sqs_queue.app_audit_log_queue.id
+  value       = aws_sqs_queue.audit_log_queue.id
 }
 
 output "sqs_api_audit_log_queue_arn" {
@@ -48,8 +48,12 @@ output "sqs_api_audit_log_queue_id" {
   value       = aws_sqs_queue.api_audit_log_queue.id
 }
 
-output "sqs_audit_log_deadletter_queue_arn" {
+output "sqs_app_audit_log_deadletter_queue_arn" {
   description = "Audit Log queues dead-letter queue ARN"
   value       = aws_sqs_queue.audit_log_deadletter_queue.arn
 }
 
+output "sqs_api_audit_log_deadletter_queue_arn" {
+  description = "Audit Log queues dead-letter queue ARN"
+  value       = aws_sqs_queue.api_audit_log_deadletter_queue.arn
+}

--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -61,8 +61,8 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
 
 # App Audit Log Queue
 
-resource "aws_sqs_queue" "app_audit_log_queue" {
-  name                       = "app_audit_log_queue"
+resource "aws_sqs_queue" "audit_log_queue" {
+  name                       = "audit_log_queue"
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 172800 // 2 days
@@ -75,18 +75,18 @@ resource "aws_sqs_queue" "app_audit_log_queue" {
   kms_data_key_reuse_period_seconds = 300
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.app_audit_log_deadletter_queue.arn
+    deadLetterTargetArn = aws_sqs_queue.audit_log_deadletter_queue.arn
     maxReceiveCount     = 5
   })
 
   redrive_allow_policy = jsonencode({
     redrivePermission = "byQueue",
-    sourceQueueArns   = [aws_sqs_queue.app_audit_log_deadletter_queue.arn]
+    sourceQueueArns   = [aws_sqs_queue.audit_log_deadletter_queue.arn]
   })
 }
 
-resource "aws_sqs_queue" "app_audit_log_deadletter_queue" {
-  name                      = "app_audit_log_deadletter_queue"
+resource "aws_sqs_queue" "audit_log_deadletter_queue" {
+  name                      = "audit_log_deadletter_queue"
   delay_seconds             = 60
   max_message_size          = 262144
   message_retention_seconds = 1209600
@@ -99,7 +99,7 @@ resource "aws_sqs_queue" "app_audit_log_deadletter_queue" {
 # API Audit Log Queue
 
 resource "aws_sqs_queue" "api_audit_log_queue" {
-  name                       = "audit_log_queue"
+  name                       = "api_audit_log_queue"
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 172800 // 2 days

--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -59,9 +59,46 @@ resource "aws_sqs_queue" "reprocess_submission_queue" {
   })
 }
 
-# Audit Log Queue
+# App Audit Log Queue
 
-resource "aws_sqs_queue" "audit_log_queue" {
+resource "aws_sqs_queue" "app_audit_log_queue" {
+  name                       = "app_audit_log_queue"
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 172800 // 2 days
+  visibility_timeout_seconds = 1960
+  # https://aws.amazon.com/premiumsupport/knowledge-center/lambda-function-process-sqs-messages/
+  # The SQS visibility timeout must be at least six times the total of the function timeout and the batch window timeout.
+  # Lambda function timeout is 300.
+
+  kms_master_key_id                 = "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = 300
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.app_audit_log_deadletter_queue.arn
+    maxReceiveCount     = 5
+  })
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.app_audit_log_deadletter_queue.arn]
+  })
+}
+
+resource "aws_sqs_queue" "app_audit_log_deadletter_queue" {
+  name                      = "app_audit_log_deadletter_queue"
+  delay_seconds             = 60
+  max_message_size          = 262144
+  message_retention_seconds = 1209600
+  receive_wait_time_seconds = 5
+
+  kms_master_key_id                 = "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = 300
+}
+
+# API Audit Log Queue
+
+resource "aws_sqs_queue" "api_audit_log_queue" {
   name                       = "audit_log_queue"
   delay_seconds              = 0
   max_message_size           = 262144
@@ -75,18 +112,18 @@ resource "aws_sqs_queue" "audit_log_queue" {
   kms_data_key_reuse_period_seconds = 300
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.audit_log_deadletter_queue.arn
+    deadLetterTargetArn = aws_sqs_queue.api_audit_log_deadletter_queue.arn
     maxReceiveCount     = 5
   })
 
   redrive_allow_policy = jsonencode({
     redrivePermission = "byQueue",
-    sourceQueueArns   = [aws_sqs_queue.audit_log_deadletter_queue.arn]
+    sourceQueueArns   = [aws_sqs_queue.api_audit_log_deadletter_queue.arn]
   })
 }
 
-resource "aws_sqs_queue" "audit_log_deadletter_queue" {
-  name                      = "audit_log_deadletter_queue"
+resource "aws_sqs_queue" "api_audit_log_deadletter_queue" {
+  name                      = "api_audit_log_deadletter_queue"
   delay_seconds             = 60
   max_message_size          = 262144
   message_retention_seconds = 1209600

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -66,7 +66,7 @@ dependency "sqs" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     sqs_reliability_deadletter_queue_arn = null
-    sqs_audit_log_deadletter_queue_arn   = null
+    sqs_app_audit_log_deadletter_queue_arn   = null
   }
 }
 
@@ -195,7 +195,7 @@ inputs = {
   lb_api_target_group_arn_suffix = dependency.load_balancer.outputs.lb_target_group_api_arn_suffix
 
   sqs_reliability_deadletter_queue_arn = dependency.sqs.outputs.sqs_reliability_deadletter_queue_arn
-  sqs_audit_log_deadletter_queue_arn   = dependency.sqs.outputs.sqs_audit_log_deadletter_queue_arn
+  sqs_app_audit_log_deadletter_queue_arn   = dependency.sqs.outputs.sqs_app_audit_log_deadletter_queue_arn
 
   ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
   ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -163,7 +163,7 @@ dependency "dynamodb" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    dynamodb_audit_logs_arn = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
+    dynamodb_app_audit_logs_arn = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
   }
 }
 
@@ -239,7 +239,7 @@ inputs = {
   rds_idp_cluster_identifier        = local.feature_flag_idp == "true" ? dependency.idp.outputs.rds_idp_cluster_identifier : ""
   rds_idp_cpu_maxiumum              = 80
 
-  dynamodb_audit_logs_arn = dependency.dynamodb.outputs.dynamodb_audit_logs_arn
+  dynamodb_app_audit_logs_arn = dependency.dynamodb.outputs.dynamodb_app_audit_logs_arn
   kms_key_dynamodb_arn    = dependency.kms.outputs.kms_key_dynamodb_arn
 
   private_subnet_ids          = dependency.network.outputs.private_subnet_ids

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -82,8 +82,8 @@ dependency "sqs" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
     sqs_reprocess_submission_queue_arn = null
-    sqs_audit_log_queue_arn            = null
-    sqs_audit_log_queue_id             = null
+    sqs_app_audit_log_queue_arn        = null
+    sqs_app_audit_log_queue_id         = null
     sqs_reprocess_submission_queue_id  = null
   }
 }
@@ -168,8 +168,8 @@ inputs = {
   database_url_secret_arn = dependency.rds.outputs.database_url_secret_arn
 
   sqs_reprocess_submission_queue_arn = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
-  sqs_audit_log_queue_arn            = dependency.sqs.outputs.sqs_audit_log_queue_arn
-  sqs_audit_log_queue_id             = dependency.sqs.outputs.sqs_audit_log_queue_id
+  sqs_app_audit_log_queue_arn        = dependency.sqs.outputs.sqs_app_audit_log_queue_arn
+  sqs_app_audit_log_queue_id         = dependency.sqs.outputs.sqs_app_audit_log_queue_id
   sqs_reprocess_submission_queue_id  = dependency.sqs.outputs.sqs_reprocess_submission_queue_id
 
   cognito_endpoint_url  = dependency.cognito.outputs.cognito_endpoint_url

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -66,6 +66,7 @@ dependency "sqs" {
     sqs_reprocess_submission_queue_arn   = null
     sqs_reliability_dead_letter_queue_id = null
     sqs_app_audit_log_queue_arn          = null
+    sqs_api_audit_log_queue_arn          = null
   }
 }
 
@@ -99,8 +100,10 @@ dependency "dynamodb" {
     dynamodb_vault_arn             = "arn:aws:dynamodb:ca-central-1:123456789012:table/Vault"
     dynamodb_vault_table_name      = "Vault"
     dynamodb_vault_stream_arn      = "arn:aws:dynamodb:ca-central-1:123456789012:table/Vault/stream/2023-03-14T15:54:31.086"
-    dynamodb_audit_logs_table_name = "AuditLogs"
-    dynamodb_audit_logs_arn        = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
+    dynamodb_app_audit_logs_table_name = "AuditLogs"
+    dynamodb_app_audit_logs_arn        = "arn:aws:dynamodb:ca-central-1:123456789012:table/AuditLogs"
+    dynamodb_api_audit_logs_table_name = "ApiAuditLogs"
+    dynamodb_api_audit_logs_arn        = "arn:aws:dynamodb:ca-central-1:123456789012:table/ApiAuditLogs"
   }
 }
 
@@ -157,8 +160,10 @@ inputs = {
   dynamodb_vault_arn             = dependency.dynamodb.outputs.dynamodb_vault_arn
   dynamodb_vault_table_name      = dependency.dynamodb.outputs.dynamodb_vault_table_name
   dynamodb_vault_stream_arn      = dependency.dynamodb.outputs.dynamodb_vault_stream_arn
-  dynamodb_audit_logs_table_name = dependency.dynamodb.outputs.dynamodb_audit_logs_table_name
-  dynamodb_audit_logs_arn        = dependency.dynamodb.outputs.dynamodb_audit_logs_arn
+  dynamodb_app_audit_logs_table_name = dependency.dynamodb.outputs.dynamodb_app_audit_logs_table_name
+  dynamodb_app_audit_logs_arn        = dependency.dynamodb.outputs.dynamodb_app_audit_logs_arn
+  dynamodb_api_audit_logs_table_name = dependency.dynamodb.outputs.dynamodb_api_audit_logs_table_name
+  dynamodb_api_audit_logs_arn        = dependency.dynamodb.outputs.dynamodb_api_audit_logs_arn
 
   kms_key_cloudwatch_arn = dependency.kms.outputs.kms_key_cloudwatch_arn
   kms_key_dynamodb_arn   = dependency.kms.outputs.kms_key_dynamodb_arn
@@ -175,6 +180,7 @@ inputs = {
   sqs_reprocess_submission_queue_arn   = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
   sqs_reliability_dead_letter_queue_id = dependency.sqs.outputs.sqs_reliability_dead_letter_queue_id
   sqs_app_audit_log_queue_arn          = dependency.sqs.outputs.sqs_app_audit_log_queue_arn
+  sqs_api_audit_log_queue_arn          = dependency.sqs.outputs.sqs_api_audit_log_queue_arn
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
 

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -65,7 +65,7 @@ dependency "sqs" {
     sqs_reliability_queue_id             = null
     sqs_reprocess_submission_queue_arn   = null
     sqs_reliability_dead_letter_queue_id = null
-    sqs_audit_log_queue_arn              = null
+    sqs_app_audit_log_queue_arn          = null
   }
 }
 
@@ -174,7 +174,7 @@ inputs = {
   sqs_reliability_queue_id             = dependency.sqs.outputs.sqs_reliability_queue_id
   sqs_reprocess_submission_queue_arn   = dependency.sqs.outputs.sqs_reprocess_submission_queue_arn
   sqs_reliability_dead_letter_queue_id = dependency.sqs.outputs.sqs_reliability_dead_letter_queue_id
-  sqs_audit_log_queue_arn              = dependency.sqs.outputs.sqs_audit_log_queue_arn
+  sqs_app_audit_log_queue_arn          = dependency.sqs.outputs.sqs_app_audit_log_queue_arn
 
   sns_topic_alert_critical_arn = dependency.sns.outputs.sns_topic_alert_critical_arn
 


### PR DESCRIPTION
# Summary | Résumé

Enables API Audit Logging by:

- Adding new DynamoDB table for API Audit Logs
- Modifies the existing Audit Log Lambda to handle both App and API SQS audit log streams

Small Refactor:
- Renames the outputs of DynamoDB and SQS modules to more clearly identify the different between the App and API Audit Log resources


Requires PR from forms-api to test properly: 

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
