### PR TITLE
Chore/update terragrunt et al

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@ volumes:
 services:
   localstack:
     container_name: "GCForms_LocalStack"
-    image: localstack/localstack-pro:3
+    image: localstack/localstack-pro:4
     ports:
       - "127.0.0.1:4566:4566" # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559" # external services port range
       - "127.0.0.1:6379:6379" # Redis
     environment:
-      - SERVICES=cloudwatch,dynamodb,ec2,events,iam,kinesis,kms,lambda,logs,s3,secretsmanager,sns,sqs,elasticache,rds,ecr
+      # - SERVICES=cloudwatch,dynamodb,ec2,events,iam,kinesis,kms,lambda,logs,s3,secretsmanager,sns,sqs,elasticache,rds,ecr
       - LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT=60
       - LAMBDA_SYNCHRONOUS_CREATE=1
       - LAMBDA_IGNORE_ARCHITECTURE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:4510-4559:4510-4559" # external services port range
       - "127.0.0.1:6379:6379" # Redis
     environment:
-      # - SERVICES=cloudwatch,dynamodb,ec2,events,iam,kinesis,kms,lambda,logs,s3,secretsmanager,sns,sqs,elasticache,rds,ecr
+      - SERVICES=cloudwatch,dynamodb,ec2,events,iam,kinesis,kms,lambda,logs,s3,secretsmanager,sns,sqs,elasticache,rds,ecr
       - LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT=60
       - LAMBDA_SYNCHRONOUS_CREATE=1
       - LAMBDA_IGNORE_ARCHITECTURE=1

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -255,6 +255,6 @@ inputs = {
 
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -140,6 +140,6 @@ inputs = {
   sqs_api_audit_log_queue_arn = dependency.sqs.outputs.sqs_api_audit_log_queue_arn
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -194,6 +194,6 @@ inputs = {
   zitadel_provider = local.zitadel_provider
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/cognito/terragrunt.hcl
+++ b/env/cloud/cognito/terragrunt.hcl
@@ -44,6 +44,6 @@ inputs = {
   ecr_repository_url_cognito_pre_sign_up_lambda  = dependency.ecr.outputs.ecr_repository_url_cognito_pre_sign_up_lambda
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/dynamodb/terragrunt.hcl
+++ b/env/cloud/dynamodb/terragrunt.hcl
@@ -19,6 +19,6 @@ inputs = {
   kms_key_dynamodb_arn = dependency.kms.outputs.kms_key_dynamodb_arn
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/ecr/terragrunt.hcl
+++ b/env/cloud/ecr/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "../../../aws//ecr"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/file_scanning/terragrunt.hcl
+++ b/env/cloud/file_scanning/terragrunt.hcl
@@ -19,6 +19,6 @@ inputs = {
   vault_file_storage_id = dependency.s3.outputs.vault_file_storage_id
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/hosted_zone/terragrunt.hcl
+++ b/env/cloud/hosted_zone/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "../../../aws//hosted_zone"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/idp/terragrunt.hcl
+++ b/env/cloud/idp/terragrunt.hcl
@@ -72,6 +72,6 @@ inputs = {
   idp_database_max_acu = 4
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/kms/terragrunt.hcl
+++ b/env/cloud/kms/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "../../../aws//kms"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -2,8 +2,8 @@ terraform {
   source = "../../../aws//lambdas"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }
 
 

--- a/env/cloud/load_balancer/terragrunt.hcl
+++ b/env/cloud/load_balancer/terragrunt.hcl
@@ -38,6 +38,6 @@ inputs = {
   vpc_id                = dependency.network.outputs.vpc_id
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/load_testing/terragrunt.hcl
+++ b/env/cloud/load_testing/terragrunt.hcl
@@ -31,6 +31,6 @@ inputs = {
   lambda_submission_function_name        = dependency.lambdas.outputs.lambda_submission_function_name
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/network/terragrunt.hcl
+++ b/env/cloud/network/terragrunt.hcl
@@ -7,6 +7,6 @@ inputs = {
   vpc_name       = "forms"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/oidc_roles/terragrunt.hcl
+++ b/env/cloud/oidc_roles/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "../../../aws//oidc_roles"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/pr_review/terragrunt.hcl
+++ b/env/cloud/pr_review/terragrunt.hcl
@@ -62,6 +62,6 @@ inputs = {
   forms_submission_lambda_name             = dependency.lambdas.outputs.lambda_submission_function_name
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/rds/terragrunt.hcl
+++ b/env/cloud/rds/terragrunt.hcl
@@ -37,6 +37,6 @@ inputs = {
   localstack_hosted = local.env == "local" ? true : false
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/redis/terragrunt.hcl
+++ b/env/cloud/redis/terragrunt.hcl
@@ -21,6 +21,6 @@ inputs = {
   redis_security_group_id = dependency.network.outputs.redis_security_group_id
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/s3/terragrunt.hcl
+++ b/env/cloud/s3/terragrunt.hcl
@@ -2,8 +2,8 @@ terraform {
   source = "../../../aws//s3"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }
 
 locals {

--- a/env/cloud/secrets/terragrunt.hcl
+++ b/env/cloud/secrets/terragrunt.hcl
@@ -2,8 +2,8 @@ terraform {
   source = "../../../aws//secrets"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }
 
 locals {

--- a/env/cloud/sns/terragrunt.hcl
+++ b/env/cloud/sns/terragrunt.hcl
@@ -22,6 +22,6 @@ inputs = {
   kms_key_cloudwatch_us_east_arn = dependency.kms.outputs.kms_key_cloudwatch_us_east_arn
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/cloud/sqs/terragrunt.hcl
+++ b/env/cloud/sqs/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "../../../aws//sqs"
 }
 
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path = find_in_parent_folders("root.hcl")
 }

--- a/env/common/local-provider.tf
+++ b/env/common/local-provider.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "1.9.8"
+  required_version = "1.10.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.78.0"
+      version = "5.84.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/env/common/provider.tf
+++ b/env/common/provider.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "1.9.8"
+  required_version = "1.10.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.78.0"
+      version = "5.84.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/env/root.hcl
+++ b/env/root.hcl
@@ -1,5 +1,5 @@
 locals {
-  account_id       = get_env("AWS_ACCOUNT_ID", "")
+  account_id       = get_env("AWS_ACCOUNT_ID", "000000000000")
   env              = get_env("APP_ENV", "local")
   domain_api       = get_env("API_DOMAIN", "localhost:3001") 
   domain_idp       = get_env("IDP_DOMAIN", "localhost:8080")
@@ -30,7 +30,7 @@ terraform {
     bucket         = "forms-${local.env}-tfstate"
     dynamodb_table = "tfstate-lock"
     region         = "ca-central-1"
-    key            = "${path_relative_to_include()}/terraform.tfstate"
+    key            = "${path_relative_to_include("root")}/terraform.tfstate"
   }
 }
 EOF
@@ -43,7 +43,7 @@ disable = local.env != "local"
   contents = <<EOF
 terraform {
   backend "local" {
-    path = "${get_parent_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+    path = "${get_parent_terragrunt_dir("root")}/${path_relative_to_include("root")}/terraform.tfstate"
   }
 }
 EOF

--- a/localstack_services.sh
+++ b/localstack_services.sh
@@ -22,8 +22,8 @@ fi
 
 # Set proper terraform and terragrunt versions
 
-tgswitch 0.69.2
-tfswitch 1.9.8
+tgswitch 0.72.5
+tfswitch 1.10.5
 
 basedir=$(pwd)
 


### PR DESCRIPTION
# Summary | Résumé
PR updates our repo to follow Terragrunt [best practices](https://terragrunt.gruntwork.io/docs/migrate/migrating-from-root-terragrunt-hcl/) of using a different name than 'terragrunt.hcl' for the root configuration file.  

Also updates:
-  Localstack to version 4
- Terragrunt to version 0.72.5
- Terraform to 1.10.5
- AWS Provider to 5.84.0

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
