### PR TITLE
chore: Use explicit accounts ids as org id does not work

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -61,6 +61,7 @@ env:
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
+  TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}
   TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -53,6 +53,7 @@ env:
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
+  TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}
   TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -63,6 +63,7 @@ env:
   TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
+  TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}
   TF_VAR_cds_org_id: ${{ secrets.STAGING_CDS_ORG_ID }}
 
 jobs:

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -100,7 +100,7 @@ resource "aws_ecr_lifecycle_policy" "api" {
 
 resource "aws_ecr_registry_policy" "cross_account_read" {
   count  = var.env == "staging" ? 1 : 0
-  policy = data.aws_iam_policy_document.ecr_cross_account_read.json
+  policy = sensitive(data.aws_iam_policy_document.ecr_cross_account_read.json)
 }
 
 data "aws_iam_policy_document" "ecr_cross_account_read" {

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -105,7 +105,7 @@ resource "aws_ecr_registry_policy" "cross_account_read" {
 
 data "aws_iam_policy_document" "ecr_cross_account_read" {
   statement {
-    sid    = "AllowCrossAccountPull"
+    sid    = "AllowCrossAccountPullOrg"
     effect = "Allow"
     actions = [
       "ecr:BatchCheckLayerAvailability",
@@ -131,5 +131,30 @@ data "aws_iam_policy_document" "ecr_cross_account_read" {
       identifiers = ["*"]
     }
   }
+  statement {
+    sid    = "AllowCrossAccountPullLambda"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:sourceAccount"
+      values   = var.aws_development_accounts
+    }
+
+    resources = ["arn:aws:ecr:${var.region}:${var.account_id}:repository/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
 
 }
+

--- a/aws/ecr/inputs.tf
+++ b/aws/ecr/inputs.tf
@@ -3,3 +3,8 @@ variable "cds_org_id" {
   type        = string
   sensitive   = true
 }
+
+variable "aws_development_accounts" {
+  description = "List of AWS development account IDs"
+  type        = list(string)
+}

--- a/env/cloud/ecr/terragrunt.hcl
+++ b/env/cloud/ecr/terragrunt.hcl
@@ -6,10 +6,8 @@ include "root" {
   path = find_in_parent_folders("root.hcl")
 }
 
-locals {
-  cds_org_id = get_env("CDS_ORG_ID", "o-1234567890")
-}
-
 inputs = {
-  cds_org_id = local.cds_org_id
+  // overwritten by TFVars
+  aws_development_accounts = ["123456789012"]
+  cds_org_id               = ["o-1234567890"]
 }


### PR DESCRIPTION
# Summary | Résumé

We need to use explicit aws account ids for developers in the ECR policy as the principals making the API calls to Staging are not part of the "organization" as they are service accounts.