### PR TITLE
fix: upgrade `ecs` module to stop task revision flip-flop

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 module "api_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=f11e70a097b0796e661b7e209e29f7d6b62240cf" # v9.6.3
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=59a56cd5ae444dd81b21ba4cf34887d05e3475e2" # v9.6.6
 
   create_cluster = false
   cluster_name   = var.ecs_cluster_name

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -46,7 +46,7 @@ locals {
 }
 
 module "idp_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=f11e70a097b0796e661b7e209e29f7d6b62240cf" # v9.6.3
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=59a56cd5ae444dd81b21ba4cf34887d05e3475e2" # v9.6.6
 
   cluster_name   = "idp"
   service_name   = "zitadel"


### PR DESCRIPTION
# Summary
Update to the v9.6.6 `ecs` module which has a fix to stop removing the latest ECS task definition revision in the Terraform plan.  

This will make things clearer when reviewing the PRs as removing the revision has no impact to our setup where the task definition is primarily managed by other workflows.

# Related
- https://github.com/cds-snc/terraform-modules/pull/562