### PR TITLE
fix: missing service discovery resource in development mode

### DIFF
--- a/aws/network/development_env/network.tf
+++ b/aws/network/development_env/network.tf
@@ -82,4 +82,8 @@ data "aws_subnets" "lambda_endpoint_available" {
   depends_on = [aws_subnet.forms_private]
 }
 
-
+resource "aws_service_discovery_private_dns_namespace" "ecs_local" {
+  name        = "ecs.local"
+  description = "DNS namespace used to provide service discovery for ECS services to allow for local communication (within VPC)"
+  vpc         = aws_vpc.forms.id
+}

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -178,7 +178,10 @@ dependency "ecr" {
 }
 
 dependency "idp" {
-  config_path                             = "../idp"
+  enabled = local.env != "development"
+
+  config_path = "../idp"
+
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
@@ -188,7 +191,10 @@ dependency "idp" {
 }
 
 dependency "api" {
-  config_path                             = "../api"
+  enabled = local.env != "development"
+
+  config_path = "../api"
+
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {


### PR DESCRIPTION
# Summary | Résumé

- Adds missing service discovery resource for when deploying environment to scratch accounts
- Disables IdP and API dependencies in Lambda module when in dev mode