### PR TITLE
fix: Inverted privatelink rule

### DIFF
--- a/aws/network/security_groups_lambda.tf
+++ b/aws/network/security_groups_lambda.tf
@@ -63,9 +63,9 @@ resource "aws_security_group" "lambda" {
 # Internet
 
 resource "aws_vpc_security_group_ingress_rule" "privatelink" {
-  description                  = "Security group rule for Nagware Lambda function ingress"
-  security_group_id            = aws_security_group.lambda.id
-  referenced_security_group_id = aws_security_group.privatelink.id
+  description                  = "Security group rule for Lambda function ingress"
+  security_group_id            =  aws_security_group.privatelink.id
+  referenced_security_group_id =  aws_security_group.lambda.id
   ip_protocol                  = "tcp"
   from_port                    = 443
   to_port                      = 443

--- a/aws/network/security_groups_lambda.tf
+++ b/aws/network/security_groups_lambda.tf
@@ -64,8 +64,8 @@ resource "aws_security_group" "lambda" {
 
 resource "aws_vpc_security_group_ingress_rule" "privatelink" {
   description                  = "Security group rule for Lambda function ingress"
-  security_group_id            =  aws_security_group.privatelink.id
-  referenced_security_group_id =  aws_security_group.lambda.id
+  security_group_id            = aws_security_group.privatelink.id
+  referenced_security_group_id = aws_security_group.lambda.id
   ip_protocol                  = "tcp"
   from_port                    = 443
   to_port                      = 443


### PR DESCRIPTION
# Summary | Résumé
Fixes inverted PrivateLink security group rule.

Was allowing traffic from privatelink => lambda instead of lambda => privatelink

![Screenshot 2024-12-03 at 3 40 54 PM](https://github.com/user-attachments/assets/8a9c940a-d0e9-4c52-a88d-45295aebfd70)
