### PR TITLE
chore: update waf to take `v[0-9][0-9]` for api server

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -511,7 +511,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_api_uri_paths" {
   description = "Regex to match the api valid urls"
 
   regular_expression {
-    regex_string = "^(?:\\/v1)?\\/forms\\/(?:(\\w{25}))\\/(?:(template|(?:(submission\\/(?:(new|(?:(\\d{2}-\\d{2}-\\w{4})\\/?(?:(confirm\\/\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}|problem)?))))))))(?:\\/)?$"
+    regex_string = "^(?:\\/v(\\d{1,2}))?\\/forms\\/(?:(\\w{25}))\\/(?:(template|(?:(submission\\/(?:(new|(?:(\\d{2}-\\d{2}-\\w{4})\\/?(?:(confirm\\/\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}|problem)?))))))))(?:\\/)?$"
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Adds the versioning moniker to the WAF rules for API server.

Accepts: 
- `/v1/forms/`
- `/v99/forms`
- `/forms`
