### PR TITLE
fix: Process formattedDate type response

### DIFF
--- a/lambda-code/reliability/lib/types.ts
+++ b/lambda-code/reliability/lib/types.ts
@@ -15,6 +15,7 @@ export type Response =
   | Record<string, unknown>[]
   | FileInputResponse
   | FileInputResponse[]
+  | DateFormat
   | Record<string, unknown>;
 
 export type FileInputResponse = {
@@ -45,6 +46,7 @@ export interface ElementProperties {
   isSectional?: boolean;
   maxNumberOfRows?: number;
   autoComplete?: string;
+  dateFormat?: string;
   [key: string]:
     | string
     | number
@@ -70,6 +72,7 @@ export enum FormElementTypes {
   name = "name",
   firstMiddleLastName = "firstMiddleLastName",
   contact = "contact",
+  formattedDate = "formattedDate",
 }
 // used to define attributes for a form element or field
 export interface FormElement {
@@ -128,3 +131,17 @@ export interface DeliveryOption {
 }
 
 export type SecurityAttribute = "Unclassified" | "Protected A" | "Protected B";
+
+export interface DateObject {
+  YYYY: number;
+  MM: number;
+  DD: number;
+}
+
+export enum DatePart {
+  DD = "day",
+  MM = "month",
+  YYYY = "year",
+}
+
+export type DateFormat = "YYYY-MM-DD" | "DD-MM-YYYY" | "MM-DD-YYYY";

--- a/lambda-code/reliability/lib/utils.ts
+++ b/lambda-code/reliability/lib/utils.ts
@@ -1,0 +1,114 @@
+import { DateFormat, DateObject } from "./types.js";
+
+/**
+ * Utility function to use when rendering a formatted date string
+ *
+ * @param dateFormat
+ * @param dateObject
+ * @returns string
+ */
+export const getFormattedDateFromObject = (
+  dateFormat: DateFormat = "YYYY-MM-DD",
+  dateObject: DateObject
+): string => {
+  // If an invalid date format is provided, use the default format
+  if (!isValidDateFormat(dateFormat)) {
+    dateFormat = "YYYY-MM-DD";
+  }
+
+  // If the date object is invalid, return a dash
+  if (!isValidDateObject(dateObject)) {
+    return "-";
+  }
+
+  const { YYYY, MM, DD } = dateObject;
+
+  const formattedDate = dateFormat
+    .replace("YYYY", YYYY.toString())
+    .replace("MM", MM.toString().padStart(2, "0"))
+    .replace("DD", DD.toString().padStart(2, "0"));
+
+  return formattedDate;
+};
+
+/**
+ * Check that a DateObject is a valid date
+ *
+ * @param dateObject
+ * @returns boolean
+ */
+export const isValidDate = (dateObject: DateObject): boolean => {
+  if (!isValidDateObject(dateObject)) {
+    return false;
+  }
+
+  if (dateObject.YYYY < 1900) {
+    return false;
+  }
+
+  const { YYYY, MM, DD } = dateObject;
+  const date = new Date(YYYY, MM - 1, DD);
+
+  return date.getFullYear() === YYYY && date.getMonth() + 1 === MM && date.getDate() === DD;
+};
+
+/**
+ * Check that a date format is valid
+ *
+ * @param dateFormat
+ * @returns boolean
+ */
+export const isValidDateFormat = (dateFormat: DateFormat): boolean => {
+  return ["YYYY-MM-DD", "DD-MM-YYYY", "MM-DD-YYYY"].includes(dateFormat);
+};
+
+/**
+ * Check that a date object is valid
+ *
+ * @param obj
+ * @returns boolean
+ */
+export const isValidDateObject = (obj: unknown): obj is DateObject => {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "YYYY" in obj &&
+    "MM" in obj &&
+    "DD" in obj &&
+    typeof obj.YYYY === "number" &&
+    typeof obj.MM === "number" &&
+    typeof obj.DD === "number"
+  );
+};
+
+/**
+ * Check if a year is a leap year
+ *
+ * @param year
+ * @returns boolean
+ */
+export const isLeapYear = (year: number) => {
+  return year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0);
+};
+
+/**
+ * Get the maximum number of days in a month
+ *
+ * @param month
+ * @param year
+ * @returns number
+ */
+export const getMaxMonthDay = (month: number, year: number) => {
+  // Months are 1-indexed
+  switch (month) {
+    case 2:
+      return isLeapYear(year) ? 29 : 28;
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      return 30;
+    default:
+      return 31;
+  }
+};


### PR DESCRIPTION
# Summary | Résumé

When we previously rolled out the [formattedDate component](https://github.com/cds-snc/platform-forms-client/pull/3581) the reliability container was not updated with the ability to process/format the response type.