### PR TITLE
chore:  Use RDS reader endpoint for non-app use

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -214,7 +214,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "rds_connect
     LambdaFunctionName      = "rds-lambda-connector"
     SecurityGroupIds        = var.connector_security_group_id
     SubnetIds               = join(",", var.private_subnet_ids)
-    DefaultConnectionString = "postgres://jdbc:postgresql://${var.rds_cluster_endpoint}:5432/${var.rds_db_name}?$${rds-connector}"
+    DefaultConnectionString = "postgres://jdbc:postgresql://${var.rds_cluster_reader_endpoint}:5432/${var.rds_db_name}?$${rds-connector}"
   }
 }
 

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -275,7 +275,7 @@ variable "connector_security_group_id" {
   type        = string
 }
 
-variable "rds_cluster_endpoint" {
+variable "rds_cluster_reader_endpoint" {
   description = "RDS cluster endpoint"
   sensitive   = true
   type        = string

--- a/aws/glue/inputs.tf
+++ b/aws/glue/inputs.tf
@@ -1,4 +1,4 @@
-variable "rds_cluster_endpoint" {
+variable "rds_cluster_reader_endpoint" {
   description = "The endpoint of the RDS database"
   type        = string
 }

--- a/aws/glue/jobs.tf
+++ b/aws/glue/jobs.tf
@@ -25,7 +25,7 @@ resource "aws_glue_connection" "forms_database" {
   connection_type = "JDBC"
 
   connection_properties = {
-    JDBC_CONNECTION_URL = "jdbc:postgresql://${var.rds_cluster_endpoint}:${var.rds_port}/${var.rds_db_name}"
+    JDBC_CONNECTION_URL = "jdbc:postgresql://${var.rds_cluster_reader_endpoint}:${var.rds_port}/${var.rds_db_name}"
     SECRET_ID           = var.rds_connector_secret_name
   }
 

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -58,8 +58,8 @@ output "rds_db_name" {
   value       = var.rds_db_name
 }
 
-output "rds_cluster_endpoint" {
+output "rds_cluster_reader_endpoint" {
   description = "RDS cluster endpoint"
   sensitive   = true
-  value       = aws_rds_cluster.forms.endpoint
+  value       = aws_rds_cluster.forms.reader_endpoint
 }

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -56,7 +56,7 @@ dependency "rds" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     rds_cluster_identifier = "forms-mock-db-cluster"
-    rds_cluster_endpoint   = "localhost"
+    rds_cluster_reader_endpoint   = "localhost"
     rds_db_name            = "default"
   }
 }
@@ -250,7 +250,7 @@ inputs = {
 
   private_subnet_ids          = dependency.network.outputs.private_subnet_ids
   connector_security_group_id = dependency.network.outputs.connector_security_group_id
-  rds_cluster_endpoint        = dependency.rds.outputs.rds_cluster_endpoint
+  rds_cluster_reader_endpoint        = dependency.rds.outputs.rds_cluster_reader_endpoint
   rds_db_name                 = dependency.rds.outputs.rds_db_name
 
 }

--- a/env/cloud/glue/terragrunt.hcl
+++ b/env/cloud/glue/terragrunt.hcl
@@ -33,7 +33,7 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
     rds_db_name                            = "mock-rds-db-name"
-    rds_cluster_endpoint                   = "mock-rds-cluster-endpoint"
+    rds_cluster_reader_endpoint                   = "mock-rds-cluster-endpoint"
     rds_cluster_instance_availability_zone = "mock-ca-central-1"
     rds_cluster_instance_identifier        = "mock-forms-database-identifier"
     rds_cluster_instance_subnet_id         = "mock-sg-12345678"
@@ -53,7 +53,7 @@ inputs = {
   etl_bucket_name                        = dependency.s3.outputs.etl_bucket_name
   glue_job_security_group_id             = dependency.network.outputs.glue_job_security_group_id
   rds_db_name                            = dependency.rds.outputs.rds_db_name
-  rds_cluster_endpoint                   = dependency.rds.outputs.rds_cluster_endpoint
+  rds_cluster_reader_endpoint                   = dependency.rds.outputs.rds_cluster_reader_endpoint
   rds_port                               = local.env == "local" ? "4510" : "5432" # Localstack is accessed on 4510, AWS on 5432
   rds_cluster_instance_availability_zone = dependency.rds.outputs.rds_cluster_instance_availability_zone
   rds_cluster_instance_identifier        = dependency.rds.outputs.rds_cluster_instance_identifier


### PR DESCRIPTION
# Summary | Résumé
Use the reader-only RDS cluster endpoint for non-app use like Athena and Glue