### PR TITLE
fix: add back auto-approve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ build_env build_module: guard-STAGING_AWS_ACCOUNT_ID
 	fmt \
 	hclfmt \
 	help \
-	terragrunt \
 	validate \
 	build_env \
 	build_module \

--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -90,7 +90,7 @@ if [ -z "$MODULE_NAME" ]; then
 else
   printf "${greenColor}=> Only building ${MODULE_NAME} Terragrunt Module${reset}\n"
   cd $basedir/env/cloud/$MODULE_NAME
-  terragrunt apply --non-interactive --log-level warn -auto-approve
+  terragrunt apply --non-interactive --log-level info -auto-approve
   exit 0
 fi
 

--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -73,8 +73,7 @@ fi
 if [ -z "$MODULE_NAME" ]; then
   printf "${greenColor}=> Building All Terragrunt Modules${reset}\n"
   terragrunt run-all apply \
-    --non-interactive --log-level info \
-    --queue-strict-include \
+    --non-interactive --log-level info -auto-approve --queue-strict-include \
     --working-dir $basedir/env \
     --queue-include-dir $basedir/env/cloud/kms \
     --queue-include-dir $basedir/env/cloud/network \
@@ -91,7 +90,7 @@ if [ -z "$MODULE_NAME" ]; then
 else
   printf "${greenColor}=> Only building ${MODULE_NAME} Terragrunt Module${reset}\n"
   cd $basedir/env/cloud/$MODULE_NAME
-  terragrunt apply --non-interactive --log-level warn
+  terragrunt apply --non-interactive --log-level warn -auto-approve
   exit 0
 fi
 

--- a/local_dev_files/connect_vpn.sh
+++ b/local_dev_files/connect_vpn.sh
@@ -47,7 +47,7 @@ if [[ "$num_of_associations" -eq 0 ]]; then
   yarn build && yarn postbuild
   # Apply VPN terraform module
   cd $basedir/env/cloud/vpn
-  terragrunt apply --non-interactive --log-level warn
+  terragrunt apply --non-interactive --log-level warn -auto-approve
 fi
 
 printf "${greenColor}=> VPN endpoint ${vpn_endpoint_id} has ${num_of_associations} subnet associations.${reset}\n"

--- a/local_dev_files/connect_vpn.sh
+++ b/local_dev_files/connect_vpn.sh
@@ -47,7 +47,7 @@ if [[ "$num_of_associations" -eq 0 ]]; then
   yarn build && yarn postbuild
   # Apply VPN terraform module
   cd $basedir/env/cloud/vpn
-  terragrunt apply --non-interactive --log-level warn -auto-approve
+  terragrunt apply --non-interactive --log-level info -auto-approve
 fi
 
 printf "${greenColor}=> VPN endpoint ${vpn_endpoint_id} has ${num_of_associations} subnet associations.${reset}\n"

--- a/local_dev_files/destroy_dev_env.sh
+++ b/local_dev_files/destroy_dev_env.sh
@@ -23,6 +23,7 @@ printf "${greenColor}=> Destroying AWS services${reset}\n"
 terragrunt run-all destroy \
     --non-interactive --log-level warn \
     --queue-strict-include \
+    -auto-approve \
     --working-dir $basedir/env \
     --queue-include-dir $basedir/env/cloud/kms \
     --queue-include-dir $basedir/env/cloud/network \


### PR DESCRIPTION
# Summary | Résumé
add back `-auto-approve` flag as it is only passed in silently when using the new `run --all` command which is still behind an `--experimental` flag.