### PR TITLE
revert: original IdP ECS task resources

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -51,8 +51,8 @@ module "idp_ecs" {
   cluster_name   = "idp"
   service_name   = "zitadel"
   container_name = "zitadel"
-  task_cpu       = 4096
-  task_memory    = 8192
+  task_cpu       = 1024
+  task_memory    = 2048
 
   service_use_latest_task_def = true
 


### PR DESCRIPTION
# Summary
Drop IdP ECS task resources back to 1 vCPU and 2 GB memory to see how it performs with the database config fix in place.

# Related
- https://github.com/cds-snc/forms-terraform/issues/852