### PR TITLE
chore: remove unused load testing lambda env variables

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -45,8 +45,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -37,8 +37,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -47,8 +47,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/aws/load_testing/inputs.tf
+++ b/aws/load_testing/inputs.tf
@@ -8,18 +8,6 @@ variable "lambda_submission_function_name" {
   type        = string
 }
 
-variable "load_testing_form_id" {
-  description = "Form ID that will be used to generate, retrieve and confirm responses."
-  type        = string
-  sensitive   = true
-}
-
-variable "load_testing_form_private_key" {
-  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key from the `var.load_testing_form_id` form."
-  type        = string
-  sensitive   = true
-}
-
 variable "load_testing_zitadel_app_private_key" {
   description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = string

--- a/aws/load_testing/lambda.tf
+++ b/aws/load_testing/lambda.tf
@@ -15,16 +15,6 @@ resource "aws_lambda_function" "load_testing" {
     ignore_changes = [image_uri]
   }
 
-  environment {
-    variables = {
-      LOCUST_RUN_TIME   = "3m"
-      LOCUST_LOCUSTFILE = "./tests/locust_test_file.py"
-      LOCUST_HOST       = "https://${var.domains[0]}"
-      LOCUST_SPAWN_RATE = "1"
-      LOCUST_NUM_USERS  = "1"
-    }
-  }
-
   tracing_config {
     mode = "PassThrough"
   }
@@ -76,10 +66,7 @@ data "aws_iam_policy_document" "load_test_lambda" {
       "ssm:GetParameters",
     ]
     resources = [
-      aws_ssm_parameter.load_testing_form_id.arn,
-      aws_ssm_parameter.load_testing_form_private_key.arn,
       aws_ssm_parameter.load_testing_zitadel_app_private_key.arn,
-      aws_ssm_parameter.load_testing_submit_form_server_action_id_key.arn,
     ]
   }
 

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -1,31 +1,7 @@
-resource "aws_ssm_parameter" "load_testing_form_id" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/form-id"
-  description = "Form ID that will be used to generate, retrieve and confirm responses."
-  type        = "SecureString"
-  value       = var.load_testing_form_id
-}
-
-resource "aws_ssm_parameter" "load_testing_form_private_key" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/form-private-key"
-  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key for the `/load-testing/form-id` form."
-  type        = "SecureString"
-  value       = var.load_testing_form_private_key
-}
-
 resource "aws_ssm_parameter" "load_testing_zitadel_app_private_key" {
   # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
   name        = "/load-testing/zitadel-app-private-key"
   description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = "SecureString"
   value       = var.load_testing_zitadel_app_private_key
-}
-
-resource "aws_ssm_parameter" "load_testing_submit_form_server_action_id_key" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/submit-form-server-action-id"
-  description = "NextJS server action identifier associated to 'submitForm' function."
-  type        = "SecureString"
-  value       = "TBD"
 }


### PR DESCRIPTION
# Summary | Résumé

- Removes unused load testing lambda env variables

Note: once merged we can remove `STAGING_LOAD_TESTING_FORM_ID` and `STAGING_LOAD_TESTING_FORM_PRIVATE_KEY` from our Github secrets