### PR TITLE
refactor: instantiate clients outside of functions

### DIFF
--- a/lambda-code/audit-logs-archiver/src/main.ts
+++ b/lambda-code/audit-logs-archiver/src/main.ts
@@ -15,16 +15,16 @@ interface AuditLog {
   [key: string]: any;
 }
 
+const dynamodbClient = new DynamoDBClient({
+  region: REGION ?? "ca-central-1",
+});
+
+const s3Client = new S3Client({
+  region: REGION ?? "ca-central-1",
+});
+
 export const handler: Handler = async () => {
   try {
-    const dynamodbClient = new DynamoDBClient({
-      region: REGION ?? "ca-central-1",
-    });
-
-    const s3Client = new S3Client({
-      region: REGION ?? "ca-central-1",
-    });
-
     await archiveAuditLogs(dynamodbClient, s3Client);
   } catch (error) {
     // Error message will be sent to slack

--- a/lambda-code/audit-logs/src/main.ts
+++ b/lambda-code/audit-logs/src/main.ts
@@ -25,9 +25,11 @@ type TransactionRequest = {
   };
 };
 
-const awsProperties = {
-  region: process.env.REGION ?? "ca-central-1",
-};
+const dynamoDb = DynamoDBDocumentClient.from(
+  new DynamoDBClient({
+    region: process.env.REGION ?? "ca-central-1",
+  })
+);
 
 const AppAuditLogArn = process.env.APP_AUDIT_LOGS_SQS_ARN;
 const ApiAuditLogArn = process.env.API_AUDIT_LOGS_SQS_ARN;
@@ -220,8 +222,6 @@ export const handler: Handler = async (event: SQSEvent) => {
     );
 
     const { apiAuditLogTransactions, appAuditLogTransactions } = buildTransactionItems(logEvents);
-
-    const dynamoDb = DynamoDBDocumentClient.from(new DynamoDBClient(awsProperties));
 
     const { UnprocessedItems } = await dynamoDb.send(
       new BatchWriteCommand({

--- a/lambda-code/cognito-email-sender/src/main.ts
+++ b/lambda-code/cognito-email-sender/src/main.ts
@@ -14,6 +14,10 @@ if (!KEY_ARN || !KEY_ALIAS || !TEMPLATE_ID) {
   );
 }
 
+const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
+  process.env.NOTIFY_API_KEY ?? ""
+);
+
 export const handler: Handler = async (event) => {
   // setup the encryptionSDK's key ring
   const { decrypt } = encryptionSDK.buildDecrypt(
@@ -53,10 +57,6 @@ export const handler: Handler = async (event) => {
   ) {
     // attempt to send the code to the user through Notify
     try {
-      const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
-        process.env.NOTIFY_API_KEY ?? ""
-      );
-
       await gcNotifyConnector.sendEmail(userEmail, TEMPLATE_ID, {
         passwordReset: event.triggerSource === "CustomEmailSender_ForgotPassword",
         // Keeping `accountVerification` and `resendCode` variables in case we need them in the future. They were removed when we implemented 2FA.

--- a/lambda-code/form-archiver/src/lib/templates.ts
+++ b/lambda-code/form-archiver/src/lib/templates.ts
@@ -1,12 +1,12 @@
 import { RDSDataClient, ExecuteStatementCommand } from "@aws-sdk/client-rds-data";
 
+const rdsDataClient = new RDSDataClient({ region: process.env.REGION });
+
 /**
  * Delete all form templates that have been marked as archived (has an TTL value that is not null)
  */
 export const deleteFormTemplatesMarkedAsArchived = async () => {
   try {
-    const rdsDataClient = new RDSDataClient({ region: process.env.REGION });
-
     const executeStatementCommand = new ExecuteStatementCommand({
       database: process.env.DB_NAME,
       resourceArn: process.env.DB_ARN,

--- a/lambda-code/nagware/src/lib/emailNotification.ts
+++ b/lambda-code/nagware/src/lib/emailNotification.ts
@@ -1,15 +1,15 @@
 import { GCNotifyConnector } from "@gcforms/connectors";
 
+const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
+  process.env.NOTIFY_API_KEY ?? ""
+);
+
 export async function notifyFormOwner(
   formID: string,
   formName: string,
   formOwnerEmailAddress: string
 ) {
   try {
-    const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
-      process.env.NOTIFY_API_KEY ?? ""
-    );
-
     const templateId = process.env.TEMPLATE_ID;
 
     if (templateId === undefined) {

--- a/lambda-code/reliability-dlq-consumer/src/main.ts
+++ b/lambda-code/reliability-dlq-consumer/src/main.ts
@@ -9,10 +9,11 @@ const REGION = process.env.REGION;
 const SQS_DEAD_LETTER_QUEUE_URL = process.env.SQS_DEAD_LETTER_QUEUE_URL;
 const SQS_SUBMISSION_PROCESSING_QUEUE_URL = process.env.SQS_SUBMISSION_PROCESSING_QUEUE_URL;
 
+const sqsClient = new SQSClient({
+  region: REGION,
+});
+
 export async function handler() {
-  const sqsClient = new SQSClient({
-    region: REGION,
-  });
   const receiveMessageCommandInput = {
     QueueUrl: SQS_DEAD_LETTER_QUEUE_URL,
   };

--- a/lambda-code/reliability/src/lib/dataLayer.ts
+++ b/lambda-code/reliability/src/lib/dataLayer.ts
@@ -18,11 +18,11 @@ import {
 } from "./types.js";
 import { getFormattedDateFromObject } from "./utils.js";
 
-const awsProperties = {
-  region: process.env.REGION ?? "ca-central-1",
-};
-
-const db = DynamoDBDocumentClient.from(new DynamoDBClient(awsProperties));
+const db = DynamoDBDocumentClient.from(
+  new DynamoDBClient({
+    region: process.env.REGION ?? "ca-central-1",
+  })
+);
 
 export async function getSubmission(message: Record<string, unknown>) {
   const DBParams = {

--- a/lambda-code/reliability/src/lib/notifyProcessing.ts
+++ b/lambda-code/reliability/src/lib/notifyProcessing.ts
@@ -4,6 +4,10 @@ import { notifyProcessed } from "./dataLayer.js";
 import { retrieveFilesFromReliabilityStorage } from "./s3FileInput.js";
 import { FormSubmission } from "./types.js";
 
+const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
+  process.env.NOTIFY_API_KEY ?? ""
+);
+
 export default async (
   submissionID: string,
   sendReceipt: string,
@@ -48,10 +52,6 @@ export default async (
         : formSubmission.deliveryOption.emailSubjectEn
         ? formSubmission.deliveryOption.emailSubjectEn
         : formSubmission.form.titleEn;
-
-    const gcNotifyConnector = await GCNotifyConnector.defaultUsingApiKeyFromAwsSecret(
-      process.env.NOTIFY_API_KEY ?? ""
-    );
 
     await gcNotifyConnector.sendEmail(
       formSubmission.deliveryOption.emailAddress,

--- a/lambda-code/reliability/src/lib/s3FileInput.ts
+++ b/lambda-code/reliability/src/lib/s3FileInput.ts
@@ -7,12 +7,8 @@ import {
 } from "@aws-sdk/client-s3";
 import { NodeJsClient } from "@smithy/types";
 
-const awsProperties = {
-  region: process.env.REGION ?? "ca-central-1",
-};
-
 const s3Client = new S3Client({
-  ...awsProperties,
+  region: process.env.REGION ?? "ca-central-1",
   forcePathStyle: true,
 }) as NodeJsClient<S3Client>;
 

--- a/lambda-code/reliability/src/lib/templates.ts
+++ b/lambda-code/reliability/src/lib/templates.ts
@@ -10,13 +10,12 @@ export type TemplateInfo = {
   };
 };
 
+const postgresConnector = await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
+  process.env.DB_URL ?? ""
+);
+
 export async function getTemplateInfo(formID: string): Promise<TemplateInfo | null> {
   try {
-    const postgresConnector =
-      await PostgresConnector.defaultUsingPostgresConnectionUrlFromAwsSecret(
-        process.env.DB_URL ?? ""
-      );
-
     const templates = await postgresConnector.executeSqlStatement()<
       {
         jsonConfig?: Record<string, unknown>;

--- a/lambda-code/response-archiver/src/main.ts
+++ b/lambda-code/response-archiver/src/main.ts
@@ -24,16 +24,16 @@ interface FormResponse {
   confirmationCode: string;
 }
 
+const dynamodbClient = new DynamoDBClient({
+  region: process.env.REGION ?? "ca-central-1",
+});
+
+const s3Client = new S3Client({
+  region: process.env.REGION ?? "ca-central-1",
+});
+
 export const handler: Handler = async () => {
   try {
-    const dynamodbClient = new DynamoDBClient({
-      region: process.env.REGION ?? "ca-central-1",
-    });
-
-    const s3Client = new S3Client({
-      region: process.env.REGION ?? "ca-central-1",
-    });
-
     await archiveResponses(dynamodbClient, s3Client);
 
     console.log(


### PR DESCRIPTION
# Summary | Résumé

Context: we are trying to fix the root cause of the client load test session that failed yesterday due to reaching maximum opened connections with our RDS cluster. It looks like https://github.com/cds-snc/forms-terraform/pull/1041 was not enough. I could not yet confirm why but it could be related to https://www.npmjs.com/package/postgres having a default timeout that keeps the connection opened even after the Lambda execution has ended.

- Instantiates clients (connectors) outside of functions in Lambdas to avoid creating unnecessary connections when benefiting from warm start invocations

(https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html)
> After the invocation completes, the execution environment is frozen. To improve resource management and performance, Lambda retains the execution environment for a period of time. During this time, if another request arrives for the same function, Lambda can reuse the environment. This second request typically finishes more quickly, since the execution environment is already fully set up. This is called a “warm start”.