### PR TITLE
chore: upgrade ALB to latest recommend SSL policy

### DIFF
--- a/aws/idp/lb.tf
+++ b/aws/idp/lb.tf
@@ -65,7 +65,7 @@ resource "aws_lb_listener" "idp" {
   load_balancer_arn = aws_lb.idp.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate.idp.arn
 
   default_action {

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -103,7 +103,7 @@ resource "aws_lb_listener" "form_viewer_https" {
   load_balancer_arn = aws_lb.form_viewer.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate.form_viewer.arn
 
   default_action {


### PR DESCRIPTION
# Summary
Update to the latest recommend ALB SSL policy which is [FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final) compliant.