### PR TITLE
chore: temporarily disable `rds` module plan/ apply

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -246,9 +246,10 @@ jobs:
         working-directory: env/cloud/redis
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      - name: Terragrunt apply rds
-        working-directory: env/cloud/rds
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      # Disabled for Serverless v1 -> v2 upgrade
+      # - name: Terragrunt apply rds
+      #   working-directory: env/cloud/rds
+      #   run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply idp
         working-directory: env/cloud/idp

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -238,9 +238,10 @@ jobs:
         working-directory: env/cloud/redis
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      - name: Terragrunt apply rds
-        working-directory: env/cloud/rds
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      # Disabled for Serverless v1 -> v2 upgrade
+      # - name: Terragrunt apply rds
+      #   working-directory: env/cloud/rds
+      #   run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply idp
         working-directory: env/cloud/idp

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -172,12 +172,13 @@ jobs:
           comment: "false"
           terragrunt: "true"
 
-      - name: Terragrunt plan rds
-        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-        with:
-          directory: "env/cloud/rds"
-          comment: "false"
-          terragrunt: "true"
+      # Disabled for Serverless v1 -> v2 upgrade
+      # - name: Terragrunt plan rds
+      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+      #   with:
+      #     directory: "env/cloud/rds"
+      #     comment: "false"
+      #     terragrunt: "true"
 
       - name: Terragrunt plan idp
         uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -295,15 +295,16 @@ jobs:
           comment-title: "Production: redis"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
-
-      - name: Terragrunt plan rds
-        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-        with:
-          directory: "env/cloud/rds"
-          comment-delete: "true"
-          comment-title: "Production: rds"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
+      
+      # Disabled for Serverless v1 -> v2 upgrade
+      # - name: Terragrunt plan rds
+      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+      #   with:
+      #     directory: "env/cloud/rds"
+      #     comment-delete: "true"
+      #     comment-title: "Production: rds"
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+      #     terragrunt: "true"
 
       - name: Terragrunt plan idp
         uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -292,16 +292,17 @@ jobs:
           comment-title: "Staging: redis"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
-
-      - name: Terragrunt plan rds
-        if: steps.filter.outputs.rds == 'true'
-        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-        with:
-          directory: "env/cloud/rds"
-          comment-delete: "true"
-          comment-title: "Staging: rds"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
+      
+      # Disabled for Serverless v1 -> v2 upgrade
+      # - name: Terragrunt plan rds
+      #   if: steps.filter.outputs.rds == 'true'
+      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+      #   with:
+      #     directory: "env/cloud/rds"
+      #     comment-delete: "true"
+      #     comment-title: "Staging: rds"
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+      #     terragrunt: "true"
 
       - name: Terragrunt plan idp
         if: steps.filter.outputs.idp == 'true'


### PR DESCRIPTION
# Summary
Disable the Terraform plan/apply steps for the `rds` module during the Aurora Serverless v1 to v2 upgrade.

This is being done so that the upgrade script changes do not get undone by Terraform changes and to avoid blocking Terraform deployments.

Once the upgrade is complete, these steps will be re-enabled.

# Related
- https://github.com/cds-snc/platform-core-services/issues/630