### PR TITLE
feat: update the processed and historical data paths

### DIFF
--- a/aws/glue/crawlers.tf
+++ b/aws/glue/crawlers.tf
@@ -31,15 +31,15 @@ resource "aws_glue_crawler" "forms_rds_data" {
   security_configuration = aws_glue_security_configuration.encryption_at_rest.name
 
   s3_target {
-    path = "s3://${var.datalake_bucket_name}/processed-data/template/"
+    path = "s3://${var.datalake_bucket_name}/platform/gc-forms/processed-data/template/"
   }
 
   s3_target {
-    path = "s3://${var.datalake_bucket_name}/processed-data/user/"
+    path = "s3://${var.datalake_bucket_name}/platform/gc-forms/processed-data/user/"
   }
 
   s3_target {
-    path = "s3://${var.datalake_bucket_name}/processed-data/templateToUser/"
+    path = "s3://${var.datalake_bucket_name}/platform/gc-forms/processed-data/templateToUser/"
   }
 
   configuration = jsonencode(
@@ -67,7 +67,7 @@ resource "aws_glue_crawler" "forms_historical_data" {
   security_configuration = aws_glue_security_configuration.encryption_at_rest.name
 
   s3_target {
-    path = "s3://${var.datalake_bucket_name}/historical-data"
+    path = "s3://${var.datalake_bucket_name}/platform/gc-forms/historical-data"
   }
 
   configuration = jsonencode(

--- a/aws/glue/scripts/historical_etl.py
+++ b/aws/glue/scripts/historical_etl.py
@@ -28,7 +28,7 @@ historical_df = spark.read.csv(args['s3_bucket'], header=True)
 datasink4 = glueContext.write_dynamic_frame.from_options(
     frame = DynamicFrame.fromDF(historical_df, glueContext, "historical_df"),
     connection_type = "s3",
-    connection_options = {"path": f"s3://{args['rds_bucket']}/historical-data/"},
+    connection_options = {"path": f"s3://{args['rds_bucket']}/platform/gc-forms/historical-data/"},
     format = "parquet",
     transformation_ctx = "datasink4"
 )

--- a/aws/glue/scripts/rds_etl.py
+++ b/aws/glue/scripts/rds_etl.py
@@ -272,7 +272,7 @@ template_to_user_df = template_to_user_df.withColumn("timestamp", date_format(fr
 templateDataSink = glueContext.write_dynamic_frame.from_options(
     frame = final_df,
     connection_type = "s3",
-    connection_options = {"path": f"s3://{args['rds_bucket']}/processed-data/template/"},
+    connection_options = {"path": f"s3://{args['rds_bucket']}/platform/gc-forms/processed-data/template/"},
     format = "parquet",
     transformation_ctx = "templateDataSink"
 )
@@ -280,7 +280,7 @@ templateDataSink = glueContext.write_dynamic_frame.from_options(
 userDataSink = glueContext.write_dynamic_frame.from_options(
     frame = DynamicFrame.fromDF(redacted_user_df, glueContext, "redacted_user_df"),
     connection_type = "s3",
-    connection_options = {"path": f"s3://{args['rds_bucket']}/processed-data/user"},
+    connection_options = {"path": f"s3://{args['rds_bucket']}/platform/gc-forms/processed-data/user"},
     format = "parquet",
     transformation_ctx = "userDataSink"
 )
@@ -288,7 +288,7 @@ userDataSink = glueContext.write_dynamic_frame.from_options(
 templateToUserDataSink = glueContext.write_dynamic_frame.from_options(
     frame = DynamicFrame.fromDF(template_to_user_df, glueContext, "template_to_user_df"),
     connection_type = "s3",
-    connection_options = {"path": f"s3://{args['rds_bucket']}/processed-data/templateToUser"},
+    connection_options = {"path": f"s3://{args['rds_bucket']}/platform/gc-forms/processed-data/templateToUser"},
     format = "parquet",
     transformation_ctx = "templateToUserDataSink"
 )


### PR DESCRIPTION
# Summary 
Update the data paths in preparation for transferring this data to the Platform data lake.

This is being done since the S3 replication rules that will be used to perform the data transfer cannot alter the replicated file's destination prefix.  As such, we're updating the files to have the desired prefix to fit into the data lake's organization structure.

As part of this change, I will manually move the existing data into the correct path structure once this PR merges in each environment.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648