### PR TITLE
chore: disable Zitadel TLS traffic enforcement

### DIFF
--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -64,7 +64,7 @@ module "idp_ecs" {
 
   # Task definition
   container_image       = "${var.zitadel_image_ecr_url}:${var.zitadel_image_tag}"
-  container_command     = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "disabled", "--config", "/app/config.yaml", "--steps", "/app/steps.yaml"] # TODO: update to `start` command only for prod
+  container_command     = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "external", "--config", "/app/config.yaml", "--steps", "/app/steps.yaml"] # TODO: update to `start` command only for prod
   container_host_port   = 8080
   container_port        = 8080
   container_environment = local.container_env

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -64,7 +64,7 @@ module "idp_ecs" {
 
   # Task definition
   container_image       = "${var.zitadel_image_ecr_url}:${var.zitadel_image_tag}"
-  container_command     = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "enabled", "--config", "/app/config.yaml", "--steps", "/app/steps.yaml"] # TODO: update to `start` command only for prod
+  container_command     = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "disabled", "--config", "/app/config.yaml", "--steps", "/app/steps.yaml"] # TODO: update to `start` command only for prod
   container_host_port   = 8080
   container_port        = 8080
   container_environment = local.container_env

--- a/aws/idp/lb.tf
+++ b/aws/idp/lb.tf
@@ -24,7 +24,7 @@ resource "random_string" "idp_alb_tg_suffix" {
   upper   = false
   keepers = {
     port              = 8080
-    protocol          = "HTTPS"
+    protocol          = "HTTP"
     protocol_versions = join(",", local.protocol_versions)
   }
 }
@@ -34,7 +34,7 @@ resource "aws_lb_target_group" "idp" {
 
   name                 = "idp-tg-${each.value}-${random_string.idp_alb_tg_suffix.result}"
   port                 = 8080
-  protocol             = "HTTPS"
+  protocol             = "HTTP"
   protocol_version     = each.value
   target_type          = "ip"
   deregistration_delay = 30
@@ -42,7 +42,7 @@ resource "aws_lb_target_group" "idp" {
 
   health_check {
     enabled  = true
-    protocol = "HTTPS"
+    protocol = "HTTP"
     path     = "/debug/healthz"
     matcher  = "200-399"
   }

--- a/idp/Makefile
+++ b/idp/Makefile
@@ -1,17 +1,5 @@
-.PHONY: build cert
+.PHONY: build
 
 # Build the IdP's Docker image
-build: cert
+build:
 	docker build -t idp/zitadel:latest ./docker -f ./docker/Dockerfile
-
-# Generate the certificate used to encrypt load balancer traffic to the ECS task
-cert:
-	openssl \
-		req \
-		-nodes \
-		-newkey rsa:2048 \
-		-x509 -days 3650 \
-		-keyout ./docker/private.key \
-		-out ./docker/certificate.crt \
-		-subj "/C=CA/ST=Ontario/L=Ottawa/O=cds-snc/OU=platform/CN=auth.forms-formulaires.alpha.canada.ca/emailAddress=platform@cds-snc.ca" > /dev/null 2>&1 &&\
-	chmod +r ./docker/private.key

--- a/idp/docker/Dockerfile
+++ b/idp/docker/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/zitadel/zitadel:v3.0.4@sha256:b253a0a96e66e0d35c8ab56896126b11ded2c4526c090bacee7eb90c8ea6ece4
 # Copy configuration and certificates
-COPY ./*.yaml ./certificate.crt ./private.key /app/
+COPY ./*.yaml /app/

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -2,29 +2,27 @@
 # https://zitadel.com/docs/self-hosting/manage/configure#runtime-configuration-file
 
 Log:
-  Level: 'info'
+  Level: "info"
 
 Port: 8080
-ExternalPort: 443
-ExternalSecure: true
+ExternalPort: 8080
+ExternalSecure: false
 TLS:
-  Enabled: true
-  KeyPath: '/app/private.key'
-  CertPath: '/app/certificate.crt'
+  Enabled: false
 
 Database:
   postgres:
     Port: 5432
     User:
       SSL:
-        Mode: 'require'
+        Mode: "require"
     Admin:
       SSL:
-        Mode: 'require'
+        Mode: "require"
     MaxOpenConns: 25
     MaxIdleConns: 10
-    MaxConnLifetime: '30m'
-    MaxConnIdleTime: '5m'
+    MaxConnLifetime: "30m"
+    MaxConnIdleTime: "5m"
 
 DefaultInstance:
   LoginPolicy:
@@ -32,13 +30,13 @@ DefaultInstance:
     ForceMFA: true
     HidePasswordReset: true
   OIDCSettings:
-    AccessTokenLifetime: '0.5h'
-    IdTokenLifetime: '0.5h'
-    RefreshTokenIdleExpiration: '720h'
-    RefreshTokenExpiration: '2160h'
+    AccessTokenLifetime: "0.5h"
+    IdTokenLifetime: "0.5h"
+    RefreshTokenIdleExpiration: "720h"
+    RefreshTokenExpiration: "2160h"
 
 OIDC:
-  DefaultAccessTokenLifetime: '0.5h'
-  DefaultIdTokenLifetime: '0.5h'
-  DefaultRefreshTokenIdleExpiration: '720h'
-  DefaultRefreshTokenExpiration: '2160h'
+  DefaultAccessTokenLifetime: "0.5h"
+  DefaultIdTokenLifetime: "0.5h"
+  DefaultRefreshTokenIdleExpiration: "720h"
+  DefaultRefreshTokenExpiration: "2160h"


### PR DESCRIPTION
# Summary | Résumé

- Disables TLS traffic enforcement in Zitadel's configuration. The AWS load balancer will handle TLS for us. The goal is to simplify local communication over VPC for services like Web App / API and IdP.

Note:
This may break the API end to end test but I will fix it in a subsequent PR.