### PR TITLE
chore: script clean up

### DIFF
--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -91,7 +91,7 @@ if [ -z "$MODULE_NAME" ]; then
 else
   printf "${greenColor}=> Only building ${MODULE_NAME} Terragrunt Module${reset}\n"
   cd $basedir/env/cloud/$MODULE_NAME
-  terragrunt apply --terragrunt-non-interactive -auto-approve --terragrunt-log-level warn
+  terragrunt apply --non-interactive --log-level warn
   exit 0
 fi
 

--- a/local_dev_files/connect_vpn.sh
+++ b/local_dev_files/connect_vpn.sh
@@ -8,6 +8,8 @@ reset='\033[0m' # No Color
 
 basedir=$(pwd)
 
+export TG_PROVIDER_CACHE=1
+
 # Set proper terraform and terragrunt versions
 
 tgswitch 0.75.10


### PR DESCRIPTION
# Summary | Résumé
Some small housekeeping:
- ensure all terragrunt commands reference the new CLI pattern without the `--terragrunt` prefix.
- Add terragrunt env var to all scripts that reference package cache