### PR TITLE
fix: Nagware should handle form template with empty name

### DIFF
--- a/aws/rds/inputs.tf
+++ b/aws/rds/inputs.tf
@@ -44,3 +44,8 @@ variable "rds_security_group_id" {
   description = "The security group used by Redis"
   type        = string
 }
+
+variable "localstack_hosted" {
+  description = "Whether or not the stack is hosted in localstack"
+  type        = bool
+}

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -74,8 +74,11 @@ resource "aws_rds_cluster_instance" "forms" {
   promotion_tier             = 1
 }
 
-# Remove once migration to prod is complete
+# Remove once migration to prod is complete, make sure to also remove the `localstack_hosted` variable used in the import block.
 import {
+  # import block does not support `count` so we need a workaround to make sure no import happens when running in LocalStack
+  for_each = var.localstack_hosted ? toset([]) : toset([1])
+
   to = aws_rds_cluster_instance.forms
   id = "${var.rds_name}-cluster-instance-2"
 }

--- a/env/cloud/rds/terragrunt.hcl
+++ b/env/cloud/rds/terragrunt.hcl
@@ -33,6 +33,8 @@ inputs = {
   # Overwritten in GitHub Actions by TFVARS
   rds_db_password           = "chummy" # RDS database password used for local setup
   rds_connector_db_password = ""
+
+  localstack_hosted = local.env == "local" ? true : false
 }
 
 include {

--- a/lambda-code/nagware/lib/templates.ts
+++ b/lambda-code/nagware/lib/templates.ts
@@ -16,7 +16,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
       {
         user_name?: string;
         email: string;
-        template_name?: string;
+        template_name: string;
         jsonConfig: Record<string, unknown>;
         isPublished: boolean;
       }[]
@@ -30,7 +30,8 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
     if (result.length > 0) {
       const { template_name, jsonConfig, isPublished } = result[0];
 
-      if (!template_name || !jsonConfig || isPublished === undefined) {
+      // Even if we type the result we expect from our Postgres.js request, the properties could still be undefined if they don't exist in the database.
+      if (template_name === undefined || jsonConfig === undefined || isPublished === undefined) {
         throw new Error(
           `Missing required parameters: template name = ${template_name} ; template jsonConfig = ${jsonConfig} ; template isPublished = ${isPublished}.`
         );


### PR DESCRIPTION
# Summary | Résumé

- Fixes Nagware lambda function retrieving template with empty name ("")
- Conditionally disables import block in RDS module due to incompatibility with LocalStack

# Tests

- Create a form without any name (left the input as "Unnamed form file")
- Create one response for that new form
- Update the response item in the Vault and set its `CreatedAt` value to `1`
- Run `awslocal lambda invoke --function-name nagware /dev/null`
- You should not see any error log in https://app.localstack.cloud/inst/default/resources/cloudwatch/groups/%2Faws%2Flambda%2Fnagware/events
- You should be receiving a Nagware email