### PR TITLE
feat: create Forms API OIDC role for releases

### DIFF
--- a/aws/oidc_roles/iam_policies.tf
+++ b/aws/oidc_roles/iam_policies.tf
@@ -114,14 +114,21 @@ data "aws_iam_policy_document" "platform_forms_client_pr_review_env" {
 #
 # Push and manage ECR images
 #
+resource "aws_iam_policy" "forms_api_release" {
+  count  = var.env == "production" ? 1 : 0
+  name   = local.forms_api_release
+  path   = "/"
+  policy = data.aws_iam_policy_document.ecr_push_image[0].json
+}
+
 resource "aws_iam_policy" "platform_forms_client_release" {
   count  = var.env == "production" ? 1 : 0
   name   = local.platform_forms_client_release
   path   = "/"
-  policy = data.aws_iam_policy_document.platform_forms_client_release[0].json
+  policy = data.aws_iam_policy_document.ecr_push_image[0].json
 }
 
-data "aws_iam_policy_document" "platform_forms_client_release" {
+data "aws_iam_policy_document" "ecr_push_image" {
   count = var.env == "production" ? 1 : 0
 
   statement {
@@ -142,7 +149,8 @@ data "aws_iam_policy_document" "platform_forms_client_release" {
       "ecr:UploadLayerPart"
     ]
     resources = [
-      "arn:aws:ecr:${var.region}:${var.account_id}:repository/form_viewer_production"
+      "arn:aws:ecr:${var.region}:${var.account_id}:repository/form_viewer_production",
+      "arn:aws:ecr:${var.region}:${var.account_id}:repository/forms/api"
     ]
   }
 

--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -1,4 +1,5 @@
 locals {
+  forms_api_release                   = "forms-api-release"
   platform_forms_client_pr_review_env = "platform-forms-client-pr-review-env"
   platform_forms_client_release       = "platform-forms-client-release"
 }
@@ -21,6 +22,11 @@ module "github_workflow_roles" {
   billing_tag_value = var.billing_tag_value
   roles = [
     {
+      name      = local.forms_api_release
+      repo_name = "forms-api"
+      claim     = "ref:refs/tags/v*"
+    },
+    {
       name      = local.platform_forms_client_pr_review_env
       repo_name = "platform-forms-client"
       claim     = "pull_request"
@@ -37,6 +43,15 @@ module "github_workflow_roles" {
 # Attach polices to the OIDC roles to grant them permissions.  These
 # attachments are scoped to only the environments that require the role.
 #
+resource "aws_iam_role_policy_attachment" "forms_api_release" {
+  count      = var.env == "production" ? 1 : 0
+  role       = local.forms_api_release
+  policy_arn = aws_iam_policy.forms_api_release[0].arn
+  depends_on = [
+    module.github_workflow_roles
+  ]
+}
+
 resource "aws_iam_role_policy_attachment" "platform_forms_client_pr_review_env" {
   count      = var.env == "staging" ? 1 : 0
   role       = local.platform_forms_client_pr_review_env


### PR DESCRIPTION
# Summary
Add a new OIDC role that will be used by the `cds-snc/forms-api` repository to authenticate and push Production API Docker images when a new GitHub release is published.