### PR TITLE
feat: project all attributes for new StatusCreatedAt index in Vault DynamoDB table

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -61,11 +61,10 @@ resource "aws_dynamodb_table" "vault" {
   }
 
   global_secondary_index {
-    name               = "StatusCreatedAt"
-    hash_key           = "FormID"
-    range_key          = "Status#CreatedAt"
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["CreatedAt", "Name"]
+    name            = "StatusCreatedAt"
+    hash_key        = "FormID"
+    range_key       = "Status#CreatedAt"
+    projection_type = "ALL"
   }
 
   server_side_encryption {


### PR DESCRIPTION
# Summary | Résumé

- Modifies `StatusCreatedAt` index for Vault table so that it projects all attributes instead of just a few