### PR TITLE
chore: temporarily disable data replication to data lake

### DIFF
--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -3,8 +3,8 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
   bucket = var.datalake_bucket_name
 
   rule {
-    id       = "send-to-platform-data-lake"
-    status   = "Disabled" # Temporarily disabled until testing is complete
+    id     = "send-to-platform-data-lake"
+    status = "Disabled" # Temporarily disabled until testing is complete
 
     destination {
       bucket = local.platform_data_lake_raw_s3_bucket_arn

--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
 
   rule {
     id       = "send-to-platform-data-lake"
-    status   = var.env == "production" ? "Enabled" : "Disabled"
+    status   = "Disabled" # Temporarily disabled until testing is complete
     priority = 10
 
     destination {

--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -5,7 +5,6 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
   rule {
     id       = "send-to-platform-data-lake"
     status   = "Disabled" # Temporarily disabled until testing is complete
-    priority = 10
 
     destination {
       bucket = local.platform_data_lake_raw_s3_bucket_arn


### PR DESCRIPTION
# Summary
Disable the S3 replication rule to the Platform data lake until the ETL job testing is complete.

ℹ️  It is expected that there is no Terraform plan since the replication rule was already disabled in Staging.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648