### PR TITLE
chore: re-enable TF management of rds module

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -246,10 +246,9 @@ jobs:
         working-directory: env/cloud/redis
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      # Disabled for Serverless v1 -> v2 upgrade
-      # - name: Terragrunt apply rds
-      #   working-directory: env/cloud/rds
-      #   run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      - name: Terragrunt apply rds
+        working-directory: env/cloud/rds
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply idp
         working-directory: env/cloud/idp

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -295,16 +295,15 @@ jobs:
           comment-title: "Production: redis"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
-      
-      # Disabled for Serverless v1 -> v2 upgrade
-      # - name: Terragrunt plan rds
-      #   uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
-      #   with:
-      #     directory: "env/cloud/rds"
-      #     comment-delete: "true"
-      #     comment-title: "Production: rds"
-      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
-      #     terragrunt: "true"
+
+      - name: Terragrunt plan rds
+        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+        with:
+          directory: "env/cloud/rds"
+          comment-delete: "true"
+          comment-title: "Production: rds"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
 
       - name: Terragrunt plan idp
         uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0


### PR DESCRIPTION
# Summary
Re-enable the Production Terraform workflow management of the `rds` module now that the Serverless v2 upgrade is complete.

# Related
- https://github.com/cds-snc/platform-core-services/issues/630