### PR TITLE
fix: missing permissions to copy S3 object with tags

### DIFF
--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -209,7 +209,9 @@ data "aws_iam_policy_document" "lambda_s3" {
       "s3:DeleteObject",
       "s3:GetObject",
       "s3:PutObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging"
     ]
 
     resources = [


### PR DESCRIPTION
# Summary | Résumé

- Adds missing permissions for the Response Archiver lambda function to execute S3 CopyObject operations. Now that the file scanner adds tags to S3 objects we need new permissions (see https://medium.com/collaborne-engineering/s3-copyobject-access-denied-5f7a6fe0393e).