### PR TITLE
chore: downgrade to Zitadel v2.61.1

### DIFF
--- a/idp/docker/Dockerfile
+++ b/idp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zitadel/zitadel:v2.62.0@sha256:9f35236d97629915ab023764b50c21e95f7a06b768b4364629193d9f1119b6fb
+FROM ghcr.io/zitadel/zitadel:v2.61.1@sha256:4f49d262cd6eea2786df87a5370164daae7aa2f7f243217ca39adc38e4a464db
 
 # Copy configuration and certificates
 COPY ./*.yaml ./certificate.crt ./private.key /app/

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -2,22 +2,22 @@
 # https://zitadel.com/docs/self-hosting/manage/configure#runtime-configuration-file
 
 Log:
-  Level: info
+  Level: 'info'
 
 Port: 8080
 ExternalPort: 443
 ExternalSecure: true
 TLS:
   Enabled: true
-  KeyPath: /app/private.key
-  CertPath: /app/certificate.crt
+  KeyPath: '/app/private.key'
+  CertPath: '/app/certificate.crt'
 
 Database:
   postgres:
     Port: 5432
     User:
       SSL:
-        Mode: require
+        Mode: 'require'
     Admin:
       SSL:
-        Mode: require
+        Mode: 'require'


### PR DESCRIPTION
# Summary
There appears to be a regression with Zitadel v2.62.0 where the configuration is not being read properly.  For now we can go to v2.61.1 and see if a fix is released for the problem.

As part of this change, the config string values are being quoted as recommended by the Zitadel docs.

# Related
- #832 