### PR TITLE
feat: output percentiles once load test has completed

### DIFF
--- a/lambda-code/load-testing/Makefile
+++ b/lambda-code/load-testing/Makefile
@@ -4,10 +4,6 @@ fmt:
 install:
 	pip3 install --user -r requirements.txt
 
-locust:
-	locust -f tests/locust_test_file.py --host=https://forms-staging.cdssandbox.xyz
-
 .PHONY: \
 	fmt \
-	install	\
-	locust
+	install

--- a/lambda-code/load-testing/README.md
+++ b/lambda-code/load-testing/README.md
@@ -1,27 +1,37 @@
 # Load testing
-Locust load tests that can be run in a Lambda function or locally.
 
-## Lambda
-Invoke the function using an event that looks like so:
-```json
-{
-  "locustfile": "./tests/locust_test_file.py",
-  "host": "https://forms-staging.cdssandbox.xyz",
-  "num_users": "5",
-  "spawn_rate": "1",
-  "run_time": "5m"
-}
+Locust load tests that can be run in Lambda functions or locally.
+
+## Lambda functions
+
+You will need AWS access credentials for the target environment.
+
+```sh
+export AWS_DEFAULT_REGION=ca-central-1
+./run_load_test_in_lambdas.py --help
+```
+
+Example of a load test session with 1 lambda running for 60 seconds and simulating traffic from 1 user.
+
+```sh
+./run_load_test_in_lambdas.py --function_name=load-testing --locust_file=./tests/test_global_system.py --locust_host=https://forms-staging.cdssandbox.xyz --threads=1 --time_limit=60 --locust_users=1
 ```
 
 ## Locally
+
 You will need AWS access credentials for the target environment, along with the following environment variables set:
+
 ```sh
-FORM_ID                 # Form ID to use for load testing
-FORM_PRIVATE_KEY        # JSON private key for the form (must be from the `FORM_ID` form)
-ZITADEL_APP_PRIVATE_KEY # JSON private key for the Zitadel application that is used for access token introspection
+FORM_ID                      # Form ID to use for load testing
+FORM_PRIVATE_KEY             # JSON private key for the form (must be from the `FORM_ID` form)
+ZITADEL_APP_PRIVATE_KEY      # JSON private key for the Zitadel application that is used for access token introspection
+SUBMIT_FORM_SERVER_ACTION_ID # NextJS server action identifier associated to 'submitForm' function
 ```
+
 Once the variables are set, you can start the tests like so:
+
 ```sh
 make install
-make locust
+
+locust -f tests/test_submit_through_client_with_file_upload.py --host=https://forms-staging.cdssandbox.xyz
 ```

--- a/lambda-code/load-testing/custom_results_aggregator.py
+++ b/lambda-code/load-testing/custom_results_aggregator.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+from numpy import histogram, percentile
+
+
+def custom_results_aggregator(results, lambda_timeout=300000):
+    """
+    Takes a list of many individual results and returns a dictionary of aggregated
+    data.
+
+    arguments
+
+    results: A list of results from LocustLoadTest.stats()
+    """
+
+    def _flatten_unique(list_of_lists):
+        l_flat = sum(list_of_lists, [])
+        l_unique = list(set(l_flat))
+        return l_unique
+
+    def _mean(numbers):
+        return float(sum(numbers)) / max(len(numbers), 1)
+
+    def _merge_response_times(response_times):
+        flat_list = []
+        for r_time in response_times:
+            for key, value in r_time.items():
+                flat_list.extend([int(float(key))] * value)
+        hist, bins = histogram(flat_list)
+        p55, p65, p75, p85, p95, p99 = percentile(flat_list, [55, 65, 75, 85, 95, 99])
+        return {
+            "histogram": hist.tolist(),
+            "bins": bins.tolist(),
+            "p55": p55,
+            "p65": p65,
+            "p75": p75,
+            "p85": p85,
+            "p95": p95,
+            "p99": p99,
+        }
+
+    def _get_min(data, key):
+        try:
+            return min([r[key] for r in data if r[key] is not None])
+        except ValueError:
+            return 0
+
+    def _get_max(data, key):
+        try:
+            return max([r[key] for r in data if r[key] is not None])
+        except ValueError:
+            return 0
+
+    def _calculate_aws_lambda_cost(
+        total_execution_time, memory_limit, invocation_count
+    ):
+        dollar_cost_per_128mb_100ms = 0.000000208
+        dollar_cost_per_invocation = 0.0000002
+        memory_cost_multiplier = int(memory_limit) / 128.0
+        time_in_100ms_lots = int(total_lambda_execution_time / 100.0)
+        invocation_cost = invocation_count * 0.0000002
+        execution_time_cost = (
+            time_in_100ms_lots * dollar_cost_per_128mb_100ms * memory_cost_multiplier
+        )
+        return invocation_cost + execution_time_cost
+
+    request_tasks = _flatten_unique([list(stat["requests"].keys()) for stat in results])
+    failed_tasks = _flatten_unique([list(stat["failures"].keys()) for stat in results])
+    total_lambda_execution_time = sum(
+        [(lambda_timeout - stat["remaining_time"]) for stat in results]
+    )
+    memory_limit = _get_max(results, "memory_limit")
+
+    agg_results = {
+        "requests": {key: {} for key in request_tasks},
+        "failures": {key: {} for key in failed_tasks},
+        "num_requests": sum([stat["num_requests"] for stat in results]),
+        "num_requests_fail": sum([stat["num_requests_fail"] for stat in results]),
+        "total_lambda_execution_time": total_lambda_execution_time,
+        "lambda_invocations": len(results),
+        "approximate_cost": _calculate_aws_lambda_cost(
+            total_lambda_execution_time, memory_limit, len(results)
+        ),
+    }
+
+    for task in request_tasks:
+        task_data_results = [
+            stat["requests"][task] for stat in results if task in stat["requests"]
+        ]
+
+        for mean_stat in ["median_response_time", "total_rps", "avg_response_time"]:
+            agg_results["requests"][task][mean_stat] = _mean(
+                [data[mean_stat] for data in task_data_results]
+            )
+
+        agg_results["requests"][task]["max_response_time"] = _get_max(
+            task_data_results, "max_response_time"
+        )
+        agg_results["requests"][task]["min_response_time"] = _get_min(
+            task_data_results, "min_response_time"
+        )
+        agg_results["requests"][task]["response_times"] = _merge_response_times(
+            [
+                data["response_times"]
+                for data in task_data_results
+                if data["response_times"] is not None
+            ]
+        )
+        agg_results["requests"][task]["total_rpm"] = (
+            agg_results["requests"][task]["total_rps"] * 60
+        )
+        agg_results["requests"][task]["num_requests"] = sum(
+            [
+                stat["requests"][task]["num_requests"]
+                for stat in results
+                if task in stat["requests"]
+            ]
+        )
+
+    for task in failed_tasks:
+        task_data_results = [
+            stat["failures"][task] for stat in results if task in stat["failures"]
+        ]
+        agg_results["failures"][task] = task_data_results[0]
+        agg_results["failures"][task]["occurrences"] = sum(
+            [stat["occurrences"] for stat in task_data_results]
+        )
+
+    return agg_results

--- a/lambda-code/load-testing/run_load_test_in_lambdas.py
+++ b/lambda-code/load-testing/run_load_test_in_lambdas.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import sys
+import json
+import numpy
+
+from custom_results_aggregator import custom_results_aggregator
+from invokust.aws_lambda import LambdaLoadTest
+
+
+def print_stat(type, name, req_count, median, avg, min, max, rps, p55, p65, p75, p85, p95, p99):
+    return "%-7s %-40s %10s %9s %9s %9s %9s %10s %7s %7s %7s %7s %7s %7s" % (
+        type,
+        name,
+        req_count,
+        median,
+        avg,
+        min,
+        max,
+        rps,
+        p55,
+        p65,
+        p75,
+        p85,
+        p95,
+        p99,
+    )
+
+
+def parse_arguments():
+    p = argparse.ArgumentParser(
+        description="Runs a Locust load tests on AWS Lambda in parallel"
+    )
+    p.add_argument("-n", "--function_name", help="Lambda function name", required=True)
+    p.add_argument("-f", "--locust_file", help="Locust file", required=True)
+    p.add_argument("-o", "--locust_host", help="Locust host", required=True)
+    p.add_argument(
+        "-u", "--locust_users", help="Number of Locust users", default=20, type=int
+    )
+    p.add_argument(
+        "-r", "--ramp_time", help="Ramp up time (seconds)", default=0, type=int
+    )
+    p.add_argument(
+        "-t", "--threads", help="Threads to run in parallel", default=1, type=int
+    )
+    p.add_argument(
+        "-l", "--time_limit", help="Time limit for run time (seconds)", type=int
+    )
+    return p.parse_args()
+
+
+def print_stats_exit(load_test_state):
+    summ_stats = load_test_state.get_summary_stats()
+    agg_results = custom_results_aggregator(load_test_state.get_locust_results())
+    agg_results["request_fail_ratio"] = summ_stats["request_fail_ratio"]
+    agg_results["invocation_error_ratio"] = summ_stats["invocation_error_ratio"]
+    agg_results["locust_settings"] = load_test_state.lambda_payload
+    agg_results["lambda_function_name"] = load_test_state.lambda_function_name
+    agg_results["threads"] = load_test_state.threads
+    agg_results["ramp_time"] = load_test_state.ramp_time
+    agg_results["time_limit"] = load_test_state.time_limit
+
+    logging.info("Aggregated results: {0}".format(json.dumps(agg_results)))
+
+    logging.info(
+        "\n============================================================"
+        f"\nRamp up time: {agg_results['ramp_time']}s"
+        f"\nStarted ramp down after {agg_results['time_limit']}s (time_limit)"
+        f"\nThread count: {agg_results['threads']}"
+        f"\nLambda invocation count: {agg_results['lambda_invocations']}"
+        f"\nLambda invocation error ratio: {agg_results['invocation_error_ratio']}"
+        f"\nCumulative lambda execution time: {agg_results['total_lambda_execution_time']}ms"
+        f"\nTotal requests sent: {agg_results['num_requests']}"
+        f"\nTotal requests failed: {agg_results['num_requests_fail']}"
+        f"\nTotal request failure ratio: {agg_results['request_fail_ratio']}\n"
+    )
+    logging.info(
+        "================================================================================================================================================================"
+    )
+    logging.info(
+        print_stat(
+            "TYPE", "NAME", "#REQUESTS", "MEDIAN", "AVERAGE", "MIN", "MAX", "#REQS/SEC", "P55", "P65", "P75", "P85", "P95", "P99"
+        )
+    )
+    logging.info(
+        "================================================================================================================================================================"
+    )
+
+    reqs = agg_results["requests"]
+    for k in reqs.keys():
+        k_arr = k.split("_")
+        type = k_arr[0]
+        del k_arr[0]
+        name = "_".join(k_arr)
+        logging.info(
+            print_stat(
+                type,
+                name,
+                reqs[k]["num_requests"],
+                round(reqs[k]["median_response_time"], 2),
+                round(reqs[k]["avg_response_time"], 2),
+                round(reqs[k]["min_response_time"], 2),
+                round(reqs[k]["max_response_time"], 2),
+                round(reqs[k]["total_rps"], 2),
+                round(reqs[k]["response_times"]["p55"]),
+                round(reqs[k]["response_times"]["p65"]),
+                round(reqs[k]["response_times"]["p75"]),
+                round(reqs[k]["response_times"]["p85"]),
+                round(reqs[k]["response_times"]["p95"]),
+                round(reqs[k]["response_times"]["p99"]),
+            )
+        )
+
+    logging.info("Exiting...")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-6s %(threadName)-11s %(message)s",
+    )
+
+    # AWS Lambda has a maximum execution time ("timeout"). We limit the execution time to 3 minutes if the overall
+    # load test time is longer, to make sure the lambda will not exceed the timeout.
+
+    lambda_runtime = f"{args.time_limit}s" if args.time_limit < 180 else "3m"
+    lambda_payload = {
+        "locustfile": args.locust_file,
+        "host": args.locust_host,
+        "num_users": args.locust_users,
+        "spawn_rate": 10,
+        "run_time": lambda_runtime,
+    }
+
+    load_test_state = LambdaLoadTest(
+        args.function_name,
+        args.threads,
+        args.ramp_time,
+        args.time_limit,
+        lambda_payload,
+    )
+
+    try:
+        load_test_state.run()
+
+    except KeyboardInterrupt:
+        print_stats_exit(load_test_state)
+    else:
+        print_stats_exit(load_test_state)


### PR DESCRIPTION
# Summary | Résumé

- Outputs percentiles once load test has completed

Note: I had to create a `custom_results_aggregator` function that is almost identical to the one from Invokust. What is new is that it calculates percentiles up to `p99`.


```sh
[2025-07-04 14:54:04,629] CJANIN-PG4Y/INFO/root: Aggregated results: {"requests": {"post_next-js-submit-form-server-action": {"median_response_time": 540.0, "total_rps": 0.5444612624317715, "avg_response_time": 658.2382576287457, "max_response_time": 2949.5496800000183, "min_response_time": 400.7509610000852, "response_times": {"histogram": [36, 7, 2, 0, 0, 0, 0, 0, 0, 2], "bins": [400.0, 650.0, 900.0, 1150.0, 1400.0, 1650.0, 1900.0, 2150.0, 2400.0, 2650.0, 2900.0], "p55": 550.0, "p65": 560.0, "p75": 620.0, "p85": 680.0, "p95": 987.0, "p99": 2900.0}, "total_rpm": 32.667675745906294, "num_requests": 47}, "post_/oauth/v2/token": {"median_response_time": 236.3694053333014, "total_rps": 0.06950080825691228, "avg_response_time": 279.7210083333539, "max_response_time": 442.1085070000572, "min_response_time": 137.08956300001773, "response_times": {"histogram": [1, 0, 0, 1, 1, 2, 0, 0, 0, 1], "bins": [140.0, 170.0, 200.0, 230.0, 260.0, 290.0, 320.0, 350.0, 380.0, 410.0, 440.0], "p55": 290.0, "p65": 300.0, "p75": 300.0, "p85": 335.0, "p95": 405.0, "p99": 433.0}, "total_rpm": 4.170048495414737, "num_requests": 6}, "get_/forms/template": {"median_response_time": 92.49276799998188, "total_rps": 0.06950080825691228, "avg_response_time": 154.45557266658247, "max_response_time": 259.49337499992, "min_response_time": 60.511001999884684, "response_times": {"histogram": [1, 1, 1, 0, 0, 0, 2, 0, 0, 1], "bins": [61.0, 80.9, 100.8, 120.69999999999999, 140.6, 160.5, 180.39999999999998, 200.29999999999998, 220.2, 240.1, 260.0], "p55": 172.5, "p65": 192.5, "p75": 197.5, "p85": 215.0, "p95": 245.0, "p99": 257.0}, "total_rpm": 4.170048495414737, "num_requests": 6}}, "failures": {}, "num_requests": 59, "num_requests_fail": 0, "total_lambda_execution_time": -1709734, "lambda_invocations": 3, "approximate_cost": -0.028448808000000003, "request_fail_ratio": 0.0, "invocation_error_ratio": 0.0, "locust_settings": {"locustfile": "./tests/test_submit_through_client_with_file_upload.py", "host": "https://forms-staging.cdssandbox.xyz", "num_users": 2, "spawn_rate": 10, "run_time": "30s"}, "lambda_function_name": "load-testing", "threads": 2, "ramp_time": 0, "time_limit": 30}
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root:
============================================================
Ramp up time: 0s
Started ramp down after 30s (time_limit)
Thread count: 2
Lambda invocation count: 3
Lambda invocation error ratio: 0.0
Cumulative lambda execution time: -1709734ms
Total requests sent: 59
Total requests failed: 0
Total request failure ratio: 0.0

[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: ================================================================================================================================================================
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: TYPE    NAME                                      #REQUESTS    MEDIAN   AVERAGE       MIN       MAX  #REQS/SEC     P55     P65     P75     P85     P95     P99
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: ================================================================================================================================================================
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: post    next-js-submit-form-server-action                47     540.0    658.24    400.75   2949.55       0.54     550     560     620     680     987    2900
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: post    /oauth/v2/token                                   6    236.37    279.72    137.09    442.11       0.07     290     300     300     335     405     433
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: get     /forms/template                                   6     92.49    154.46     60.51    259.49       0.07     172     192     198     215     245     257
[2025-07-04 14:54:04,630] CJANIN-PG4Y/INFO/root: Exiting...
```
