### PR TITLE
chore: Add zitadel key for app

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -40,6 +40,7 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.PRODUCTION_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
   TF_VAR_zitadel_provider: ${{ vars.PRODUCTION_ZITADEL_PROVIDER }}
+  TF_VAR_zitadel_administration_key: ${{ secrets.PRODUCTION_ZITADEL_ADMINISTRATION_KEY }}
   # IdP
   TF_VAR_idp_database_cluster_admin_username: ${{ secrets.PRODUCTION_IDP_DATABASE_CLUSTER_ADMIN_USERNAME }}
   TF_VAR_idp_database_cluster_admin_password: ${{ secrets.PRODUCTION_IDP_DATABASE_CLUSTER_ADMIN_PASSWORD }}
@@ -144,7 +145,7 @@ jobs:
     needs: [get-version, terragrunt-apply-ecr-only]
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ needs.get-version.outputs.version }} 
+      VERSION: ${{ needs.get-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -42,6 +42,7 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.PRODUCTION_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
   TF_VAR_zitadel_provider: ${{ vars.PRODUCTION_ZITADEL_PROVIDER }}
+  TF_VAR_zitadel_administration_key: ${{ secrets.PRODUCTION_ZITADEL_ADMINISTRATION_KEY }}
   # IdP
   TF_VAR_idp_database_cluster_admin_username: ${{ secrets.PRODUCTION_IDP_DATABASE_CLUSTER_ADMIN_USERNAME }}
   TF_VAR_idp_database_cluster_admin_password: ${{ secrets.PRODUCTION_IDP_DATABASE_CLUSTER_ADMIN_PASSWORD }}


### PR DESCRIPTION
# Summary | Résumé
Added GitHub secret for Production Administration Key for Zitadel to allow the app to create and modify users.