### PR TITLE
chore: Modify github release to hold back zitadel update

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -146,34 +146,35 @@ jobs:
           image-name: ${{ matrix.image }}
           image-tag: ${{ env.VERSION }}
 
-  build-tag-push-idp-image:
-    needs: [get-version, terragrunt-apply-ecr-only]
-    runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ needs.get-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ env.VERSION }}
+  # build-tag-push-idp-image:
+  #   needs: [get-version, terragrunt-apply-ecr-only]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     VERSION: ${{ needs.get-version.outputs.version }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         ref: ${{ env.VERSION }}
 
-      - name: Build IdP image
-        working-directory: idp
-        run: |
-          make build
+  #     - name: Build IdP image
+  #       working-directory: idp
+  #       run: |
+  #         make build
 
-      - name: Tag and push IdP image
-        uses: ./.github/workflows/tag-and-push-docker-images
-        with:
-          aws-role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply
-          aws-role-session-name: TFApply
-          aws-region: ${{ env.AWS_REGION }}
-          image-name: idp/zitadel
-          image-tag: ${{ env.VERSION }}
-          repository-suffix: ""
+  #     - name: Tag and push IdP image
+  #       uses: ./.github/workflows/tag-and-push-docker-images
+  #       with:
+  #         aws-role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply
+  #         aws-role-session-name: TFApply
+  #         aws-region: ${{ env.AWS_REGION }}
+  #         image-name: idp/zitadel
+  #         image-tag: ${{ env.VERSION }}
+  #         repository-suffix: ""
 
   terragrunt-apply-all-modules:
-    needs: [get-version, build-tag-push-lambda-images, build-tag-push-idp-image]
+    # needs: [get-version, build-tag-push-lambda-images, build-tag-push-idp-image]
+    needs: [get-version, build-tag-push-lambda-images]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     env:
@@ -329,12 +330,11 @@ jobs:
           image-tag: "idp/zitadel:${{ env.VERSION }}"
 
   notify-on-error:
-    needs:
-      [
+    needs: [
         get-version,
         terragrunt-apply-ecr-only,
         build-tag-push-lambda-images,
-        build-tag-push-idp-image,
+        # build-tag-push-idp-image,
         terragrunt-apply-all-modules,
         update-lambda-function-image,
         update-idp-ecs-service-image,

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -306,28 +306,28 @@ jobs:
           lambda-name: ${{ matrix.image }}
           image-tag: ${{ env.VERSION }}
 
-  update-idp-ecs-service-image:
-    needs: [get-version, terragrunt-apply-all-modules]
-    if: ${{ !failure() && !cancelled() }}
-    runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ needs.get-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ env.VERSION }}
+  # update-idp-ecs-service-image:
+  #   needs: [get-version, terragrunt-apply-all-modules]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     VERSION: ${{ needs.get-version.outputs.version }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         ref: ${{ env.VERSION }}
 
-      - name: Update IdP ESC service to use new image
-        uses: ./.github/workflows/request-ecs-service-to-use-new-image
-        with:
-          aws-role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply
-          aws-role-session-name: TFApply
-          aws-region: ${{ env.AWS_REGION }}
-          ecs-cluster-name: idp
-          ecs-service-name: zitadel
-          ecs-task-def-name: zitadel
-          image-tag: "idp/zitadel:${{ env.VERSION }}"
+  #     - name: Update IdP ESC service to use new image
+  #       uses: ./.github/workflows/request-ecs-service-to-use-new-image
+  #       with:
+  #         aws-role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-terraform-apply
+  #         aws-role-session-name: TFApply
+  #         aws-region: ${{ env.AWS_REGION }}
+  #         ecs-cluster-name: idp
+  #         ecs-service-name: zitadel
+  #         ecs-task-def-name: zitadel
+  #         image-tag: "idp/zitadel:${{ env.VERSION }}"
 
   notify-on-error:
     needs: [
@@ -337,7 +337,7 @@ jobs:
         # build-tag-push-idp-image,
         terragrunt-apply-all-modules,
         update-lambda-function-image,
-        update-idp-ecs-service-image,
+        # update-idp-ecs-service-image,
       ]
     if: ${{ failure() && !cancelled() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary | Résumé
Modify github production workflow to hold back Zitadel major version update while we continue to test in Staging.