### PR TITLE
fix: add missing Scan permission on DynamoDB for the API service

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "api_ecs_dynamodb_vault" {
       "dynamodb:BatchWriteItem",
       "dynamodb:BatchGetItem",
       "dynamodb:Query",
+      "dynamodb:Scan",
     ]
 
     resources = [


### PR DESCRIPTION
# Summary | Résumé

- Adds missing Scan permission on DynamoDB for the API service (this operation is used by the newer version of the `/status` endpoint)