### PR TITLE
fix: Remove rate limiting WAF on api domain url

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -26,7 +26,25 @@ resource "aws_wafv2_rule_group" "rate_limiters_group" {
       rate_based_statement {
         limit              = 2500
         aggregate_key_type = "IP"
-
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = var.domain_api
+                text_transformation {
+                  priority = 1
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
       }
     }
 
@@ -50,15 +68,38 @@ resource "aws_wafv2_rule_group" "rate_limiters_group" {
         limit              = 100
         aggregate_key_type = "IP"
         scope_down_statement {
-          byte_match_statement {
-            positional_constraint = "EXACTLY"
-            field_to_match {
-              method {}
+          and_statement {
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "host"
+                      }
+                    }
+                    search_string = var.domain_api
+                    text_transformation {
+                      priority = 1
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+              }
             }
-            search_string = "post"
-            text_transformation {
-              priority = 1
-              type     = "LOWERCASE"
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  method {}
+                }
+                search_string = "post"
+                text_transformation {
+                  priority = 1
+                  type     = "LOWERCASE"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
# Summary | Résumé

Removes the blanket and POST rate limiting on the API Server URL that is co-hosted with the GCForms app in ECS and share the same Load Balancer and WAF Rules.

The API remains protected through it's own implementation of Token Bucket Rate Limiting.
