### PR TITLE
Chore: Zitadel config

### DIFF
--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -49,3 +49,19 @@ OIDC:
   DefaultIdTokenLifetime: "0.5h"
   DefaultRefreshTokenIdleExpiration: "720h"
   DefaultRefreshTokenExpiration: "2160h"
+
+Notifications:
+  # Notifications can be processed by either a sequential mode (legacy) or a new parallel mode.
+  # The parallel mode is currently only recommended for Postgres databases.
+  # If legacy mode is enabled, the worker config below is ignored.
+  LegacyEnabled: false
+  # The amount of workers processing the notification request events.
+  # If set to 0, no notification request events will be handled. This can be useful when running in
+  # multi binary / pod setup and allowing only certain executables to process the events.
+  Workers: 1
+  # The maximum duration a job can do it's work before it is considered as failed.
+  TransactionDuration: 10s
+  # Automatically cancel the notification after the amount of failed attempts
+  MaxAttempts: 3
+  # Automatically cancel the notification if it cannot be handled within a specific time
+  MaxTtl: 5m

--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -4,8 +4,17 @@
 Log:
   Level: "info"
 
+Metrics:
+  Type: none
+Tracing:
+  Type: none
+Profiler:
+  Type: none
+Telemetry:
+  Enabled: false
+
 Port: 8080
-ExternalPort: 8080
+ExternalPort: 443
 ExternalSecure: false
 TLS:
   Enabled: false
@@ -19,9 +28,9 @@ Database:
     Admin:
       SSL:
         Mode: "require"
-    MaxOpenConns: 15
+    MaxOpenConns: 20
     MaxIdleConns: 10
-    MaxConnLifetime: "1h"
+    MaxConnLifetime: "30m"
     MaxConnIdleTime: "5m"
 
 DefaultInstance:


### PR DESCRIPTION
# Summary | Résumé
Update external port to be 443,
Update Notifications to use parallel instead of legacy to see if the errors are resolved.