### PR TITLE
fix: adjust IdP CloudWatch alarm error filter

### DIFF
--- a/aws/alarms/locals.tf
+++ b/aws/alarms/locals.tf
@@ -1,8 +1,14 @@
 locals {
   # Define the pattern that will be used to detect errors in the IdP logs
   # Any log message that contains a word from `idp_error` and does not contain a word from `idp_error_ignore` will be detected
-  idp_error         = ["level=error"]
-  idp_error_ignore  = ["context canceled"]
+  idp_error = [
+    "level=error",
+    "level=ERROR"
+  ]
+  idp_error_ignore = [
+    "context canceled",        # user cancels request before it completes
+    "Errors.AuthNKey.NotFound" # user requests an access token with an invalid key
+  ]
   idp_error_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.idp_error)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.idp_error_ignore)}*\"]"
 
   lambda_submission_expect_invocation_in_period = var.env == "production" ? var.lambda_submission_expect_invocation_in_period : 60 * 24 # expect once a day in non-prod envs


### PR DESCRIPTION
# Summary
Update the IdP's CloudWatch alarm filter pattern so that it includes logs with a capitalized `ERROR` term, while also omitting access token requests where the user has signed the JWT with an invalid private key.
