### PR TITLE
fix: Boost lambda memory

### DIFF
--- a/aws/lambdas/prisma_migration.tf
+++ b/aws/lambdas/prisma_migration.tf
@@ -4,6 +4,7 @@ resource "aws_lambda_function" "prisma_migration" {
   package_type  = "Image"
   role          = aws_iam_role.lambda.arn
   timeout       = 300
+  memory_size   = 512
 
   lifecycle {
     ignore_changes = [image_uri]


### PR DESCRIPTION
# Summary | Résumé
Lambda running very slowly due to max memory usage.  In click-ops testing 512 seems to do the trick.