### PR TITLE
test: revert IdP ECS/RDS resources

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -51,16 +51,16 @@ module "idp_ecs" {
   cluster_name   = "idp"
   service_name   = "zitadel"
   container_name = "zitadel"
-  task_cpu       = 4096
-  task_memory    = 8192
+  task_cpu       = 1024
+  task_memory    = 2048
 
   service_use_latest_task_def = true
 
   # Scaling
   enable_autoscaling       = true
-  desired_count            = 3
-  autoscaling_min_capacity = 3
-  autoscaling_max_capacity = 6
+  desired_count            = 1
+  autoscaling_min_capacity = 1
+  autoscaling_max_capacity = 3
 
   # Task definition
   container_image       = "${var.zitadel_image_ecr_url}:${var.zitadel_image_tag}"

--- a/env/cloud/idp/terragrunt.hcl
+++ b/env/cloud/idp/terragrunt.hcl
@@ -68,8 +68,8 @@ inputs = {
   waf_ipv4_blocklist_arn        = dependency.load_balancer.outputs.waf_ipv4_blocklist_arn
 
   # 1 ACU ~= 2GB of memory and 1vCPU
-  idp_database_min_acu = 3
-  idp_database_max_acu = 6
+  idp_database_min_acu = 1
+  idp_database_max_acu = 4
 }
 
 include {


### PR DESCRIPTION
# Summary
Revert the IdP resources for now since the IdP performance tests are complete.  As demand grows, these will likely need to be increased.

Note that the RDS max ACU has been increased from its original value as the database is bottlenecked under load at 2 ACUs.

The rationale for dropping the ECS resources below minimum recommended values (4 vCPU, 8 GB memory) is that the current IdP demand is very low and the response times are acceptable for that demand.

# Related
- https://github.com/cds-snc/forms-terraform/issues/852