### PR TITLE
chore: disable Nagware Slack notifications

### DIFF
--- a/lambda-code/nagware/main.ts
+++ b/lambda-code/nagware/main.ts
@@ -24,12 +24,11 @@ export const handler: Handler = async () => {
     const oldestFormResponseByFormID = await findOldestFormResponseByFormID();
 
     const dayOfWeek = new Date().getDay();
-    const isSunday = dayOfWeek == 0;
     const isTuesdayOrThursday = dayOfWeek == 2 || dayOfWeek == 4;
 
     await nagOrDelete(oldestFormResponseByFormID, {
       shouldSendEmail: isTuesdayOrThursday,
-      shouldSendSlackNotification: isSunday,
+      shouldSendSlackNotification: false,
     });
 
     await setOverdueResponseCache(oldestFormResponseByFormID);


### PR DESCRIPTION
# Summary | Résumé

- Disables Nagware notifications on Slack