### PR TITLE
Fix: Add missing api path check on APP WAF rule

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -538,7 +538,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_app_uri_paths" {
 
   # App paths
   regular_expression {
-    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|form-builder|forms|id|auth|profile|support|contact|unlock-publishing)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
+    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|api|form-builder|forms|id|auth|profile|support|contact|unlock-publishing)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
   }
 
   # Static Pages


### PR DESCRIPTION
# Summary | Résumé
Adds missing `api` check on APP WAF rule.

# Test instructions | Instructions pour tester la modification

Trust me..... what could go wrong??   (cough cough)