### PR TITLE
Fix: Certain Redis infra features need to be disabled for localstack

### DIFF
--- a/aws/redis/redis.tf
+++ b/aws/redis/redis.tf
@@ -5,7 +5,7 @@
 
 resource "aws_elasticache_replication_group" "redis" {
   # checkov:skip=CKV_AWS_191: KMS encryption using customer managed key not required
-  automatic_failover_enabled = true
+  automatic_failover_enabled = var.env == "local" ? false : true
   replication_group_id       = "gcforms-redis-rep-group"
   description                = "Redis cluster for GCForms"
   node_type                  = "cache.t2.micro"
@@ -13,7 +13,7 @@ resource "aws_elasticache_replication_group" "redis" {
   engine_version             = var.env == "local" ? "6.2" : "6.x" # Localstack does not accept the use of latest minor version (`.x`) at creation time
   parameter_group_name       = "default.redis6.x"
   port                       = 6379
-  multi_az_enabled           = true
+  multi_az_enabled           = var.env == "local" ? false : true
   subnet_group_name          = aws_elasticache_subnet_group.redis.name
   security_group_ids         = [var.redis_security_group_id]
 }


### PR DESCRIPTION
# Summary | Résumé
Localstack does not support automatic failover with only a single instance.
