### PR TITLE
chore: suppress user OIDC request errors

### DIFF
--- a/aws/alarms/locals.tf
+++ b/aws/alarms/locals.tf
@@ -6,8 +6,10 @@ locals {
     "level=ERROR"
   ]
   idp_error_ignore = [
-    "context canceled",        # user cancels request before it completes
-    "Errors.AuthNKey.NotFound" # user requests an access token with an invalid key
+    "context canceled",         # user cancels request before it completes
+    "Errors.AuthNKey.NotFound", # user requests an access token with an invalid key
+    "oidc.Time*cannot parse",   # user sends a JWT with a malformed epoch time
+    "token has expired"         # user access token has expired
   ]
   idp_error_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.idp_error)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.idp_error_ignore)}*\"]"
 


### PR DESCRIPTION
# Summary
Add new error patterns to suppress OIDC request errors caused by issues on the user's end.

This will prevent the following errors from being posted in Slack:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/1773bbda-8f9b-4ff5-8375-d59db12162e2">

<img width="668" alt="image" src="https://github.com/user-attachments/assets/bcd9a244-d232-44d4-8399-90cd50840cb4">
