### PR TITLE
fix: add prisma lambda to filter for build

### DIFF
--- a/.github/lambda-filter.yml
+++ b/.github/lambda-filter.yml
@@ -37,3 +37,6 @@ submission:
 vault-integrity:
   - "lambda-code/vault-integrity/**"
   - "lambda-code/force-deploy-images.txt"
+prisma-migration:
+  - "lambda-code/prisma-migration/**"
+  - "lambda-code/force-deploy-images.txt"

--- a/.github/production-lambda-functions.conf
+++ b/.github/production-lambda-functions.conf
@@ -1,14 +1,15 @@
 [
-  "audit-logs",
-  "audit-logs-archiver",
-  "cognito-email-sender",
-  "cognito-pre-sign-up",
-  "form-archiver",
-  "nagware",
-  "notify-slack",
-  "reliability",
-  "reliability-dlq-consumer",
-  "response-archiver",
-  "submission",
-  "vault-integrity"
+"audit-logs",
+"audit-logs-archiver",
+"cognito-email-sender",
+"cognito-pre-sign-up",
+"form-archiver",
+"nagware",
+"notify-slack",
+"reliability",
+"reliability-dlq-consumer",
+"response-archiver",
+"submission",
+"vault-integrity",
+"prisma-migration"
 ]


### PR DESCRIPTION
# Summary | Résumé
Adds prisma migration lambda to github action lambda filter to ensure it is built and deployed.