### PR TITLE
fix: add api end to end test lambda to list of production lambdas

### DIFF
--- a/.github/production-lambda-functions.conf
+++ b/.github/production-lambda-functions.conf
@@ -11,5 +11,6 @@
 "response-archiver",
 "submission",
 "vault-integrity",
-"prisma-migration"
+"prisma-migration",
+"api-end-to-end-test"
 ]


### PR DESCRIPTION
# Summary | Résumé

- Adds API end to end test lambda to list of production lambdas