### PR TITLE
feat: bump healthy host count alarm to SEV1

### DIFF
--- a/aws/alarms/cloudwatch_api.tf
+++ b/aws/alarms/cloudwatch_api.tf
@@ -1,14 +1,15 @@
 #
 # ECS resource usage alarms
 #
+
 resource "aws_cloudwatch_metric_alarm" "api_cpu_utilization_high_warn" {
   alarm_name          = "API-CpuUtilizationWarn"
   alarm_description   = "API ECS Warning - High CPU usage has been detected."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = 2
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = 120
   statistic           = "Maximum"
   threshold           = var.threshold_ecs_cpu_utilization_high
   treat_missing_data  = "notBreaching"
@@ -29,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "api_memory_utilization_high_warn" {
   evaluation_periods  = 2
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = 120
   statistic           = "Maximum"
   threshold           = var.threshold_ecs_memory_utilization_high
   treat_missing_data  = "notBreaching"
@@ -57,11 +58,11 @@ resource "aws_cloudwatch_metric_alarm" "api_lb_unhealthy_host_count" {
   alarm_name          = "API-UnhealthyHostCount"
   alarm_description   = "API LB Warning - unhealthy host count >= 1 in a 1 minute period"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = "1"
-  evaluation_periods  = "1"
+  threshold           = 1
+  evaluation_periods  = 1
   metric_name         = "UnHealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = 60
   statistic           = "Maximum"
   treat_missing_data  = "breaching"
 
@@ -75,14 +76,14 @@ resource "aws_cloudwatch_metric_alarm" "api_lb_unhealthy_host_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_lb_healthy_host_count" {
-  alarm_name          = "API-HealthyHostCount" # TODO: bump to SEV1 once this is in production
+  alarm_name          = "API-HealthyHostCount-SEV1" # SEV1 will prompt the on-call team to respond.
   alarm_description   = "API LB Critical - no healthy hosts in a 1 minute period"
   comparison_operator = "LessThanThreshold"
-  threshold           = "1"
-  evaluation_periods  = "1"
+  threshold           = 1
+  evaluation_periods  = 1
   metric_name         = "HealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = 60
   statistic           = "Maximum"
   treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
@@ -97,8 +98,8 @@ resource "aws_cloudwatch_metric_alarm" "api_response_time_warn" {
   alarm_name          = "API-ResponseTimeWarn"
   alarm_description   = "API LB Warning - The latency of response times from the API are abnormally high."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "5"
-  datapoints_to_alarm = "2"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 2
   threshold           = var.threshold_lb_response_time
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
@@ -123,11 +124,12 @@ resource "aws_cloudwatch_metric_alarm" "api_response_time_warn" {
 #
 # Audit Log Dead Letter Queue
 #
+
 resource "aws_cloudwatch_metric_alarm" "api_audit_log_dead_letter_queue_warn" {
   alarm_name          = "ApiAuditLogDeadLetterQueueWarn"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  threshold           = "0"
+  evaluation_periods  = 1
+  threshold           = 0
   alarm_description   = "Detect when a message is sent to the API Audit Log Dead Letter Queue"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
 

--- a/aws/alarms/cloudwatch_idp.tf
+++ b/aws/alarms/cloudwatch_idp.tf
@@ -5,10 +5,10 @@ resource "aws_cloudwatch_metric_alarm" "idp_cpu_utilization_high_warn" {
   alarm_name          = "IdP-CpuUtilizationWarn"
   alarm_description   = "IdP ECS Warning - High CPU usage has been detected."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = 2
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = 120
   statistic           = "Maximum"
   threshold           = var.threshold_ecs_cpu_utilization_high
   treat_missing_data  = "notBreaching"
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_memory_utilization_high_warn" {
   evaluation_periods  = 2
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = 120
   statistic           = "Maximum"
   threshold           = var.threshold_ecs_memory_utilization_high
   treat_missing_data  = "notBreaching"
@@ -59,11 +59,11 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
   alarm_name          = "IdP-UnhealthyHostCount-${each.key}"
   alarm_description   = "IdP LB Warning - unhealthy ${each.key} host count >= 1 in a 1 minute period"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = "1"
-  evaluation_periods  = "1"
+  threshold           = 1
+  evaluation_periods  = 1
   metric_name         = "UnHealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = 60
   statistic           = "Maximum"
   treat_missing_data  = "breaching"
 
@@ -79,14 +79,14 @@ resource "aws_cloudwatch_metric_alarm" "idb_lb_unhealthy_host_count" {
 resource "aws_cloudwatch_metric_alarm" "idb_lb_healthy_host_count" {
   for_each = var.lb_idp_target_groups_arn_suffix
 
-  alarm_name          = "IdP-HealthyHostCount-${each.key}" # TODO: bump to SEV1 once in production
+  alarm_name          = "IdP-HealthyHostCount-${each.key}-SEV1" # SEV1 will prompt the on-call team to respond.
   alarm_description   = "IdP LB Critical - no healthy ${each.key} hosts in a 1 minute period"
   comparison_operator = "LessThanThreshold"
-  threshold           = "1"
-  evaluation_periods  = "1"
+  threshold           = 1
+  evaluation_periods  = 1
   metric_name         = "HealthyHostCount"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = 60
   statistic           = "Maximum"
   treat_missing_data  = "breaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
@@ -101,8 +101,8 @@ resource "aws_cloudwatch_metric_alarm" "idp_response_time_warn" {
   alarm_name          = "IdP-ResponseTimeWarn"
   alarm_description   = "IdP LB Warning - The latency of response times from the IdP are abnormally high."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "5"
-  datapoints_to_alarm = "2"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 2
   threshold           = var.threshold_lb_response_time
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_topic_alert_warning_arn]
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_response_time_warn" {
     metric {
       metric_name = "TargetResponseTime"
       namespace   = "AWS/ApplicationELB"
-      period      = "60"
+      period      = 60
       stat        = "Average"
       dimensions = {
         LoadBalancer = var.lb_idp_arn_suffix
@@ -130,10 +130,10 @@ resource "aws_cloudwatch_metric_alarm" "idp_rds_cpu_utilization" {
   alarm_name          = "IdP-RDSCpuUtilization"
   alarm_description   = "IdP RDS Warning - high CPU use for RDS cluster in a 5 minute period"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
-  period              = "300"
+  period              = 300
   statistic           = "Average"
   threshold           = var.rds_idp_cpu_maxiumum
 
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_bounce_rate_high" {
   alarm_name          = "IdP-SESBounceRate"
   alarm_description   = "IdP SES Warning - bounce rate >=7% over the last 12 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = "Reputation.BounceRate"
   namespace           = "AWS/SES"
   period              = 60 * 60 * 12
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "idp_complaint_rate_high" {
   alarm_name          = "IdP-SESComplaintRate"
   alarm_description   = "IdP SES Warning - complaint rate >=0.4% over the last 12 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = "Reputation.ComplaintRate"
   namespace           = "AWS/SES"
   period              = 60 * 60 * 12

--- a/aws/load_balancer/lb.tf
+++ b/aws/load_balancer/lb.tf
@@ -81,7 +81,7 @@ resource "aws_lb_target_group" "forms_api" {
 
   health_check {
     enabled             = true
-    interval            = 10
+    interval            = 20
     port                = 3001
     path                = "/status"
     matcher             = "200"


### PR DESCRIPTION
# Summary | Résumé

- Adds SEV1 suffix to API and IdP HealthyHostCount alarm
- Increases API `/status` health check polling interval from 10 to 20