### PR TITLE
fix: WAF ignore 404 from LB and Dynamic IP Rule

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -675,7 +675,8 @@ module "waf_ip_blocklist" {
   athena_query_results_bucket      = "forms-${var.env}-athena-bucket"
   athena_query_source_bucket       = var.cbs_satellite_bucket_name
   athena_workgroup_name            = "primary"
-  waf_rule_ids_skip                = ["BlockLargeRequests", "RateLimitersRuleGroup"]
+  waf_rule_ids_skip                = ["BlockLargeRequests", "RateLimitersRuleGroup", "BlockedIPv4"]
+  lb_status_code_skip              = ["404"]
   athena_lb_table_name             = "lb_logs"
   query_lb                         = true
   query_waf                        = false

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -668,7 +668,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_maintenance_mode_uri_paths" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=64b19ecfc23025718cd687e24b7115777fd09666" # v10.2.1
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=7341e0355a0a346574828da97863af2f552d05ed" # v10.4.6
 
   service_name                     = "forms_app"
   athena_database_name             = "access_logs"


### PR DESCRIPTION
# Summary | Résumé
Ignore 404's from the app (target responses) for now.
Exclude 403's coming from the rule that blocks IP's on the list so that the IP is removed within 24 hours and does not continue to block traffic.