### PR TITLE
chore: Change log level to debug and enable Notifcation worker

### DIFF
--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -2,7 +2,7 @@
 # https://zitadel.com/docs/self-hosting/manage/configure#runtime-configuration-file
 
 Log:
-  Level: "info"
+  Level: "debug"
 
 Metrics:
   Type: none
@@ -54,7 +54,7 @@ Notifications:
   # Notifications can be processed by either a sequential mode (legacy) or a new parallel mode.
   # The parallel mode is currently only recommended for Postgres databases.
   # If legacy mode is enabled, the worker config below is ignored.
-  LegacyEnabled: true
+  LegacyEnabled: false
   # The amount of workers processing the notification request events.
   # If set to 0, no notification request events will be handled. This can be useful when running in
   # multi binary / pod setup and allowing only certain executables to process the events.


### PR DESCRIPTION
# Summary | Résumé
Enable debug logs to see if we can get better insight into what is causing the error to throw in Zitadel.