### PR TITLE
chore: Enable dynamic ip block on WAF

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -412,7 +412,7 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     priority = 80
 
     action {
-      count {}
+      block {}
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé
Modifies WAF Dynamic IP rule from Count to Block