### PR TITLE
fix: API end to end test security group is missing connection with private link one

### DIFF
--- a/aws/network/security_group_api_end_to_end_test.tf
+++ b/aws/network/security_group_api_end_to_end_test.tf
@@ -46,6 +46,7 @@ resource "aws_security_group_rule" "local_lambda_to_api_ingress" {
   to_port                  = 3001
 }
 
+// This allows the API end to end test lambda to invoke the Submission lambda
 resource "aws_vpc_security_group_egress_rule" "https_from_api_end_to_end_test_to_private_link" {
   description                  = "Egress to privatelink security group for HTTPS communication"
   security_group_id            = aws_security_group.api_end_to_end_test_lambda.id
@@ -55,6 +56,8 @@ resource "aws_vpc_security_group_egress_rule" "https_from_api_end_to_end_test_to
   to_port                      = 443
 }
 
+// This allows the API end to end test lambda to invoke the Submission lambda
+//
 // Using aws_security_group_rule instead of aws_vpc_security_group_egress_rule
 // due to warning on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
 resource "aws_security_group_rule" "https_from_private_link_to_api_end_to_end_test" {

--- a/aws/network/security_group_api_end_to_end_test.tf
+++ b/aws/network/security_group_api_end_to_end_test.tf
@@ -45,3 +45,24 @@ resource "aws_security_group_rule" "local_lambda_to_api_ingress" {
   from_port                = 3001
   to_port                  = 3001
 }
+
+resource "aws_vpc_security_group_egress_rule" "https_from_api_end_to_end_test_to_private_link" {
+  description                  = "Egress to privatelink security group for HTTPS communication"
+  security_group_id            = aws_security_group.api_end_to_end_test_lambda.id
+  referenced_security_group_id = aws_security_group.privatelink.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+}
+
+// Using aws_security_group_rule instead of aws_vpc_security_group_egress_rule
+// due to warning on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
+resource "aws_security_group_rule" "https_from_private_link_to_api_end_to_end_test" {
+  description              = "Ingress from API end to end test security group for HTTPS communication"
+  type                     = "ingress"
+  security_group_id        = aws_security_group.privatelink.id
+  source_security_group_id = aws_security_group.api_end_to_end_test_lambda.id
+  protocol                 = "tcp"
+  from_port                = 443
+  to_port                  = 443
+}


### PR DESCRIPTION
# Summary | Résumé

- Adds missing connection between new API end to end test security group and private link one. This will resolve the communication problem with the AWS Lambda API (when we want to invoke the Submission lambda)