### PR TITLE
chore: revert failing ecr policy

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -60,8 +60,6 @@ env:
   TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
-  # ECR
-  TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:
   # We deploy ECR first to make sure it is available for the 'build-tag-push-lambda-images' job which will be run in parallel with `terragrunt-apply-all-modules`

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -52,8 +52,6 @@ env:
   TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
-  # ECR
-  TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:
   terragrunt-plan:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -62,8 +62,6 @@ env:
   TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
-  # ECR
-  TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:
   detect-lambda-changes:

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -97,30 +97,3 @@ resource "aws_ecr_lifecycle_policy" "api" {
   repository = aws_ecr_repository.api.name
   policy     = file("${path.module}/policy/lifecycle.json")
 }
-
-resource "aws_ecr_registry_policy" "cross_account_read" {
-  count = var.env == "staging" ? 1 : 0
-  policy = jsonencode({
-    policyText = jsonencode({
-      Version = "2012-10-17",
-      Statement = [
-        {
-          Sid       = "AllowCrossAccountPull",
-          Effect    = "Allow",
-          Principal = "*",
-          Action = [
-            "ecr:BatchCheckLayerAvailability",
-            "ecr:BatchGetImage",
-            "ecr:DescribeImages",
-            "ecr:DescribeRepositories",
-            "ecr:GetDownloadUrlForLayer"
-          ],
-          Resource = "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
-          Condition : {
-            StringEquals : { "aws:PrincipalOrgID" : ["${var.cds_org_id}"] }
-          }
-        }
-      ]
-    })
-  })
-}

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -105,19 +105,19 @@ resource "aws_ecr_registry_policy" "cross_account_read" {
       Version = "2012-10-17",
       Statement = [
         {
-          "Sid"       = "AllowCrossAccountPull",
-          "Effect"    = "Allow",
-          "Principal" = "*",
-          "Action" = [
+          Sid       = "AllowCrossAccountPull",
+          Effect    = "Allow",
+          Principal = "*",
+          Action = [
             "ecr:BatchCheckLayerAvailability",
             "ecr:BatchGetImage",
             "ecr:DescribeImages",
             "ecr:DescribeRepositories",
             "ecr:GetDownloadUrlForLayer"
           ],
-          "Resource" = "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
-          "Condition" : {
-            "StringEquals" : { "aws:PrincipalOrgID" : ["${var.cds_org_id}"] }
+          Resource = "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
+          Condition : {
+            StringEquals : { "aws:PrincipalOrgID" : ["${var.cds_org_id}"] }
           }
         }
       ]

--- a/aws/ecr/inputs.tf
+++ b/aws/ecr/inputs.tf
@@ -1,5 +1,0 @@
-variable "cds_org_id" {
-  description = "AWS CDS organization ID"
-  type        = string
-  sensitive   = true
-}

--- a/env/cloud/ecr/terragrunt.hcl
+++ b/env/cloud/ecr/terragrunt.hcl
@@ -5,11 +5,3 @@ terraform {
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }
-
-locals {
-  cds_org_id = get_env("CDS_ORG_ID", "o-1234567890")
-}
-
-inputs = {
-  cds_org_id = local.cds_org_id
-}


### PR DESCRIPTION
# Summary | Résumé
Reverts previous PR's targeting ECR policy for across account sharing until we get this wrapped up properly.