### PR TITLE
feat: replicate prod data to the Platform data lake

### DIFF
--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
 
   rule {
     id       = "send-to-platform-data-lake"
-    status   = "Enabled"
+    status   = var.env == "production" ? "Enabled" : "Disabled"
     priority = 10
 
     destination {


### PR DESCRIPTION
# Summary
Update the S3 replication rule to only replicate date to the Platform data lake in production.

This is because the Platform data lake currently only has one environment and we do not want to intermingle Staging and Production data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648