### PR TITLE
fix: test if Notify Slack log message JSON is valid

### DIFF
--- a/lambda-code/notify-slack/main.ts
+++ b/lambda-code/notify-slack/main.ts
@@ -33,7 +33,8 @@ export const handler = async (event: any) => {
 export const safeParseLogIncludingJSON = (message: string) => {
   try {
     const jsonPartOfLogMessage = message.slice(message.indexOf("{"));
-    return JSON.parse(jsonPartOfLogMessage);
+    const jsonParsed = JSON.parse(jsonPartOfLogMessage);
+    return jsonParsed && typeof jsonParsed === "object" ? jsonParsed : false;
   } catch (e) {
     return false;
   }

--- a/lambda-code/notify-slack/main.ts
+++ b/lambda-code/notify-slack/main.ts
@@ -120,7 +120,7 @@ export const handleCloudWatchLogEvent = async (logData: string) => {
         })
       );
     } else {
-      // These are unhandled errors from the GCForms app only
+      // Non-JSON log message.  Send as-is and treat as an error.
       await sendToSlack(parsedResult.logGroup, log.message, "error");
 
       console.log(


### PR DESCRIPTION
# Summary
Update the `notify-slack` lambda function to check if the parsed JSON is actually a JSON object.

This will eliminate the Slack messages we see where the [expected log message format cannot be parsed](https://gcdigital.slack.com/archives/C05G75MNP4Z/p1726673820091379):

![image](https://github.com/user-attachments/assets/77c622b6-ec92-4307-bbb3-61c63659772f)

# Related
- [Example showing the parse failure](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBAtgUwhAhgcwTAvDARFAS0SwB1cAmABnIBYBaSgTjoEYAOAFRYFYAuAZgBsvboIBaZGABsEANwRSsCAE7KQy+BDSlc0FFASIwsBAA8EwAK6FwMAGYoCMgCaTgKKTOU6A9AAsQRB9lSzAwFR8Ad3UAax8ALwIoFGcFBKSUtIJjFTAPHzkEY2h1BH8UMGcvH1lycsqvADo0EF5BckFJFTVvMggARyleGChlCtRgGzAYPxQIGA9lBBSATxgAIwQimFA4OCSDZxh1GDVPBCP1lGAYyQAHNQArCymsB5BnyYJwCEbLCBUEBY-FwAG4AFCgSCwR4QcAABRQyigAHk7AAZEBoACySFQGGw8Dx6AQjQgUgIwAQAApEMgSY1sqlTGjqbgAN64ACUXIhULhMkaUix1IAUgBlFEAOUadyRAOpsIRSNRGKxuPpGB5oKAA)