### PR TITLE
refactor: replace use of Status with new Status#CreatedAt attribute when requesting Vault items

### DIFF
--- a/lambda-code/nagware/lib/dynamodbDataLayer.ts
+++ b/lambda-code/nagware/lib/dynamodbDataLayer.ts
@@ -27,10 +27,10 @@ export async function retrieveNewOrDownloadedFormResponsesOver28DaysOld() {
           TableName: DYNAMODB_VAULT_TABLE_NAME,
           ExclusiveStartKey: lastEvaluatedKey ?? undefined,
           FilterExpression:
-            "(#status = :statusNew OR #status = :statusDownloaded) AND CreatedAt <= :createdAt",
+            "(begins_with(#statusCreatedAt, :statusNew) OR begins_with(#statusCreatedAt, :statusDownloaded)) AND CreatedAt <= :createdAt",
           ProjectionExpression: "FormID,CreatedAt",
           ExpressionAttributeNames: {
-            "#status": "Status",
+            "#statusCreatedAt": "Status#CreatedAt",
           },
           ExpressionAttributeValues: {
             ":statusNew": "New",


### PR DESCRIPTION
# Summary | Résumé

Part 7 of https://github.com/cds-snc/platform-forms-client/issues/4287

- Replaces any reference to the old `Status` with new `Status#CreatedAt` attribute when requesting Vault items.