### PR TITLE
chore: Allow ECS task to access Audit Logs for APP and API

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -215,7 +215,7 @@ resource "aws_iam_policy" "forms_audit_logs" {
   name        = "forms_audit_logs"
   path        = "/"
   description = "IAM policy for allowing access for Forms ECS task to read the Audit Logs"
-  policy      = data.aws_iam_policy_document.forms_dynamodb.json
+  policy      = data.aws_iam_policy_document.forms_audit_logs.json
 }
 
 data "aws_iam_policy_document" "forms_audit_logs" {

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -112,6 +112,11 @@ resource "aws_iam_role_policy_attachment" "dynamodb_forms" {
   policy_arn = aws_iam_policy.forms_dynamodb.arn
 }
 
+resource "aws_iam_role_policy_attachment" "audit_logs_forms" {
+  role       = aws_iam_role.forms.name
+  policy_arn = aws_iam_policy.forms_audit_logs.arn
+}
+
 resource "aws_iam_role_policy_attachment" "sqs_forms" {
   role       = aws_iam_role.forms.name
   policy_arn = aws_iam_policy.forms_sqs.arn
@@ -203,6 +208,31 @@ data "aws_iam_policy_document" "forms_dynamodb" {
       var.dynamodb_relability_queue_arn,
       var.dynamodb_vault_arn,
       "${var.dynamodb_vault_arn}/index/*"
+    ]
+  }
+}
+resource "aws_iam_policy" "forms_audit_logs" {
+  name        = "forms_audit_logs"
+  path        = "/"
+  description = "IAM policy for allowing access for Forms ECS task to read the Audit Logs"
+  policy      = data.aws_iam_policy_document.forms_dynamodb.json
+}
+
+data "aws_iam_policy_document" "forms_audit_logs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:Query",
+    ]
+
+    resources = [
+      var.dynamodb_api_audit_logs_arn,
+      var.dynamodb_app_audit_logs_arn,
+      "${var.dynamodb_api_audit_logs_arn}/index/*",
+      "${var.dynamodb_app_audit_logs_arn}/index/*"
     ]
   }
 }

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -23,6 +23,16 @@ variable "dynamodb_vault_arn" {
   type        = string
 }
 
+variable "dynamodb_api_audit_logs_arn" {
+  description = "API Audit logs DynamodDB table ARN"
+  type        = string
+}
+
+variable "dynamodb_app_audit_logs_arn" {
+  description = "App Audit Logs DynamodDB table ARN"
+  type        = string
+}
+
 variable "ecs_autoscale_enabled" {
   description = "Should memory/CPU threshold ECS task scaling be enabled"
   type        = bool

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -14,6 +14,8 @@ dependency "dynamodb" {
   mock_outputs = {
     dynamodb_relability_queue_arn = null
     dynamodb_vault_arn            = null
+    dynamodb_app_audit_logs_arn   = null
+    dynamodb_api_audit_logs_arn   = null
   }
 }
 
@@ -152,6 +154,8 @@ inputs = {
 
   dynamodb_relability_queue_arn = dependency.dynamodb.outputs.dynamodb_relability_queue_arn
   dynamodb_vault_arn            = dependency.dynamodb.outputs.dynamodb_vault_arn
+  dynamodb_app_audit_logs_arn   = dependency.dynamodb.outputs.dynamodb_app_audit_logs_arn
+  dynamodb_api_audit_logs_arn   = dependency.dynamodb.outputs.dynamodb_api_audit_logs_arn
 
   ecr_repository_url_form_viewer = dependency.ecr.outputs.ecr_repository_url_form_viewer
 


### PR DESCRIPTION
# Summary | Résumé
Add read permissions to ECS task for the dynamodb tables and indexes for App and API Audit Logs.

Supports PR cds-snc/platform-forms-client#5476