### PR TITLE
feat: enable data lake replication from production

### DIFF
--- a/aws/glue/s3.tf
+++ b/aws/glue/s3.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket_replication_configuration" "forms_s3_replicate_to_platfo
 
   rule {
     id     = "send-to-platform-data-lake"
-    status = var.env == "staging" ? "Enabled" : "Disabled" # Temporarily disabled in Prod until testing is complete
+    status = var.env == "production" ? "Enabled" : "Disabled"
 
     destination {
       bucket = local.platform_data_lake_raw_s3_bucket_arn


### PR DESCRIPTION
# Summary
Update the S3 data replication to the data lake so that it is enabled for Production.  Data validation has been completed with the Staging data and all looks good.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648