### PR TITLE
fix: IdP task memory value

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -52,7 +52,7 @@ module "idp_ecs" {
   service_name   = "zitadel"
   container_name = "zitadel"
   task_cpu       = 4096
-  task_memory    = 8096
+  task_memory    = 8192
 
   service_use_latest_task_def = true
 


### PR DESCRIPTION
# Summary
Update to the correct 8GB memory value.

# Related
- #854 
- https://github.com/cds-snc/forms-terraform/issues/852