### PR TITLE
fix: remove old version of file_scanning

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -221,10 +221,6 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       # Depends on S3
-      - name: Terragrunt apply file_scanning
-        working-directory: env/cloud/file_scanning
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
-
       - name: Terragrunt apply guard_duty
         working-directory: env/cloud/guard_duty
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -213,10 +213,6 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       # Depends on S3
-      - name: Terragrunt apply file_scanning
-        working-directory: env/cloud/file_scanning
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
-
       - name: Terragrunt apply guard_duty
         working-directory: env/cloud/guard_duty
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -126,13 +126,6 @@ jobs:
           terragrunt: "true"
 
       # Depends on S3
-      - name: Terragrunt plan file_scanning
-        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
-        with:
-          directory: "env/cloud/file_scanning"
-          comment: "false"
-          terragrunt: "true"
-
       - name: Terragrunt plan guard_duty
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -235,15 +235,6 @@ jobs:
           terragrunt: "true"
 
       # Depends on S3
-      - name: Terragrunt plan file_scanning
-        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
-        with:
-          directory: "env/cloud/file_scanning"
-          comment-delete: "true"
-          comment-title: "Production: file_scanning"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
       - name: Terragrunt plan guard_duty
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -226,16 +226,6 @@ jobs:
           terragrunt: "true"
 
       # Depends on S3
-      - name: Terragrunt plan file_scanning
-        if: steps.filter.outputs.file_scanning == 'true'
-        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
-        with:
-          directory: "env/cloud/file_scanning"
-          comment-delete: "true"
-          comment-title: "Staging: file_scanning"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
       - name: Terragrunt plan guard_duty
         if: steps.filter.outputs.guard_duty == 'true'
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3

--- a/env/cloud/file_scanning/terragrunt.hcl
+++ b/env/cloud/file_scanning/terragrunt.hcl
@@ -1,9 +1,0 @@
-terraform {
-  source = "../../../aws//file_scanning"
-}
-
-
-
-include "root" {
-  path = find_in_parent_folders("root.hcl")
-}


### PR DESCRIPTION
# Summary | Résumé
Removes old file_scanning code references now that the module has been replaced by guard duty.