### PR TITLE
chore: update connectors package to version 2.0.2 in order to pull Axios 1.8.4 update

### DIFF
--- a/lambda-code/cognito-email-sender/package.json
+++ b/lambda-code/cognito-email-sender/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "4.0.0",
-    "@gcforms/connectors": "^2.0.0"
+    "@gcforms/connectors": "^2.0.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.126",

--- a/lambda-code/cognito-email-sender/yarn.lock
+++ b/lambda-code/cognito-email-sender/yarn.lock
@@ -984,13 +984,13 @@
   dependencies:
     tslib "^2.3.1"
 
-"@gcforms/connectors@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
-  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
+"@gcforms/connectors@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.2.tgz#be8bbf8a4bac7064624ccdc4f8a4d107dbf4da45"
+  integrity sha512-b+1IGqgMNJZCHQOTFSpOLva95cZYy5X2tpnWp0PfHNn7gOeRo8NNRkennj6hAb49P5+XppyHKgGQ/KUxgESX3Q==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
-    axios "^1.7.9"
+    axios "^1.8.4"
     postgres "^3.4.5"
 
 "@smithy/abort-controller@^2.0.15":
@@ -1819,10 +1819,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"

--- a/lambda-code/nagware/package.json
+++ b/lambda-code/nagware/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.667.0",
     "@aws-sdk/lib-dynamodb": "3.667.0",
-    "@gcforms/connectors": "^2.0.0",
+    "@gcforms/connectors": "^2.0.2",
     "redis": "^4.7.0"
   },
   "devDependencies": {

--- a/lambda-code/nagware/yarn.lock
+++ b/lambda-code/nagware/yarn.lock
@@ -858,13 +858,13 @@
     "@smithy/types" "^4.1.0"
     tslib "^2.6.2"
 
-"@gcforms/connectors@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
-  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
+"@gcforms/connectors@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.2.tgz#be8bbf8a4bac7064624ccdc4f8a4d107dbf4da45"
+  integrity sha512-b+1IGqgMNJZCHQOTFSpOLva95cZYy5X2tpnWp0PfHNn7gOeRo8NNRkennj6hAb49P5+XppyHKgGQ/KUxgESX3Q==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
-    axios "^1.7.9"
+    axios "^1.8.4"
     postgres "^3.4.5"
 
 "@redis/bloom@1.2.0":
@@ -1695,10 +1695,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"

--- a/lambda-code/reliability/package.json
+++ b/lambda-code/reliability/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-s3": "3.667.0",
     "@aws-sdk/client-sqs": "3.667.0",
     "@aws-sdk/lib-dynamodb": "3.667.0",
-    "@gcforms/connectors": "^2.0.0",
+    "@gcforms/connectors": "^2.0.2",
     "json2md": "^1.10.0",
     "uuid": "^8.3.2"
   },

--- a/lambda-code/reliability/yarn.lock
+++ b/lambda-code/reliability/yarn.lock
@@ -1170,13 +1170,13 @@
     "@smithy/types" "^3.5.0"
     tslib "^2.6.2"
 
-"@gcforms/connectors@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.0.tgz#24dea38dc27ee017951797875863537ef08de62b"
-  integrity sha512-PvF/kG1Ss56N9AOoMMn1xEyVp+/g3N2kCmyt+g9X7P+38PFaMEAvwAzRc8F9+JoA1rvox9SCoNVZarmaU2VLkw==
+"@gcforms/connectors@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@gcforms/connectors/-/connectors-2.0.2.tgz#be8bbf8a4bac7064624ccdc4f8a4d107dbf4da45"
+  integrity sha512-b+1IGqgMNJZCHQOTFSpOLva95cZYy5X2tpnWp0PfHNn7gOeRo8NNRkennj6hAb49P5+XppyHKgGQ/KUxgESX3Q==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.750.0"
-    axios "^1.7.9"
+    axios "^1.8.4"
     postgres "^3.4.5"
 
 "@smithy/abort-controller@^3.1.5":
@@ -2071,10 +2071,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
# Summary | Résumé

- Updates Connectors package to version `2.0.2` (to pull in Axios update `1.8.4`)