### PR TITLE
chore: Remove warn on grant and revoke form access

### DIFF
--- a/lambda-code/audit-logs/main.ts
+++ b/lambda-code/audit-logs/main.ts
@@ -36,9 +36,6 @@ const AppAuditLogArn = process.env.APP_AUDIT_LOGS_SQS_ARN;
 const ApiAuditLogArn = process.env.API_AUDIT_LOGS_SQS_ARN;
 
 const warnOnEvents = [
-  // Form Events
-  "GrantFormAccess",
-  "RevokeFormAccess",
   // User Events
   "UserActivated",
   "UserDeactivated",


### PR DESCRIPTION
# Summary | Résumé
Now that granting and revoking form access is a public feature we can stop the warning in Slack of these previously only administrative actions.
