### PR TITLE
chore: change from debug to info level for Zitadel

### DIFF
--- a/idp/docker/config.yaml
+++ b/idp/docker/config.yaml
@@ -2,7 +2,7 @@
 # https://zitadel.com/docs/self-hosting/manage/configure#runtime-configuration-file
 
 Log:
-  Level: "debug"
+  Level: "info"
 
 Metrics:
   Type: none


### PR DESCRIPTION
# Summary | Résumé

Debug level logs did not produce any more info about the errors.  Switching back to "info" level and giving up until next week.