### PR TITLE
fix: handle empty string response for checkbox components

### DIFF
--- a/lambda-code/reliability/lib/dataLayer.ts
+++ b/lambda-code/reliability/lib/dataLayer.ts
@@ -349,24 +349,15 @@ function handleDynamicForm(
 }
 
 function handleArrayResponse(title: string, response: Response, collector: string[]) {
-  if (!Array.isArray(response)) throw new Error("Checkbox responses must be in an array");
-  if (response.length) {
-    if (Array.isArray(response)) {
-      const responses = response
-        .map((item) => {
-          return `-  ${item}`;
-        })
-        .join(String.fromCharCode(13));
-      collector.push(`**${title}**${String.fromCharCode(13)}${responses}`);
-      return;
-    } else {
-      handleTextResponse(title, response, collector);
-      return;
-    }
+  if (Array.isArray(response) && response.length > 0) {
+    const responses = response.map((item) => `-  ${item}`).join(String.fromCharCode(13));
+    collector.push(`**${title}**${String.fromCharCode(13)}${responses}`);
+    return;
   }
+
   // Note the below dash is an em_dash (longer dash). This is a work around for a lone dash being
   // stripped out in an email. Same fore similar cases below.
-  collector.push(`**${title}**${String.fromCharCode(13)}—`); 
+  collector.push(`**${title}**${String.fromCharCode(13)}—`);
 }
 
 function handleTextResponse(title: string, response: Response, collector: string[]) {


### PR DESCRIPTION
# Summary | Résumé

This is related to the incident `email form submission stuck in DLQ / Forms`

- Fixes issue with checkbox component not able to process any response that is not of type array.

# Tests

- Run the scenario that was mentioned in the Slack threads after you deployed the new Reliability Lambda update