### PR TITLE
chore: reduce Zitadel token timeout to 30 mins

### DIFF
--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -28,13 +28,13 @@ DefaultInstance:
     ForceMFA: true
     HidePasswordReset: true
   OIDCSettings:
-    AccessTokenLifetime: '1h'
-    IdTokenLifetime: '1h'
+    AccessTokenLifetime: '0.5h'
+    IdTokenLifetime: '0.5h'
     RefreshTokenIdleExpiration: '720h'
     RefreshTokenExpiration: '2160h'
 
 OIDC:
-  DefaultAccessTokenLifetime: '1h'
-  DefaultIdTokenLifetime: '1h'
+  DefaultAccessTokenLifetime: '0.5h'
+  DefaultIdTokenLifetime: '0.5h'
   DefaultRefreshTokenIdleExpiration: '720h'
   DefaultRefreshTokenExpiration: '2160h'


### PR DESCRIPTION
# Summary
Update the instance config so that the access token and ID token expire after 30 mins.  This will improve security by providing less time that a leaked token can be abused.