### PR TITLE
fix: no healthy hosts alarms should treat missing data as breaching

### DIFF
--- a/aws/alarms/cloudwatch_api.tf
+++ b/aws/alarms/cloudwatch_api.tf
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "api_lb_unhealthy_host_count" {
   namespace           = "AWS/ApplicationELB"
   period              = "60"
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "breaching"
 
   alarm_actions = [var.sns_topic_alert_warning_arn]
   ok_actions    = [var.sns_topic_alert_ok_arn]
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "api_lb_healthy_host_count" {
   namespace           = "AWS/ApplicationELB"
   period              = "60"
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   dimensions = {

--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "ELB_healthy_hosts" {
   comparison_operator = "LessThanThreshold"
   threshold           = "1"
   evaluation_periods  = "1"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_critical_arn]
 
   metric_query {
@@ -111,9 +111,9 @@ resource "aws_cloudwatch_metric_alarm" "UnHealthyHostCount-TargetGroup1" {
   evaluation_periods  = "1" # Evaluate once
   metric_name         = "UnHealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"           # Every minute
-  statistic           = "Maximum"      # the highest value observed during the specified period
-  treat_missing_data  = "notBreaching" # don't alarm if there's no data
+  period              = "60"      # Every minute
+  statistic           = "Maximum" # the highest value observed during the specified period
+  treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
   dimensions = {
     LoadBalancer = var.lb_arn_suffix
@@ -129,9 +129,9 @@ resource "aws_cloudwatch_metric_alarm" "UnHealthyHostCount-TargetGroup2" {
   evaluation_periods  = "1" # Evaluate once
   metric_name         = "UnHealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"           # Every minute
-  statistic           = "Maximum"      # the highest value observed during the specified period
-  treat_missing_data  = "notBreaching" # don't alarm if there's no data
+  period              = "60"      # Every minute
+  statistic           = "Maximum" # the highest value observed during the specified period
+  treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
   dimensions = {
     LoadBalancer = var.lb_arn_suffix

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
   namespace           = "AWS/ApplicationELB"
   period              = "60"
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "breaching"
 
   alarm_actions = [var.sns_topic_alert_warning_arn]
   ok_actions    = [var.sns_topic_alert_ok_arn]
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_healthy_host_count" {
   namespace           = "AWS/ApplicationELB"
   period              = "60"
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
 
   dimensions = {


### PR DESCRIPTION
# Summary | Résumé

- Updates alarms around no healthy hosts to treat missing data as breaching

Why?
When we shutdown the web application, all registered targets in the current active target group are being deleted so both the `HealthyHostCount` and `UnHealthyHostCount` metrics are not available.