### PR TITLE
chore: bump connectors package from v1 to v2

### DIFF
--- a/lambda-code/cognito-email-sender/package.json
+++ b/lambda-code/cognito-email-sender/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "4.0.0",
-    "@gcforms/connectors": "^1.0.0"
+    "@gcforms/connectors": "^2.0.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.126",

--- a/lambda-code/cognito-email-sender/yarn.lock
+++ b/lambda-code/cognito-email-sender/yarn.lock
@@ -984,10 +984,10 @@
   dependencies:
     tslib "^2.3.1"
 
-"@gcforms/connectors@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-1.0.0.tgz#e34b66e0cc268de52634a06d7fd0b55190687f91"
-  integrity sha512-mnSgNflpoBIzzOt43+uho1Fc3TjuZefL5qCPONGyv7pQXYVjrEtS5R5t6SgWO+Y9RX0rrlKQZfmmFOyw2Y2c8g==
+"@gcforms/connectors@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
+  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
     axios "^1.7.9"

--- a/lambda-code/nagware/lib/templates.ts
+++ b/lambda-code/nagware/lib/templates.ts
@@ -13,8 +13,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
   try {
     const postgresConnector =
       await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
-        process.env.DB_URL ?? "",
-        false
+        process.env.DB_URL ?? ""
       );
 
     const result = await postgresConnector.executeSqlStatement()<

--- a/lambda-code/nagware/package.json
+++ b/lambda-code/nagware/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.667.0",
     "@aws-sdk/lib-dynamodb": "3.667.0",
-    "@gcforms/connectors": "^1.0.0",
+    "@gcforms/connectors": "^2.0.0",
     "redis": "^4.7.0"
   },
   "devDependencies": {

--- a/lambda-code/nagware/yarn.lock
+++ b/lambda-code/nagware/yarn.lock
@@ -858,10 +858,10 @@
     "@smithy/types" "^4.1.0"
     tslib "^2.6.2"
 
-"@gcforms/connectors@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-1.0.0.tgz#e34b66e0cc268de52634a06d7fd0b55190687f91"
-  integrity sha512-mnSgNflpoBIzzOt43+uho1Fc3TjuZefL5qCPONGyv7pQXYVjrEtS5R5t6SgWO+Y9RX0rrlKQZfmmFOyw2Y2c8g==
+"@gcforms/connectors@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
+  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
     axios "^1.7.9"

--- a/lambda-code/reliability/lib/templates.ts
+++ b/lambda-code/reliability/lib/templates.ts
@@ -14,8 +14,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo | nu
   try {
     const postgresConnector =
       await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
-        process.env.DB_URL ?? "",
-        false
+        process.env.DB_URL ?? ""
       );
 
     const templates = await postgresConnector.executeSqlStatement()<

--- a/lambda-code/reliability/package.json
+++ b/lambda-code/reliability/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-s3": "3.667.0",
     "@aws-sdk/client-sqs": "3.667.0",
     "@aws-sdk/lib-dynamodb": "3.667.0",
-    "@gcforms/connectors": "^1.0.0",
+    "@gcforms/connectors": "^2.0.0",
     "json2md": "^1.10.0",
     "uuid": "^8.3.2"
   },

--- a/lambda-code/reliability/yarn.lock
+++ b/lambda-code/reliability/yarn.lock
@@ -1170,10 +1170,10 @@
     "@smithy/types" "^3.5.0"
     tslib "^2.6.2"
 
-"@gcforms/connectors@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-1.0.0.tgz#e34b66e0cc268de52634a06d7fd0b55190687f91"
-  integrity sha512-mnSgNflpoBIzzOt43+uho1Fc3TjuZefL5qCPONGyv7pQXYVjrEtS5R5t6SgWO+Y9RX0rrlKQZfmmFOyw2Y2c8g==
+"@gcforms/connectors@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
+  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
     axios "^1.7.9"


### PR DESCRIPTION
# Summary | Résumé

- Bumps https://www.npmjs.com/package/@gcforms/connectors package from v1 to v2 (removal of Localstack support)