### PR TITLE
feat: revamp API load testing scenario

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -45,8 +45,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -37,8 +37,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -47,8 +47,6 @@ env:
   TF_VAR_cognito_code_template_id: 12a18f84-062c-4a67-8310-bf114af051ea
   TF_VAR_email_address_contact_us: ${{ vars.STAGING_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
-  TF_VAR_load_testing_form_id: ${{ secrets.STAGING_LOAD_TESTING_FORM_ID }}
-  TF_VAR_load_testing_form_private_key: ${{ secrets.STAGING_LOAD_TESTING_FORM_PRIVATE_KEY }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}

--- a/aws/load_testing/inputs.tf
+++ b/aws/load_testing/inputs.tf
@@ -8,18 +8,6 @@ variable "lambda_submission_function_name" {
   type        = string
 }
 
-variable "load_testing_form_id" {
-  description = "Form ID that will be used to generate, retrieve and confirm responses."
-  type        = string
-  sensitive   = true
-}
-
-variable "load_testing_form_private_key" {
-  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key from the `var.load_testing_form_id` form."
-  type        = string
-  sensitive   = true
-}
-
 variable "load_testing_zitadel_app_private_key" {
   description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = string

--- a/aws/load_testing/lambda.tf
+++ b/aws/load_testing/lambda.tf
@@ -15,16 +15,6 @@ resource "aws_lambda_function" "load_testing" {
     ignore_changes = [image_uri]
   }
 
-  environment {
-    variables = {
-      LOCUST_RUN_TIME   = "3m"
-      LOCUST_LOCUSTFILE = "./tests/locust_test_file.py"
-      LOCUST_HOST       = "https://${var.domains[0]}"
-      LOCUST_SPAWN_RATE = "1"
-      LOCUST_NUM_USERS  = "1"
-    }
-  }
-
   tracing_config {
     mode = "PassThrough"
   }
@@ -76,10 +66,7 @@ data "aws_iam_policy_document" "load_test_lambda" {
       "ssm:GetParameters",
     ]
     resources = [
-      aws_ssm_parameter.load_testing_form_id.arn,
-      aws_ssm_parameter.load_testing_form_private_key.arn,
       aws_ssm_parameter.load_testing_zitadel_app_private_key.arn,
-      aws_ssm_parameter.load_testing_submit_form_server_action_id_key.arn,
     ]
   }
 

--- a/aws/load_testing/parameters.tf
+++ b/aws/load_testing/parameters.tf
@@ -1,31 +1,7 @@
-resource "aws_ssm_parameter" "load_testing_form_id" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/form-id"
-  description = "Form ID that will be used to generate, retrieve and confirm responses."
-  type        = "SecureString"
-  value       = var.load_testing_form_id
-}
-
-resource "aws_ssm_parameter" "load_testing_form_private_key" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/form-private-key"
-  description = "Private key JSON of the form that will be used to authenticate the API requests.  This must be a key for the `/load-testing/form-id` form."
-  type        = "SecureString"
-  value       = var.load_testing_form_private_key
-}
-
 resource "aws_ssm_parameter" "load_testing_zitadel_app_private_key" {
   # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
   name        = "/load-testing/zitadel-app-private-key"
   description = "Private key JSON of the Zitadel application to perform access token introspection requests."
   type        = "SecureString"
   value       = var.load_testing_zitadel_app_private_key
-}
-
-resource "aws_ssm_parameter" "load_testing_submit_form_server_action_id_key" {
-  # checkov:skip=CKV_AWS_337: default service encryption key is acceptable
-  name        = "/load-testing/submit-form-server-action-id"
-  description = "NextJS server action identifier associated to 'submitForm' function."
-  type        = "SecureString"
-  value       = "TBD"
 }

--- a/lambda-code/load-testing/example_test_configuration.json
+++ b/lambda-code/load-testing/example_test_configuration.json
@@ -1,9 +1,12 @@
 {
+  "templates": {
+    "basicForm": "{\"titleEn\":\"test\",\"titleFr\":\"test\",\"introduction\":{\"descriptionEn\":\"\",\"descriptionFr\":\"\"},\"privacyPolicy\":{\"descriptionEn\":\"test\",\"descriptionFr\":\"test\"},\"confirmation\":{\"descriptionEn\":\"test\",\"descriptionFr\":\"test\",\"referrerUrlEn\":\"\",\"referrerUrlFr\":\"\"},\"layout\":[1],\"elements\":[{\"id\":1,\"type\":\"textField\",\"properties\":{\"questionId\":\"\",\"tags\":[],\"subElements\":[],\"choices\":[{\"en\":\"\",\"fr\":\"\"}],\"titleEn\":\"Q1\",\"titleFr\":\"test\",\"validation\":{\"required\":false},\"descriptionEn\":\"\",\"descriptionFr\":\"\",\"placeholderEn\":\"\",\"placeholderFr\":\"\"},\"uuid\":\"f3969a91-863a-499e-9dfd-cfd043ebab55\"}],\"groups\":{\"start\":{\"name\":\"Start\",\"titleEn\":\"Start page\",\"titleFr\":\"Page de départ\",\"elements\":[\"1\"],\"nextAction\":\"review\"},\"review\":{\"name\":\"Review\",\"titleEn\":\"End (Review page and Confirmation)\",\"titleFr\":\"Fin (Page récapitulative et confirmation)\",\"elements\":[],\"nextAction\":\"end\"},\"end\":{\"name\":\"End\",\"titleEn\":\"Confirmation page\",\"titleFr\":\"Page de confirmation\",\"elements\":[]}},\"groupsLayout\":[],\"lastGeneratedElementId\":1}"
+  },
   "testForms": [
     {
-      "id": "",
-      "template": "",
-      "apiPrivateKey": ""
+      "id": "...",
+      "usedTemplate": "basicForm",
+      "apiKey": "..."
     }
   ],
   "submitFormServerActionIdentifier": ""

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -24,7 +24,12 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         test_configuration = load_test_configuration()
         random_test_form = test_configuration.get_random_test_form()
         self.form_id = random_test_form.id
-        self.form_private_key = random_test_form.apiPrivateKey
+
+        if random_test_form.apiKey is None:
+            raise Exception("Test requires form API key")
+
+        self.form_private_key = random_test_form.apiKey
+
         self.idp_project_id = get_idp_project_id()
         self.idp_url = get_idp_url_from_target_host(self.parent.host)
         self.api_url = get_api_url_from_target_host(self.parent.host)

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -28,21 +28,21 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         self.idp_project_id = get_idp_project_id()
         self.idp_url = get_idp_url_from_target_host(self.parent.host)
         self.api_url = get_api_url_from_target_host(self.parent.host)
-        self.form_decrypted_submissions = {}
-        self.form_new_submissions = None
         self.headers = None
-        self.jwt_form = None
 
     def on_start(self) -> None:
-        self.jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
+        jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
+
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "assertion": self.jwt_form,
+            "assertion": jwt_form,
             "scope": f"openid profile urn:zitadel:iam:org:project:id:{self.idp_project_id}:aud",
         }
+
         response = self.request_with_failure_check(
             "post", f"{self.idp_url}/oauth/v2/token", 200, data=data
         )
+
         self.headers = {
             "Authorization": f"Bearer {response['access_token']}",
             "Content-Type": "application/json",
@@ -50,7 +50,7 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
 
     @task
     def get_new_submissions(self) -> None:
-        self.form_new_submissions = self.request_with_failure_check(
+        form_new_submissions = self.request_with_failure_check(
             "get",
             f"{self.api_url}/forms/{self.form_id}/submission/new",
             200,
@@ -58,7 +58,14 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
             name=f"/forms/submission/new",
         )
 
-    @task
+        self.get_form_template()
+
+        while form_new_submissions:
+            new_submission = form_new_submissions.pop(0)
+            new_submission_name = new_submission["name"]
+            submission = self.get_submission_by_name(new_submission_name)
+            self.confirm_submission(new_submission_name, submission["confirmationCode"])
+
     def get_form_template(self) -> None:
         self.request_with_failure_check(
             "get",
@@ -68,32 +75,26 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
             name=f"/forms/template",
         )
 
-    @task
-    def get_submission_by_name(self) -> None:
-        submission = self.form_new_submissions.pop()
+    def get_submission_by_name(self, submission_name: str) -> dict:
         response = self.request_with_failure_check(
             "get",
-            f"{self.api_url}/forms/{self.form_id}/submission/{submission['name']}",
+            f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}",
             200,
             headers=self.headers,
             name=f"/forms/submission/retrieve",
         )
+
         encrypted_submission = EncryptedFormSubmission.from_json(response)
         decrypted_submission = FormSubmissionDecrypter.decrypt(
             encrypted_submission, self.form_private_key
         )
-        self.form_decrypted_submissions[submission["name"]] = json.loads(
-            decrypted_submission
-        )
 
-    @task
-    def confirm_submission(self) -> None:
-        submission = self.form_decrypted_submissions.popitem()
-        submission_name = submission[0]
-        submission_data = submission[1]
+        return json.loads(decrypted_submission)
+
+    def confirm_submission(self, submission_name: str, confirmation_code: str) -> None:
         self.request_with_failure_check(
             "put",
-            f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}/confirm/{submission_data['confirmationCode']}",
+            f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}/confirm/{confirmation_code}",
             200,
             headers=self.headers,
             name=f"/forms/submission/confirm",

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -4,7 +4,7 @@ Tests the API's retrieval of new and specific responses.
 
 import json
 from locust import HttpUser, task
-from tests.utils.config import (
+from utils.config import (
     get_idp_project_id,
     get_idp_url_from_target_host,
     get_api_url_from_target_host,
@@ -15,7 +15,7 @@ from utils.form_submission_decrypter import (
     FormSubmissionDecrypter,
 )
 from utils.jwt_generator import JwtGenerator
-from tests.utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
+from utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
 
 
 class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -3,14 +3,14 @@ Tests the IdP's access token generation and introspection endpoints.
 """
 
 from locust import HttpUser, task
-from tests.utils.config import (
+from utils.config import (
     get_zitadel_app_private_key,
     get_idp_project_id,
     get_idp_url_from_target_host,
     load_test_configuration,
 )
 from utils.jwt_generator import JwtGenerator
-from tests.utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
+from utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
 
 
 class AccessTokenBehaviour(SequentialTaskSetWithFailure):

--- a/lambda-code/load-testing/tests/behaviours/idp.py
+++ b/lambda-code/load-testing/tests/behaviours/idp.py
@@ -17,7 +17,13 @@ class AccessTokenBehaviour(SequentialTaskSetWithFailure):
     def __init__(self, parent: HttpUser) -> None:
         super().__init__(parent)
         test_configuration = load_test_configuration()
-        self.form_private_key = test_configuration.get_random_test_form().apiPrivateKey
+        random_test_form = test_configuration.get_random_test_form()
+
+        if random_test_form.apiKey is None:
+            raise Exception("Test requires form API key")
+
+        self.form_private_key = random_test_form.apiKey
+
         self.idp_url = get_idp_url_from_target_host(self.parent.host)
         self.idp_project_id = get_idp_project_id()
         self.zitadel_app_private_key = get_zitadel_app_private_key()

--- a/lambda-code/load-testing/tests/behaviours/submit_client.py
+++ b/lambda-code/load-testing/tests/behaviours/submit_client.py
@@ -4,8 +4,8 @@ Tests the Form submission flow through the client
 
 import json
 from locust import HttpUser, task
-from tests.utils.config import get_client_url_from_target_host, load_test_configuration
-from tests.utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
+from utils.config import get_client_url_from_target_host, load_test_configuration
+from utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
 from utils.form_submission_generator import FormSubmissionGenerator
 
 

--- a/lambda-code/load-testing/tests/behaviours/submit_client.py
+++ b/lambda-code/load-testing/tests/behaviours/submit_client.py
@@ -15,7 +15,9 @@ class FormSubmitThroughClientBehaviour(SequentialTaskSetWithFailure):
         test_configuration = load_test_configuration()
         random_test_form = test_configuration.get_random_test_form()
         self.form_id = random_test_form.id
-        self.form_template = random_test_form.template
+        self.form_template = test_configuration.get_form_template(
+            random_test_form.usedTemplate
+        )
         self.client_url = get_client_url_from_target_host(self.parent.host)
         self.submit_form_server_action_id = (
             test_configuration.submitFormServerActionIdentifier

--- a/lambda-code/load-testing/tests/behaviours/submit_infra.py
+++ b/lambda-code/load-testing/tests/behaviours/submit_infra.py
@@ -4,8 +4,8 @@ Tests the Form submission flow through the reliability queue
 
 import json
 from locust import HttpUser, task
-from tests.utils.config import load_test_configuration
-from tests.utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
+from utils.config import load_test_configuration
+from utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
 from utils.form_submission_generator import FormSubmissionGenerator
 from botocore.config import Config
 from boto3 import client

--- a/lambda-code/load-testing/tests/behaviours/submit_infra.py
+++ b/lambda-code/load-testing/tests/behaviours/submit_infra.py
@@ -17,7 +17,9 @@ class FormSubmitThroughInfraBehaviour(SequentialTaskSetWithFailure):
         test_configuration = load_test_configuration()
         random_test_form = test_configuration.get_random_test_form()
         self.form_id = random_test_form.id
-        self.form_template = random_test_form.template
+        self.form_template = test_configuration.get_form_template(
+            random_test_form.usedTemplate
+        )
         self.form_submission_generator = None
 
     def on_start(self) -> None:

--- a/lambda-code/load-testing/tests/test_api.py
+++ b/lambda-code/load-testing/tests/test_api.py
@@ -1,0 +1,7 @@
+import global_setup  # This line ensures global setup runs before the test and creates the test_configuration file in /tmp
+from locust import HttpUser
+from behaviours.api import RetrieveResponseBehaviour
+
+
+class ApiUser(HttpUser):
+    tasks = [RetrieveResponseBehaviour]

--- a/lambda-code/load-testing/tests/test_global_system.py
+++ b/lambda-code/load-testing/tests/test_global_system.py
@@ -2,7 +2,7 @@ import global_setup  # This line ensures global setup runs before the test and c
 from locust import HttpUser, between
 from behaviours.api import RetrieveResponseBehaviour
 from behaviours.idp import AccessTokenBehaviour
-from tests.behaviours.submit_infra import FormSubmitThroughInfraBehaviour
+from behaviours.submit_infra import FormSubmitThroughInfraBehaviour
 from utils.http2_user import Http2User
 
 

--- a/lambda-code/load-testing/tests/test_send_submissions_through_client.py
+++ b/lambda-code/load-testing/tests/test_send_submissions_through_client.py
@@ -3,7 +3,6 @@ from locust import HttpUser, between
 from behaviours.submit_client import FormSubmitThroughClientBehaviour
 
 
-class SubmitThroughClientWithFileUploadUser(HttpUser):
+class SendSubmissionsThroughClientUser(HttpUser):
     tasks = [FormSubmitThroughClientBehaviour]
     wait_time = between(1, 5)
-    weight = 1

--- a/lambda-code/load-testing/tests/test_submit_through_client_with_file_upload.py
+++ b/lambda-code/load-testing/tests/test_submit_through_client_with_file_upload.py
@@ -1,6 +1,6 @@
 import global_setup  # This line ensures global setup runs before the test and creates the test_configuration file in /tmp
 from locust import HttpUser, between
-from tests.behaviours.submit_client import FormSubmitThroughClientBehaviour
+from behaviours.submit_client import FormSubmitThroughClientBehaviour
 
 
 class SubmitThroughClientWithFileUploadUser(HttpUser):

--- a/lambda-code/load-testing/tests/utils/config.py
+++ b/lambda-code/load-testing/tests/utils/config.py
@@ -6,6 +6,20 @@ from pydantic import BaseModel
 from urllib.parse import urlparse
 
 
+class EvenDistributor:
+    def __init__(self, items):
+        self.items = items
+        self.index = 0
+
+    def next_item(self):
+        item = self.items[self.index]
+        self.index = (self.index + 1) % len(self.items)
+        return item
+
+
+shared_test_forms_distributor: Optional[EvenDistributor] = None
+
+
 class PrivateKey(BaseModel):
     keyId: str
     key: str
@@ -25,7 +39,11 @@ class TestConfiguration(BaseModel):
     submitFormServerActionIdentifier: str
 
     def get_random_test_form(self) -> TestForm:
-        return random.choice(self.testForms)
+        global shared_test_forms_distributor
+        if shared_test_forms_distributor is None:
+            shared_test_forms_distributor = EvenDistributor(self.testForms)
+
+        return shared_test_forms_distributor.next_item()
 
     def get_form_template(self, template_name: str) -> Dict[str, Any]:
         return self.templates[template_name]

--- a/lambda-code/load-testing/tests/utils/form_submission_decrypter.py
+++ b/lambda-code/load-testing/tests/utils/form_submission_decrypter.py
@@ -4,7 +4,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.hashes import SHA256
-from tests.utils.config import PrivateKey
+from utils.config import PrivateKey
 from dataclasses import dataclass
 
 

--- a/lambda-code/load-testing/tests/utils/http2_user.py
+++ b/lambda-code/load-testing/tests/utils/http2_user.py
@@ -1,15 +1,12 @@
 import re
 import time
-
 from locust import User
 from locust.exception import LocustError
 import httpx
 from httpx import Request, Response
 from requests.auth import HTTPBasicAuth
 from httpx import InvalidURL, RequestError
-
 from urllib.parse import urlparse, urlunparse
-
 from locust.exception import CatchResponseError, ResponseError
 
 absolute_http_url_regexp = re.compile(r"^https?://", re.I)

--- a/lambda-code/load-testing/tests/utils/jwt_generator.py
+++ b/lambda-code/load-testing/tests/utils/jwt_generator.py
@@ -1,10 +1,8 @@
 import jwt
 import time
-
-from dataclasses import dataclass
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from tests.utils.config import PrivateKey
+from utils.config import PrivateKey
 
 
 class JwtGenerator:


### PR DESCRIPTION
# Summary | Résumé

- Removes unused load testing lambda env variables
- Reworks API load test scenario to match real use case (get new responses, fetch and confirm them all)
- Tweaks load testing implementation to work with new upcoming test-setup tool https://github.com/cds-snc/platform-forms-client/pull/5893
- Distributes test forms to virtual users in an even pattern

Note: once merged we can remove `STAGING_LOAD_TESTING_FORM_ID` and `STAGING_LOAD_TESTING_FORM_PRIVATE_KEY` from our Github secrets