### PR TITLE
chore: set reliability lambda concurrency to 150

### DIFF
--- a/aws/lambdas/reliability.tf
+++ b/aws/lambdas/reliability.tf
@@ -5,7 +5,6 @@ resource "aws_lambda_function" "reliability" {
   role          = aws_iam_role.lambda.arn
   timeout       = 300
 
-
   // Even in development mode this lambda should be attached to the VPC in order to connecto the DB
   // In development mode the lambda cannot sent emails as there is no internet access
   vpc_config {
@@ -42,6 +41,10 @@ resource "aws_lambda_event_source_mapping" "reliability" {
   function_name    = aws_lambda_function.reliability.arn
   batch_size       = 1
   enabled          = true
+
+  scaling_config {
+    maximum_concurrency = 150
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "reprocess_submission" {
@@ -49,6 +52,10 @@ resource "aws_lambda_event_source_mapping" "reprocess_submission" {
   function_name    = aws_lambda_function.reliability.arn
   batch_size       = 1
   enabled          = true
+
+  scaling_config {
+    maximum_concurrency = 150
+  }
 }
 
 /*

--- a/aws/lambdas/reliability.tf
+++ b/aws/lambdas/reliability.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_event_source_mapping" "reliability" {
   enabled          = true
 
   scaling_config {
-    maximum_concurrency = 500
+    maximum_concurrency = 150
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_lambda_event_source_mapping" "reprocess_submission" {
   enabled          = true
 
   scaling_config {
-    maximum_concurrency = 500
+    maximum_concurrency = 150
   }
 }
 

--- a/aws/lambdas/reliability.tf
+++ b/aws/lambdas/reliability.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_event_source_mapping" "reliability" {
   enabled          = true
 
   scaling_config {
-    maximum_concurrency = 150
+    maximum_concurrency = 500
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_lambda_event_source_mapping" "reprocess_submission" {
   enabled          = true
 
   scaling_config {
-    maximum_concurrency = 150
+    maximum_concurrency = 500
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

- Limits concurrency for Reliability lambda invocations. Limit is set to 150. When we started seeing the `remaining connection slots are reserved for non-replication superuser connections ` issue in Staging with had a peak of 218 connections on the RDS cluster.