### PR TITLE
fix: revert localstack detection when initializing Postgres connector

### DIFF
--- a/lambda-code/nagware/lib/templates.ts
+++ b/lambda-code/nagware/lib/templates.ts
@@ -14,7 +14,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
     const postgresConnector =
       await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
         process.env.DB_URL ?? "",
-        Boolean(process.env.LOCALSTACK)
+        process.env.LOCALSTACK === "true"
       );
 
     // Due to Localstack limitations we have to define aliases for fields that have the same name

--- a/lambda-code/reliability/lib/templates.ts
+++ b/lambda-code/reliability/lib/templates.ts
@@ -15,7 +15,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo | nu
     const postgresConnector =
       await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
         process.env.DB_URL ?? "",
-        Boolean(process.env.LOCALSTACK)
+        process.env.LOCALSTACK === "true"
       );
 
     const templates = await postgresConnector.executeSqlStatement()<


### PR DESCRIPTION
# Summary | Résumé

- Reverts localstack detection when initializing Postgres connector