### PR TITLE
feat: add new submission attachments property to Vault

### DIFF
--- a/lambda-code/reliability/src/lib/dataLayer.ts
+++ b/lambda-code/reliability/src/lib/dataLayer.ts
@@ -111,6 +111,7 @@ const generateRandomString = (length: number = 5) => {
 export async function saveToVault(
   submissionID: string,
   formResponse: Responses,
+  submissionAttachments: string,
   formID: string,
   language: string,
   createdAt: string,
@@ -148,6 +149,7 @@ export async function saveToVault(
             ConfirmationCode: confirmationCode,
             Name: name,
             FormSubmissionHash: formSubmissionHash,
+            SubmissionAttachments: submissionAttachments,
           },
         },
       };

--- a/lambda-code/reliability/src/lib/file_scanning.ts
+++ b/lambda-code/reliability/src/lib/file_scanning.ts
@@ -1,6 +1,4 @@
-import { extractFileInputResponses } from "./dataLayer.js";
 import { getFileMetaData } from "./s3FileInput.js";
-import { FormSubmission } from "./types.js";
 
 export class FileScanningCompletionError extends Error {
   constructor(message: string) {
@@ -9,26 +7,37 @@ export class FileScanningCompletionError extends Error {
   }
 }
 
-export const verifyFileScanCompletion = async (formSubmission: FormSubmission) => {
-  const fileInputPaths = extractFileInputResponses(formSubmission);
-  const fileMetaDataPromises = fileInputPaths.map((filePath) => getFileMetaData(filePath));
+export type SubmissionAttachmentWithScanStatus = {
+  attachmentPath: string;
+  scanStatus: string | undefined;
+};
 
-  const fileMetaData = await Promise.allSettled(fileMetaDataPromises).then((results) => {
-    return results.map((result) => {
-      if (result.status === "fulfilled") {
-        return result.value;
-      } else {
-        console.error(`Error retrieving metadata for file: ${result.reason}`);
-        return undefined;
-      }
+export function getAllSubmissionAttachmentScanStatuses(
+  attachmentPaths: string[]
+): Promise<SubmissionAttachmentWithScanStatus[]> {
+  const submissionAttachmentScanStatusQueries = attachmentPaths.map((path) => {
+    return getSubmissionAttachmentScanStatus(path).then((status) => {
+      console.info(`File ${path} / Scan status: ${JSON.stringify(status)}`);
+      return { attachmentPath: path, scanStatus: status };
     });
   });
 
-  fileMetaData.forEach((meta, index) => {
-    console.info(`File ${fileInputPaths[index]} Metadata: ${JSON.stringify(meta)}`);
-  });
+  return Promise.all(submissionAttachmentScanStatusQueries);
+}
 
-  return fileMetaData.every((meta) =>
-    meta?.some((tag) => tag.Key === "GuardDutyMalwareScanStatus")
-  );
-};
+export function haveAllSubmissionAttachmentsBeenScanned(
+  attachmentsWithScanStatuses: SubmissionAttachmentWithScanStatus[]
+) {
+  return attachmentsWithScanStatuses.every((item) => item.scanStatus !== undefined);
+}
+
+function getSubmissionAttachmentScanStatus(attachmentPath: string): Promise<string | undefined> {
+  return getFileMetaData(attachmentPath)
+    .then((tags) => {
+      return tags.find((tag) => tag.Key === "GuardDutyMalwareScanStatus")?.Value;
+    })
+    .catch((error) => {
+      console.error(`Error retrieving scan status for file: ${(error as Error).message}`);
+      return undefined;
+    });
+}

--- a/lambda-code/reliability/src/lib/notifyProcessing.ts
+++ b/lambda-code/reliability/src/lib/notifyProcessing.ts
@@ -1,6 +1,6 @@
 import { GCNotifyConnector } from "@gcforms/connectors";
 import convertMessage from "./markdown.js";
-import { extractFileInputResponses, notifyProcessed } from "./dataLayer.js";
+import { notifyProcessed } from "./dataLayer.js";
 import { retrieveFilesFromReliabilityStorage } from "./s3FileInput.js";
 import { FormSubmission } from "./types.js";
 
@@ -8,6 +8,7 @@ export default async (
   submissionID: string,
   sendReceipt: string,
   formSubmission: FormSubmission,
+  submissionAttachmentPaths: string[],
   language: string,
   createdAt: string
 ) => {
@@ -20,9 +21,8 @@ export default async (
       throw Error("Email address is missing or empty.");
     }
 
-    const fileInputPaths = extractFileInputResponses(formSubmission);
-    const files = await retrieveFilesFromReliabilityStorage(fileInputPaths);
-    const attachFileParameters = fileInputPaths.reduce((acc, current, index) => {
+    const files = await retrieveFilesFromReliabilityStorage(submissionAttachmentPaths);
+    const attachFileParameters = submissionAttachmentPaths.reduce((acc, current, index) => {
       return {
         [`file${index}`]: {
           file: files[index],


### PR DESCRIPTION
# Summary | Résumé

- Adds new `SubmissionAttachments` property to Vault. The idea is to have a place where we can find all attachments for a submission along with its name, path and scan status (AWS Guard Duty scan result).