### PR TITLE
chore: re-enable Staging data replication to Data Lake

### DIFF
--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
 
   rule {
     id     = "send-to-platform-data-lake"
-    status = "Disabled" # Temporarily disabled until testing is complete
+    status = var.env == "staging" ? "Enabled" : "Disabled" # Temporarily disabled in Prod until testing is complete
 
     destination {
       bucket = local.platform_data_lake_raw_s3_bucket_arn


### PR DESCRIPTION
# Summary
Update the data S3 replication rule so that Staging data is sent to the Platform Data Lake.  This will allow us to validate the data before making Production data available.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648