### PR TITLE
fix: api end to end test security group can egress to the whole internet

### DIFF
--- a/aws/network/security_group_api_end_to_end_test.tf
+++ b/aws/network/security_group_api_end_to_end_test.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "local_lambda_to_api_ingress" {
 
 // This allows the API end to end test lambda to invoke the Submission lambda
 resource "aws_vpc_security_group_egress_rule" "https_from_api_end_to_end_test_to_private_link" {
-  description       = "Egress to privatelink security group for HTTPS communication"
+  description       = "Egress to the internet for HTTPS communication"
   security_group_id = aws_security_group.api_end_to_end_test_lambda.id
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "tcp"

--- a/aws/network/security_group_api_end_to_end_test.tf
+++ b/aws/network/security_group_api_end_to_end_test.tf
@@ -48,12 +48,12 @@ resource "aws_security_group_rule" "local_lambda_to_api_ingress" {
 
 // This allows the API end to end test lambda to invoke the Submission lambda
 resource "aws_vpc_security_group_egress_rule" "https_from_api_end_to_end_test_to_private_link" {
-  description                  = "Egress to privatelink security group for HTTPS communication"
-  security_group_id            = aws_security_group.api_end_to_end_test_lambda.id
-  referenced_security_group_id = aws_security_group.privatelink.id
-  ip_protocol                  = "tcp"
-  from_port                    = 443
-  to_port                      = 443
+  description       = "Egress to privatelink security group for HTTPS communication"
+  security_group_id = aws_security_group.api_end_to_end_test_lambda.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
 }
 
 // This allows the API end to end test lambda to invoke the Submission lambda


### PR DESCRIPTION
# Summary | Résumé

- Opens egress rule for API end to end test security group to the whole internet