### PR TITLE
feat: add SSM parameters for the load tests

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -46,8 +46,8 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
-  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
+  TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
+  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -45,6 +45,9 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
+  TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
+  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -47,7 +47,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
   TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
-  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_zitadel_app_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -37,6 +37,9 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
+  TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
+  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -39,7 +39,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
   TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
-  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_zitadel_app_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -38,8 +38,8 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
-  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
+  TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
+  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -49,7 +49,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
   TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
-  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_zitadel_app_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -48,8 +48,8 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
-  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
+  TF_VAR_load_testing_form_private_key: ${{ vars.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
+  TF_VAR_load_testing_form_api_private_key: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -47,6 +47,9 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
+  TF_VAR_load_testing_form_id: ${{ vars.STAGING_LOAD_TESTING_FORM_ID }}
+  TF_VAR_load_testing_private_key_app: ${{ vars.STAGING_ZITADEL_APPLICATION_KEY }}
+  TF_VAR_load_testing_private_key_form: ${{ vars.STAGING_LOAD_TESTING_PRIVATE_KEY_FORM }}
   TF_VAR_zitadel_provider: ${{ vars.STAGING_ZITADEL_PROVIDER }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   # IdP

--- a/aws/load_testing/inputs.tf
+++ b/aws/load_testing/inputs.tf
@@ -20,8 +20,8 @@ variable "load_testing_form_private_key" {
   sensitive   = true
 }
 
-variable "load_testing_form_api_private_key" {
-  description = "Private key JSON used by the API to perform access token introspection requests.  This corresponds to the Zitadel application created for the API."
+variable "load_testing_zitadel_app_private_key" {
+  description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = string
   sensitive   = true
 }

--- a/aws/load_testing/inputs.tf
+++ b/aws/load_testing/inputs.tf
@@ -14,14 +14,14 @@ variable "load_testing_form_id" {
   sensitive   = true
 }
 
-variable "load_testing_private_key_app" {
-  description = "Private key JSON used by the application to perform access token introspection requests."
+variable "load_testing_form_private_key" {
+  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key from the `var.load_testing_form_id` form."
   type        = string
   sensitive   = true
 }
 
-variable "load_testing_private_key_form" {
-  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key from the `var.load_testing_form_id` form."
+variable "load_testing_form_api_private_key" {
+  description = "Private key JSON used by the API to perform access token introspection requests.  This corresponds to the Zitadel application created for the API."
   type        = string
   sensitive   = true
 }

--- a/aws/load_testing/inputs.tf
+++ b/aws/load_testing/inputs.tf
@@ -2,3 +2,26 @@ variable "ecr_repository_url_load_testing_lambda" {
   description = "URL of the Load Testing Lambda ECR"
   type        = string
 }
+
+variable "lambda_submission_function_name" {
+  description = "Name of the Submission Lambda function."
+  type        = string
+}
+
+variable "load_testing_form_id" {
+  description = "Form ID that will be used to generate, retrieve and confirm responses."
+  type        = string
+  sensitive   = true
+}
+
+variable "load_testing_private_key_app" {
+  description = "Private key JSON used by the application to perform access token introspection requests."
+  type        = string
+  sensitive   = true
+}
+
+variable "load_testing_private_key_form" {
+  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key from the `var.load_testing_form_id` form."
+  type        = string
+  sensitive   = true
+}

--- a/aws/load_testing/lambda.tf
+++ b/aws/load_testing/lambda.tf
@@ -77,8 +77,8 @@ data "aws_iam_policy_document" "load_test_lambda" {
     ]
     resources = [
       aws_ssm_parameter.load_testing_form_id.arn,
-      aws_ssm_parameter.load_testing_private_key_form.arn,
-      aws_ssm_parameter.load_testing_private_key_app.arn,
+      aws_ssm_parameter.load_testing_form_private_key.arn,
+      aws_ssm_parameter.load_testing_form_api_private_key.arn,
     ]
   }
 

--- a/aws/load_testing/lambda.tf
+++ b/aws/load_testing/lambda.tf
@@ -6,8 +6,8 @@ resource "aws_lambda_function" "load_testing" {
   image_uri     = "${var.ecr_repository_url_load_testing_lambda}:latest"
   function_name = "load-testing"
   role          = aws_iam_role.load_test_lambda.arn
-  timeout       = 300
-  memory_size   = 200
+  timeout       = 900
+  memory_size   = 1024
   package_type  = "Image"
   description   = "A function that runs a locust load test"
 

--- a/aws/load_testing/lambda.tf
+++ b/aws/load_testing/lambda.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "load_test_lambda" {
     resources = [
       aws_ssm_parameter.load_testing_form_id.arn,
       aws_ssm_parameter.load_testing_form_private_key.arn,
-      aws_ssm_parameter.load_testing_form_api_private_key.arn,
+      aws_ssm_parameter.load_testing_zitadel_app_private_key.arn,
     ]
   }
 

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -1,0 +1,20 @@
+resource "aws_ssm_parameter" "load_testing_form_id" {
+  name        = "/load-testing/form-id"
+  description = "Form ID that will be used to generate, retrieve and confirm responses."
+  type        = "SecureString"
+  value       = var.load_testing_form_id
+}
+
+resource "aws_ssm_parameter" "load_testing_private_key_form" {
+  name        = "/load-testing/private-api-key-form"
+  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key for the `/load-testing/form-id` form."
+  type        = "SecureString"
+  value       = var.load_testing_private_key_form
+}
+
+resource "aws_ssm_parameter" "load_testing_private_key_app" {
+  name        = "/load-testing/private-api-key-app"
+  description = "Private key JSON used by the application to perform access token introspection requests."
+  type        = "SecureString"
+  value       = var.load_testing_private_key_app
+}

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -19,5 +19,5 @@ resource "aws_ssm_parameter" "load_testing_form_api_private_key" {
   name        = "/load-testing/form-api-private-key"
   description = "Private key JSON used by the application to perform access token introspection requests.  This corresponds to the Zitadel application created for the API."
   type        = "SecureString"
-  value       = var.load_testing_app_private_key
+  value       = var.load_testing_form_api_private_key
 }

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -1,20 +1,23 @@
 resource "aws_ssm_parameter" "load_testing_form_id" {
+  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
   name        = "/load-testing/form-id"
   description = "Form ID that will be used to generate, retrieve and confirm responses."
   type        = "SecureString"
   value       = var.load_testing_form_id
 }
 
-resource "aws_ssm_parameter" "load_testing_private_key_form" {
-  name        = "/load-testing/private-api-key-form"
+resource "aws_ssm_parameter" "load_testing_form_private_key" {
+  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
+  name        = "/load-testing/form-private-key"
   description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key for the `/load-testing/form-id` form."
   type        = "SecureString"
-  value       = var.load_testing_private_key_form
+  value       = var.load_testing_form_private_key
 }
 
-resource "aws_ssm_parameter" "load_testing_private_key_app" {
-  name        = "/load-testing/private-api-key-app"
-  description = "Private key JSON used by the application to perform access token introspection requests."
+resource "aws_ssm_parameter" "load_testing_form_api_private_key" {
+  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
+  name        = "/load-testing/form-api-private-key"
+  description = "Private key JSON used by the application to perform access token introspection requests.  This corresponds to the Zitadel application created for the API."
   type        = "SecureString"
-  value       = var.load_testing_private_key_app
+  value       = var.load_testing_app_private_key
 }

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -14,10 +14,10 @@ resource "aws_ssm_parameter" "load_testing_form_private_key" {
   value       = var.load_testing_form_private_key
 }
 
-resource "aws_ssm_parameter" "load_testing_form_api_private_key" {
+resource "aws_ssm_parameter" "load_testing_zitadel_app_private_key" {
   # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/form-api-private-key"
-  description = "Private key JSON used by the application to perform access token introspection requests.  This corresponds to the Zitadel application created for the API."
+  name        = "/load-testing/zitadel-app-private-key"
+  description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = "SecureString"
-  value       = var.load_testing_form_api_private_key
+  value       = var.load_testing_zitadel_app_private_key
 }

--- a/env/cloud/load_testing/terragrunt.hcl
+++ b/env/cloud/load_testing/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../ecr"]
+  paths = ["../ecr", "../lambdas"]
 }
 
 dependency "ecr" {
@@ -16,8 +16,19 @@ dependency "ecr" {
   }
 }
 
+dependency "lambdas" {
+  config_path = "../lambdas"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    lambda_submission_function_name = "Submission"
+  }
+}
+
 inputs = {
   ecr_repository_url_load_testing_lambda = dependency.ecr.outputs.ecr_repository_url_load_testing_lambda
+  lambda_submission_function_name        = dependency.lambdas.outputs.lambda_submission_function_name
 }
 
 include {

--- a/lambda-code/load-testing/Dockerfile
+++ b/lambda-code/load-testing/Dockerfile
@@ -1,12 +1,9 @@
-FROM amazon/aws-lambda-python:3.11@sha256:99cadc3bd9674a32a4ef694ff2e27f0b3d6c7f369b174db792b0099699fa0da4
+FROM amazon/aws-lambda-python:3.12@sha256:37b95206c4c78331f6d5cb0e8389ef573f39cfea01f73c530f28f3ac6f6493c7
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
 COPY main.py .
 COPY tests ./tests
-COPY requirements.txt .
-
-RUN yum -y groupinstall "Development Tools"
-
-RUN pip3 install --upgrade pip
-
-RUN pip3 install -r requirements.txt
 
 CMD ["main.handler"]

--- a/lambda-code/load-testing/README.md
+++ b/lambda-code/load-testing/README.md
@@ -1,6 +1,18 @@
 # Load testing
 Locust load tests that can be run in a Lambda function or locally.
 
+## Lambda
+Invoke the function using an event that looks like so:
+```json
+{
+  "locustfile": "./tests/locust_test_file.py",
+  "host": "https://forms-staging.cdssandbox.xyz",
+  "num_users": "5",
+  "spawn_rate": "1",
+  "run_time": "5m"
+}
+```
+
 ## Locally
 You will need AWS access credentials for the target environment, along with the following environment variables set:
 ```sh

--- a/lambda-code/load-testing/README.md
+++ b/lambda-code/load-testing/README.md
@@ -1,0 +1,15 @@
+# Load testing
+Locust load tests that can be run in a Lambda function or locally.
+
+## Locally
+You will need AWS access credentials for the target environment, along with the following environment variables set:
+```sh
+FORM_ID                 # Form ID to use for load testing
+FORM_PRIVATE_KEY        # JSON private key for the form (must be from the `FORM_ID` form)
+ZITADEL_APP_PRIVATE_KEY # JSON private key for the Zitadel application that is used for access token introspection
+```
+Once the variables are set, you can start the tests like so:
+```sh
+make install
+make locust
+```

--- a/lambda-code/load-testing/main.py
+++ b/lambda-code/load-testing/main.py
@@ -19,13 +19,13 @@ params = get_ssm_parameters(
     ssm_client,
     [
         "/load-testing/form-id",
-        "/load-testing/private-api-key-app",
-        "/load-testing/private-api-key-form",
+        "/load-testing/form-private-key",
+        "/load-testing/form-api-private-key",
     ],
 )
 os.environ["FORM_ID"] = params["/load-testing/form-id"]
-os.environ["PRIVATE_API_KEY_APP_JSON"] = params["/load-testing/private-api-key-app"]
-os.environ["PRIVATE_API_KEY_FORM_JSON"] = params["/load-testing/private-api-key-form"]
+os.environ["FORM_PRIVATE_KEY"] = params["/load-testing/form-private-key"]
+os.environ["FORM_API_PRIVATE_KEY"] = params["/load-testing/form-api-private-key"]
 
 
 def handler(event=None, context=None):
@@ -33,8 +33,8 @@ def handler(event=None, context=None):
     # Check for required environment variables
     required_env_vars = [
         "FORM_ID",
-        "PRIVATE_API_KEY_APP_JSON",
-        "PRIVATE_API_KEY_FORM_JSON",
+        "FORM_PRIVATE_KEY",
+        "FORM_API_PRIVATE_KEY",
     ]
     for env_var in required_env_vars:
         if env_var not in os.environ:

--- a/lambda-code/load-testing/main.py
+++ b/lambda-code/load-testing/main.py
@@ -20,12 +20,12 @@ params = get_ssm_parameters(
     [
         "/load-testing/form-id",
         "/load-testing/form-private-key",
-        "/load-testing/form-api-private-key",
+        "/load-testing/zitadel-app-private-key",
     ],
 )
 os.environ["FORM_ID"] = params["/load-testing/form-id"]
 os.environ["FORM_PRIVATE_KEY"] = params["/load-testing/form-private-key"]
-os.environ["FORM_API_PRIVATE_KEY"] = params["/load-testing/form-api-private-key"]
+os.environ["ZITADEL_APP_PRIVATE_KEY"] = params["/load-testing/zitadel-app-private-key"]
 
 
 def handler(event=None, context=None):
@@ -34,7 +34,7 @@ def handler(event=None, context=None):
     required_env_vars = [
         "FORM_ID",
         "FORM_PRIVATE_KEY",
-        "FORM_API_PRIVATE_KEY",
+        "ZITADEL_APP_PRIVATE_KEY",
     ]
     for env_var in required_env_vars:
         if env_var not in os.environ:

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -20,13 +20,13 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         self.form_decrypted_submissions = {}
         self.form_new_submissions = None
         self.headers = None
-        self.jwt_user = None
+        self.jwt_form = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
+        self.jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "assertion": self.jwt_user,
+            "assertion": self.jwt_form,
             "scope": f"openid profile urn:zitadel:iam:org:project:id:{self.idp_project_id}:aud",
         }
         response = self.request_with_failure_check(

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -23,7 +23,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         self.jwt_user = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_user)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": self.jwt_user,
@@ -69,7 +69,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         )
         encrypted_submission = EncryptedFormSubmission.from_json(response)
         decrypted_submission = FormSubmissionDecrypter.decrypt(
-            encrypted_submission, self.private_api_key_user
+            encrypted_submission, self.private_api_key_form
         )
         self.form_decrypted_submissions[submission["name"]] = json.loads(
             decrypted_submission

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -33,7 +33,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
             "post", f"{self.idp_url}/oauth/v2/token", 200, data=data
         )
         self.headers = {
-            "Authorization": f"Bearer {response["access_token"]}",
+            "Authorization": f"Bearer {response['access_token']}",
             "Content-Type": "application/json",
         }
 

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -23,7 +23,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         self.jwt_user = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": self.jwt_user,
@@ -69,7 +69,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         )
         encrypted_submission = EncryptedFormSubmission.from_json(response)
         decrypted_submission = FormSubmissionDecrypter.decrypt(
-            encrypted_submission, self.private_api_key_form
+            encrypted_submission, self.form_private_key
         )
         self.form_decrypted_submissions[submission["name"]] = json.loads(
             decrypted_submission

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -16,7 +16,7 @@ class AccessTokenBehaviour(SequentialTaskSetWithFailure):
 
     def on_start(self) -> None:
         self.jwt_app = JwtGenerator.generate(self.idp_url, self.private_api_key_app)
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_user)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
 
     @task
     def request_access_token(self) -> None:

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -15,8 +15,8 @@ class AccessTokenBehaviour(SequentialTaskSetWithFailure):
         self.access_token = None
 
     def on_start(self) -> None:
-        self.jwt_app = JwtGenerator.generate(self.idp_url, self.private_api_key_app)
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
+        self.jwt_app = JwtGenerator.generate(self.idp_url, self.form_api_private_key)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
 
     @task
     def request_access_token(self) -> None:

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -10,19 +10,19 @@ from utils.task_set import SequentialTaskSetWithFailure
 class AccessTokenBehaviour(SequentialTaskSetWithFailure):
     def __init__(self, parent: HttpUser) -> None:
         super().__init__(parent)
-        self.jwt_app = None
-        self.jwt_user = None
+        self.jwt_api = None
+        self.jwt_form = None
         self.access_token = None
 
     def on_start(self) -> None:
-        self.jwt_app = JwtGenerator.generate(self.idp_url, self.form_api_private_key)
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
+        self.jwt_api = JwtGenerator.generate(self.idp_url, self.form_api_private_key)
+        self.jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
 
     @task
     def request_access_token(self) -> None:
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "assertion": self.jwt_user,
+            "assertion": self.jwt_form,
             "scope": f"openid profile urn:zitadel:iam:org:project:id:{self.idp_project_id}:aud",
         }
         response = self.request_with_failure_check(
@@ -34,7 +34,7 @@ class AccessTokenBehaviour(SequentialTaskSetWithFailure):
     def introspect_access_token(self) -> None:
         data = {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion": self.jwt_app,
+            "client_assertion": self.jwt_api,
             "token": self.access_token,
         }
         self.request_with_failure_check(

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -10,12 +10,12 @@ from utils.task_set import SequentialTaskSetWithFailure
 class AccessTokenBehaviour(SequentialTaskSetWithFailure):
     def __init__(self, parent: HttpUser) -> None:
         super().__init__(parent)
-        self.jwt_api = None
+        self.jwt_app = None
         self.jwt_form = None
         self.access_token = None
 
     def on_start(self) -> None:
-        self.jwt_api = JwtGenerator.generate(self.idp_url, self.form_api_private_key)
+        self.jwt_app = JwtGenerator.generate(self.idp_url, self.zitadel_app_private_key)
         self.jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
 
     @task
@@ -34,7 +34,7 @@ class AccessTokenBehaviour(SequentialTaskSetWithFailure):
     def introspect_access_token(self) -> None:
         data = {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion": self.jwt_api,
+            "client_assertion": self.jwt_app,
             "token": self.access_token,
         }
         self.request_with_failure_check(

--- a/lambda-code/load-testing/tests/behaviours/submit.py
+++ b/lambda-code/load-testing/tests/behaviours/submit.py
@@ -15,16 +15,16 @@ class FormSubmitBehaviour(SequentialTaskSetWithFailure):
     def __init__(self, parent: HttpUser) -> None:
         super().__init__(parent)
         self.access_token = None
-        self.jwt_user = None
+        self.jwt_form = None
         self.form_id = os.getenv("FORM_ID")
         self.form_template = None
         self.form_submission_generator = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
+        self.jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "assertion": self.jwt_user,
+            "assertion": self.jwt_form,
             "scope": f"openid profile urn:zitadel:iam:org:project:id:{self.idp_project_id}:aud",
         }
         response = self.request_with_failure_check(

--- a/lambda-code/load-testing/tests/behaviours/submit.py
+++ b/lambda-code/load-testing/tests/behaviours/submit.py
@@ -21,7 +21,7 @@ class FormSubmitBehaviour(SequentialTaskSetWithFailure):
         self.form_submission_generator = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.form_private_key)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": self.jwt_user,

--- a/lambda-code/load-testing/tests/behaviours/submit.py
+++ b/lambda-code/load-testing/tests/behaviours/submit.py
@@ -21,7 +21,7 @@ class FormSubmitBehaviour(SequentialTaskSetWithFailure):
         self.form_submission_generator = None
 
     def on_start(self) -> None:
-        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_user)
+        self.jwt_user = JwtGenerator.generate(self.idp_url, self.private_api_key_form)
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": self.jwt_user,

--- a/lambda-code/load-testing/tests/utils/task_set.py
+++ b/lambda-code/load-testing/tests/utils/task_set.py
@@ -19,8 +19,8 @@ class SequentialTaskSetWithFailure(SequentialTaskSet):
         self.private_api_key_app = PrivateApiKey.from_json(
             json.loads(os.getenv("PRIVATE_API_KEY_APP_JSON"))
         )
-        self.private_api_key_user = PrivateApiKey.from_json(
-            json.loads(os.getenv("PRIVATE_API_KEY_USER_JSON"))
+        self.private_api_key_form = PrivateApiKey.from_json(
+            json.loads(os.getenv("PRIVATE_API_KEY_FORM_JSON"))
         )
 
     def request_with_failure_check(

--- a/lambda-code/load-testing/tests/utils/task_set.py
+++ b/lambda-code/load-testing/tests/utils/task_set.py
@@ -17,10 +17,10 @@ class SequentialTaskSetWithFailure(SequentialTaskSet):
         self.idp_url = f"{parsed_url.scheme}://auth.{parsed_url.netloc}"
         self.idp_project_id = os.getenv("IDP_PROJECT_ID", "275372254274006635")
         self.form_private_key = PrivateApiKey.from_json(
-            json.loads(os.getenv("FORM_PRIVATE_KEY"))
+            json.loads(os.getenv("FORM_PRIVATE_KEY").replace('\n', '\\n'))
         )
         self.zitadel_app_private_key = PrivateApiKey.from_json(
-            json.loads(os.getenv("ZITADEL_APP_PRIVATE_KEY"))
+            json.loads(os.getenv("ZITADEL_APP_PRIVATE_KEY").replace('\n', '\\n'))
         )
 
     def request_with_failure_check(

--- a/lambda-code/load-testing/tests/utils/task_set.py
+++ b/lambda-code/load-testing/tests/utils/task_set.py
@@ -19,8 +19,8 @@ class SequentialTaskSetWithFailure(SequentialTaskSet):
         self.form_private_key = PrivateApiKey.from_json(
             json.loads(os.getenv("FORM_PRIVATE_KEY"))
         )
-        self.form_api_private_key = PrivateApiKey.from_json(
-            json.loads(os.getenv("FORM_API_PRIVATE_KEY"))
+        self.zitadel_app_private_key = PrivateApiKey.from_json(
+            json.loads(os.getenv("ZITADEL_APP_PRIVATE_KEY"))
         )
 
     def request_with_failure_check(

--- a/lambda-code/load-testing/tests/utils/task_set.py
+++ b/lambda-code/load-testing/tests/utils/task_set.py
@@ -16,11 +16,11 @@ class SequentialTaskSetWithFailure(SequentialTaskSet):
         self.api_url = f"{parsed_url.scheme}://api.{parsed_url.netloc}"
         self.idp_url = f"{parsed_url.scheme}://auth.{parsed_url.netloc}"
         self.idp_project_id = os.getenv("IDP_PROJECT_ID", "275372254274006635")
-        self.private_api_key_app = PrivateApiKey.from_json(
-            json.loads(os.getenv("PRIVATE_API_KEY_APP_JSON"))
+        self.form_private_key = PrivateApiKey.from_json(
+            json.loads(os.getenv("FORM_PRIVATE_KEY"))
         )
-        self.private_api_key_form = PrivateApiKey.from_json(
-            json.loads(os.getenv("PRIVATE_API_KEY_FORM_JSON"))
+        self.form_api_private_key = PrivateApiKey.from_json(
+            json.loads(os.getenv("FORM_API_PRIVATE_KEY"))
         )
 
     def request_with_failure_check(


### PR DESCRIPTION
# Summary
Add AWS SSM parameters needed by the load tests to run.  This includes changes to the Lambda so that it can read these parameters and load them into the execution environment.

The reason these are not being passed in directly as Lambda environment variables is because these are stored as plain text and can be leaked by AWS CLI commands.

# Related
- https://github.com/cds-snc/forms-terraform/issues/852