### PR TITLE
fix: API end to end test does not need custom httpAgent to bypass TLS certificate verification

### DIFF
--- a/aws/lambdas/api_end_to_end_test.tf
+++ b/aws/lambdas/api_end_to_end_test.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "api_end_to_end_test" {
   environment {
     variables = {
       IDP_TRUSTED_DOMAIN     = var.domain_idp
-      IDP_URL                = "https://${var.ecs_idp_service_name}.${var.service_discovery_private_dns_namespace_ecs_local_name}:${var.ecs_idp_service_port}"
+      IDP_URL                = "http://${var.ecs_idp_service_name}.${var.service_discovery_private_dns_namespace_ecs_local_name}:${var.ecs_idp_service_port}"
       IDP_PROJECT_IDENTIFIER = var.idp_project_identifier
       API_URL                = "http://${var.ecs_api_service_name}.${var.service_discovery_private_dns_namespace_ecs_local_name}:${var.ecs_api_service_port}"
       FORM_ID                = var.api_end_to_end_test_form_identifier

--- a/lambda-code/api-end-to-end-test/src/lib/idpClient.ts
+++ b/lambda-code/api-end-to-end-test/src/lib/idpClient.ts
@@ -1,11 +1,6 @@
 import { createPrivateKey } from "node:crypto";
 import { SignJWT } from "jose";
 import axios from "axios";
-import https from "https";
-
-const noSslHttpsAgent = new https.Agent({
-  rejectUnauthorized: false,
-});
 
 export class IdpClient {
   private identityProviderTrustedDomain: string;
@@ -33,7 +28,7 @@ export class IdpClient {
       .setIssuedAt()
       .setIssuer(this.privateApiKey.userId)
       .setSubject(this.privateApiKey.userId)
-      .setAudience(`https://${this.identityProviderTrustedDomain}`) // To bypass JWT Audience check from IdP
+      .setAudience(`https://${this.identityProviderTrustedDomain}`) // Expected audience for the JWT token is the IdP external domain
       .setExpirationTime("1 minute");
 
     return jsonWebTokenSigner
@@ -47,9 +42,8 @@ export class IdpClient {
             scope: `openid profile urn:zitadel:iam:org:project:id:${this.projectIdentifier}:aud`,
           },
           {
-            httpsAgent: noSslHttpsAgent, // To bypass self signed SSL certificate barrier
             headers: {
-              Host: this.identityProviderTrustedDomain, // To bypass HTTP Host check from IdP
+              Host: this.identityProviderTrustedDomain, // This is required by Zitadel to accept requests. See https://zitadel.com/docs/self-hosting/manage/custom-domain#standard-config
               "Content-Type": "application/x-www-form-urlencoded",
             },
           }


### PR DESCRIPTION
# Summary | Résumé

- Removes custom httpAgent that does not verify TLS certificate validity now that we have removed TLS support from Zitadel