### PR TITLE
fix: Increase default timeout to Notify

### DIFF
--- a/lambda-code/nagware/lib/gc-notify-client.ts
+++ b/lambda-code/nagware/lib/gc-notify-client.ts
@@ -9,7 +9,7 @@ export class GCNotifyClient {
   private apiKey: string;
   private timeout: number;
 
-  public static default(apiKey: string, timeout: number = 2000): GCNotifyClient {
+  public static default(apiKey: string, timeout: number = 5000): GCNotifyClient {
     return new GCNotifyClient(API_URL, apiKey, timeout);
   }
 

--- a/lambda-code/reliability/lib/gc-notify-client.ts
+++ b/lambda-code/reliability/lib/gc-notify-client.ts
@@ -9,7 +9,7 @@ export class GCNotifyClient {
   private apiKey: string;
   private timeout: number;
 
-  public static default(apiKey: string, timeout: number = 2000): GCNotifyClient {
+  public static default(apiKey: string, timeout: number = 5000): GCNotifyClient {
     return new GCNotifyClient(API_URL, apiKey, timeout);
   }
 


### PR DESCRIPTION
# Summary | Résumé
Increases the default timeout of the Notify Client from 2 seconds to 5 seconds.