### PR TITLE
fix: Set output of RDS subnet id to string

### DIFF
--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -38,7 +38,7 @@ output "rds_cluster_instance_identifier" {
 output "rds_cluster_instance_subnet_id" {
   description = "RDS cluster instance's subnet ID, null if not found"
   value = try(
-    [for subnet in data.aws_subnet.private : subnet.id if subnet.availability_zone == aws_rds_cluster_instance.forms.availability_zone],
+    [for subnet in data.aws_subnet.private : subnet.id if subnet.availability_zone == aws_rds_cluster_instance.forms.availability_zone][0],
     null
   )
 }


### PR DESCRIPTION
# Summary | Résumé
Fixes output of RDS subnet id to be a string instead of a list