### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         id: sre_app_token
         with:
-          app_id: ${{ secrets.SRE_APP_ID }}
-          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:


### PR DESCRIPTION
# Summary
Update the release please workflow to use a dedicated GitHub app for releases. This will allow us to scale back the use of the SRE read/write GitHub app.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707