### PR TITLE
fix: add lambda get function to prisma role

### DIFF
--- a/aws/oidc_roles/iam_policies.tf
+++ b/aws/oidc_roles/iam_policies.tf
@@ -198,6 +198,7 @@ data "aws_iam_policy_document" "forms_db_migration" {
     effect = "Allow"
     actions = [
       "lambda:InvokeFunction",
+      "lambda:GetFunction"
     ]
     resources = [
       "arn:aws:lambda:${var.region}:${var.account_id}:function:prisma-migration",


### PR DESCRIPTION
# Summary | Résumé
Adds the `GetFunction` permission to the Prisma Migration OIDC role.  The permission is needed in order to check if the lambda is active and can be invoked.