### PR TITLE
chore: Adds captcha path to app WAF regex

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -481,7 +481,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_app_uri_paths" {
 
   # App paths
   regular_expression {
-    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|api|form-builder|forms|id|auth|profile|support|contact|unlock-publishing)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
+    regex_string = "^\\/(?:en|fr)?\\/?(?:(admin|api|form-builder|forms|id|auth|profile|support|contact|unlock-publishing|captcha)(?:\\/[\\w-]+)?)(?:\\/.*)?$"
   }
 
   # Static Pages


### PR DESCRIPTION
# Summary | Résumé

Adds captcha path to WAF app regex.

Probably the easiest way to test is merging and then on Staging try to navigate to https://forms-staging.cdssandbox.xyz/en/captcha
