### PR TITLE
fix: RDS serverless v2 Terraform sync

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -238,10 +238,9 @@ jobs:
         working-directory: env/cloud/redis
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      # Disabled for Serverless v1 -> v2 upgrade
-      # - name: Terragrunt apply rds
-      #   working-directory: env/cloud/rds
-      #   run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      - name: Terragrunt apply rds
+        working-directory: env/cloud/rds
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply idp
         working-directory: env/cloud/idp

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -172,13 +172,12 @@ jobs:
           comment: "false"
           terragrunt: "true"
 
-      # Disabled for Serverless v1 -> v2 upgrade
-      # - name: Terragrunt plan rds
-      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-      #   with:
-      #     directory: "env/cloud/rds"
-      #     comment: "false"
-      #     terragrunt: "true"
+      - name: Terragrunt plan rds
+        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+        with:
+          directory: "env/cloud/rds"
+          comment: "false"
+          terragrunt: "true"
 
       - name: Terragrunt plan idp
         uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -292,17 +292,16 @@ jobs:
           comment-title: "Staging: redis"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
-      
-      # Disabled for Serverless v1 -> v2 upgrade
-      # - name: Terragrunt plan rds
-      #   if: steps.filter.outputs.rds == 'true'
-      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-      #   with:
-      #     directory: "env/cloud/rds"
-      #     comment-delete: "true"
-      #     comment-title: "Staging: rds"
-      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
-      #     terragrunt: "true"
+
+      - name: Terragrunt plan rds
+        if: steps.filter.outputs.rds == 'true'
+        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+        with:
+          directory: "env/cloud/rds"
+          comment-delete: "true"
+          comment-title: "Staging: rds"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
 
       - name: Terragrunt plan idp
         if: steps.filter.outputs.idp == 'true'

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -60,13 +60,18 @@ resource "aws_rds_cluster" "forms" {
 }
 
 resource "aws_rds_cluster_instance" "forms" {
+  #checkov:skip=CKV_AWS_118:enhanced monitoring is not required
+  #checkov:skip=CKV_AWS_353:performance insights are not required
+  #checkov:skip=CKV_AWS_354:performance insights are not required 
   identifier           = "${var.rds_name}-cluster-instance-2"
   cluster_identifier   = aws_rds_cluster.forms.id
   instance_class       = "db.serverless"
   engine               = local.rds_engine
   engine_version       = local.rds_engine_version
   db_subnet_group_name = aws_db_subnet_group.forms.name
-  promotion_tier       = 1
+
+  auto_minor_version_upgrade = true
+  promotion_tier             = 1
 }
 
 # Remove once migration to prod is complete

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -1,3 +1,8 @@
+locals {
+  rds_engine         = "aurora-postgresql"
+  rds_engine_version = "13.12"
+}
+
 resource "random_string" "random" {
   length  = 6
   special = false
@@ -21,9 +26,8 @@ resource "aws_rds_cluster" "forms" {
   // TODO: Implement Encryption using KMS CMKs
 
   cluster_identifier          = "${var.rds_name}-cluster"
-  engine                      = "aurora-postgresql"
-  engine_mode                 = "serverless"
-  engine_version              = "13.12"
+  engine                      = local.rds_engine
+  engine_version              = local.rds_engine_version
   enable_http_endpoint        = true
   database_name               = var.rds_db_name
   deletion_protection         = true
@@ -37,8 +41,7 @@ resource "aws_rds_cluster" "forms" {
   allow_major_version_upgrade = true
   copy_tags_to_snapshot       = true
 
-  scaling_configuration {
-    auto_pause   = false
+  serverlessv2_scaling_configuration {
     max_capacity = 8
     min_capacity = 2
   }
@@ -54,4 +57,20 @@ resource "aws_rds_cluster" "forms" {
       snapshot_identifier
     ]
   }
+}
+
+resource "aws_rds_cluster_instance" "forms" {
+  identifier           = "${var.rds_name}-cluster-instance-2"
+  cluster_identifier   = aws_rds_cluster.forms.id
+  instance_class       = "db.serverless"
+  engine               = local.rds_engine
+  engine_version       = local.rds_engine_version
+  db_subnet_group_name = aws_db_subnet_group.forms.name
+  promotion_tier       = 1
+}
+
+# Remove once migration to prod is complete
+import {
+  to = aws_rds_cluster_instance.forms
+  id = "${var.rds_name}-cluster-instance-2"
 }


### PR DESCRIPTION
# Summary
Update the Terraform now that that Staging Serverless v1 to v2 upgrade is complete.  This also re-enables the workflows managing Staging infrastructure.

The Production workflows will be re-enabled once the upgrade has been completed in that environment.

# Related
- https://github.com/cds-snc/platform-core-services/issues/630