### PR TITLE
chore: reduce the number of oidc roles created

### DIFF
--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -38,14 +38,9 @@ module "github_workflow_roles" {
       claim     = "ref:refs/tags/v*"
     },
     {
-      name      = "${local.platform_forms_client_db_migration}-staging"
+      name      = "${local.platform_forms_client_db_migration}"
       repo_name = "platform-forms-client"
-      claim     = "ref:refs/heads/main"
-    },
-    {
-      name      = "${local.platform_forms_client_db_migration}-production"
-      repo_name = "platform-forms-client"
-      claim     = "ref:refs/tags/v*"
+      claim     = var.env == "staging" ? "ref:refs/heads/main" : "ref:refs/tags/v*"
     }
   ]
 }
@@ -81,20 +76,11 @@ resource "aws_iam_role_policy_attachment" "platform_forms_client_release" {
   ]
 }
 
-resource "aws_iam_role_policy_attachment" "platform_forms_db_migration_staging" {
-  count      = var.env == "staging" ? 1 : 0
-  role       = "${local.platform_forms_client_db_migration}-staging"
+resource "aws_iam_role_policy_attachment" "platform_forms_db_migration" {
+  role       = "${local.platform_forms_client_db_migration}"
   policy_arn = aws_iam_policy.forms_db_migration.arn
   depends_on = [
     module.github_workflow_roles
   ]
 }
 
-resource "aws_iam_role_policy_attachment" "platform_forms_db_migration_production" {
-  count      = var.env == "production" ? 1 : 0
-  role       = "${local.platform_forms_client_db_migration}-production"
-  policy_arn = aws_iam_policy.forms_db_migration.arn
-  depends_on = [
-    module.github_workflow_roles
-  ]
-}

--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -77,7 +77,7 @@ resource "aws_iam_role_policy_attachment" "platform_forms_client_release" {
 }
 
 resource "aws_iam_role_policy_attachment" "platform_forms_db_migration" {
-  role       = "${local.platform_forms_client_db_migration}"
+  role       = local.platform_forms_client_db_migration
   policy_arn = aws_iam_policy.forms_db_migration.arn
   depends_on = [
     module.github_workflow_roles


### PR DESCRIPTION
# Summary | Résumé
Reduces the complexity and naming of oidc roles required for prisma migration.  Instead of using different names for the roles required for Staging and Production the same role name is used by the claim is based on the env.