### PR TITLE
chore: suppress `context canceled` IdP errors

### DIFF
--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_log_subscription_filter" "idp_error_detection" {
 
   name            = "error_detection_in_idp_logs"
   log_group_name  = var.ecs_idp_cloudwatch_log_group_name
-  filter_pattern  = "level=error"
+  filter_pattern  = local.idp_error_pattern
   destination_arn = aws_lambda_function.notify_slack.arn
 }
 

--- a/aws/alarms/locals.tf
+++ b/aws/alarms/locals.tf
@@ -1,3 +1,9 @@
 locals {
+  # Define the pattern that will be used to detect errors in the IdP logs
+  # Any log message that contains a word from `idp_error` and does not contain a word from `idp_error_ignore` will be detected
+  idp_error         = ["level=error"]
+  idp_error_ignore  = ["context canceled"]
+  idp_error_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.idp_error)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.idp_error_ignore)}*\"]"
+
   lambda_submission_expect_invocation_in_period = var.env == "production" ? var.lambda_submission_expect_invocation_in_period : 60 * 24 # expect once a day in non-prod envs
 }


### PR DESCRIPTION
# Summary
Update the IdP error log to suppress errors caused by the client cancelling their request before Zitadel has time to respond.