### PR TITLE
test: increase IdP resources for performance tests

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -51,16 +51,16 @@ module "idp_ecs" {
   cluster_name   = "idp"
   service_name   = "zitadel"
   container_name = "zitadel"
-  task_cpu       = 1024
-  task_memory    = 2048
+  task_cpu       = 4096
+  task_memory    = 8096
 
   service_use_latest_task_def = true
 
   # Scaling
   enable_autoscaling       = true
-  desired_count            = 1
-  autoscaling_min_capacity = 1
-  autoscaling_max_capacity = 3
+  desired_count            = 3
+  autoscaling_min_capacity = 3
+  autoscaling_max_capacity = 6
 
   # Task definition
   container_image       = "${var.zitadel_image_ecr_url}:${var.zitadel_image_tag}"

--- a/env/cloud/idp/terragrunt.hcl
+++ b/env/cloud/idp/terragrunt.hcl
@@ -68,8 +68,8 @@ inputs = {
   waf_ipv4_blocklist_arn        = dependency.load_balancer.outputs.waf_ipv4_blocklist_arn
 
   # 1 ACU ~= 2GB of memory and 1vCPU
-  idp_database_min_acu = 1
-  idp_database_max_acu = 2
+  idp_database_min_acu = 3
+  idp_database_max_acu = 4
 }
 
 include {


### PR DESCRIPTION
# Summary
Increase the IdP ECS task count and resources to recommended minimums:
- 3 nodes
- 4 CPU, 8 GB memory

Increase the RDS ACUs to recommended minimums:
- 2 vCPU
- 6 GB memory

Note that these resource changes will be reverted after the performance testing is finished to save costs while we analyze the results.

# Related
- [**Zitadel minimum system requirements**](https://zitadel.com/docs/self-hosting/manage/production#minimum-system-requirements)
- https://github.com/cds-snc/forms-terraform/issues/852