### PR TITLE
chore: add reference name to previously created Route53 health checks

### DIFF
--- a/aws/load_balancer/route53_health_checks.tf
+++ b/aws/load_balancer/route53_health_checks.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_health_check" "lb_web_app_target_group_1" {
+  reference_name                  = "LB Tar Group 1 health"
   type                            = "CLOUDWATCH_METRIC"
   cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.UnHealthyHostCount-TargetGroup1.alarm_name
   cloudwatch_alarm_region         = var.region
@@ -6,6 +7,7 @@ resource "aws_route53_health_check" "lb_web_app_target_group_1" {
 }
 
 resource "aws_route53_health_check" "lb_web_app_target_group_2" {
+  reference_name                  = "LB Tar Group 2 health"
   type                            = "CLOUDWATCH_METRIC"
   cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.UnHealthyHostCount-TargetGroup2.alarm_name
   cloudwatch_alarm_region         = var.region
@@ -16,6 +18,7 @@ resource "aws_route53_health_check" "lb_web_app_target_group_2" {
 # will be triggered because of that. This health check ensures that at least one target group is healthy. If not then we will be able to
 # serve the maintenance page to our visitors.
 resource "aws_route53_health_check" "lb_web_app_global_target_group" {
+  reference_name         = "Active LB Tar Group health"
   type                   = "CALCULATED"
   child_health_threshold = 1
   child_healthchecks = [


### PR DESCRIPTION
# Summary | Résumé

- Adds reference names to previously created Route53 health checks to help identify what they mean when inside AWS Console