### PR TITLE
feat: add S3 replicate rule to Platform data lake

### DIFF
--- a/aws/glue/locals.tf
+++ b/aws/glue/locals.tf
@@ -1,4 +1,6 @@
 locals {
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
   glue_etl_log_group_name     = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
+
+  platform_data_lake_raw_s3_bucket_arn = "arn:aws:s3:::cds-data-lake-raw-production"
 }

--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platform_data_lake" {
+  role   = aws_iam_role.forms_s3_replicate.arn
+  bucket = var.datalake_bucket_name
+
+  rule {
+    id       = "send-to-platform-data-lake"
+    status   = "Enabled"
+    priority = 10
+
+    destination {
+      bucket = local.platform_data_lake_raw_s3_bucket_arn
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Add an S3 replication rule and IAM role to replicate the processed and historical data to the Platform data lake Raw S3 bucket.

⚠️  **Note:** the plan is to test out the replication in Staging, and then once it's confirmed to be working, disable Staging replication and only replicate from the Prod account.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648