### PR TITLE
fix: set default OIDC token expiry times

### DIFF
--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -21,3 +21,20 @@ Database:
     Admin:
       SSL:
         Mode: 'require'
+
+DefaultInstance:
+  LoginPolicy:
+    AllowRegister: false
+    ForceMFA: true
+    HidePasswordReset: true
+  OIDCSettings:
+    AccessTokenLifetime: '1h'
+    IdTokenLifetime: '1h'
+    RefreshTokenIdleExpiration: '720h'
+    RefreshTokenExpiration: '2160h'
+
+OIDC:
+  DefaultAccessTokenLifetime: '1h'
+  DefaultIdTokenLifetime: '1h'
+  DefaultRefreshTokenIdleExpiration: '720h'
+  DefaultRefreshTokenExpiration: '2160h'


### PR DESCRIPTION
# Summary
Update the configuration to set the default OIDC access token expiry times.  These can be overridden in the console if needed.

Update the login policy to initially disable registration and enforce MFA for new instances.  These are being set to prevent abuse.