### PR TITLE
chore: IDP waf dynamic Ip now blocks

### DIFF
--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -295,7 +295,7 @@ resource "aws_wafv2_web_acl" "idp" {
     priority = 70
 
     action {
-      count {}
+      block {}
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

Enable Dynamic IP Blocking rule to BLOCK instead of COUNT on IDP.  (Already blocks on app and api)