### PR TITLE
feat: replaced out of country alarm by WAF header injection for detection within the web application

### DIFF
--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -503,29 +503,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_run_lambda" {
   source_arn    = "arn:aws:logs:ca-central-1:${var.account_id}:log-group:*:*"
 }
 
-// Monitor for Cognito sign-ins from outside of Canada within a 1 minute period
-resource "aws_cloudwatch_metric_alarm" "cognito_login_outside_canada_warn" {
-  alarm_name          = "AWSCognitoLoginOutsideCanadaAlarm"
-  namespace           = "AWS/WAFV2"
-  metric_name         = "CountedRequests"
-  statistic           = "SampleCount"
-  period              = "60" // 1 minute
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = "0"
-  evaluation_periods  = "1"            // number of datapoints to evaluate
-  treat_missing_data  = "notBreaching" // don't alarm if there's no data
-
-  alarm_actions = [var.sns_topic_alert_warning_arn]
-
-  dimensions = {
-    Rule   = "AWSCognitoLoginOutsideCanada"
-    WebACL = "GCForms"
-    Region = "ca-central-1"
-  }
-
-  alarm_description = "Forms: A sign-in by a forms owner has been detected from outside of Canada."
-}
-
 #
 # Service health: these will trigger if expected metrics thresholds are not met
 #

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -366,7 +366,14 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     priority = 70
 
     action {
-      count {}
+      count {
+        custom_request_handling {
+          insert_header {
+            name  = "cognito-login-outside-of-canada"
+            value = "detected"
+          }
+        }
+      }
     }
 
     statement {


### PR DESCRIPTION
- Replaces the login out of country Cognito login alarm by a simple flag using WAF header injection. The new HTTP header will be used by the web application to produce an info log