### PR TITLE
fix: set database max connection properties

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -51,8 +51,8 @@ module "idp_ecs" {
   cluster_name   = "idp"
   service_name   = "zitadel"
   container_name = "zitadel"
-  task_cpu       = 1024
-  task_memory    = 2048
+  task_cpu       = 4096
+  task_memory    = 8192
 
   service_use_latest_task_def = true
 

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -21,6 +21,10 @@ Database:
     Admin:
       SSL:
         Mode: 'require'
+    MaxOpenConns: 25
+    MaxIdleConns: 10
+    MaxConnLifetime: '30m'
+    MaxConnIdleTime: '5m'
 
 DefaultInstance:
   LoginPolicy:


### PR DESCRIPTION
# Summary
Update the IdP config to specify the database max connections and max idle connections.

Although these should not be needed because we use the RDS proxy to manage our connections, there is a bug report stating that leaving these empty causes slower access token responses.

The ECS task resources have also be bumped back up to the minimum recommend values to run one more performance test.

# Related
- https://github.com/cds-snc/forms-terraform/issues/852
- https://github.com/zitadel/zitadel/issues/6755