### PR TITLE
fix: replace old FileKeysCreatedAt with new HasFileKeysByCreatedAt to resolve issue with primary key being too large

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -11,15 +11,21 @@ resource "aws_dynamodb_table" "reliability_queue" {
   }
 
   attribute {
-    name = "FileKeys"
-    type = "S"
+    name = "HasFileKeys"
+    type = "N"
+  }
+
+  attribute {
+    name = "CreatedAt"
+    type = "N"
   }
 
   global_secondary_index {
-    name               = "FileKeysCreatedAt"
-    hash_key           = "FileKeys"
+    name               = "HasFileKeysByCreatedAt"
+    hash_key           = "HasFileKeys"
+    range_key          = "CreatedAt"
     projection_type    = "INCLUDE"
-    non_key_attributes = ["SubmissionID", "CreatedAt", "SendReceipt", "NotifyProcessed"]
+    non_key_attributes = ["SubmissionID", "SendReceipt", "NotifyProcessed", "FileKeys"]
   }
 
   ttl {

--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -132,6 +132,7 @@ data "aws_iam_policy_document" "lambda_dynamodb" {
 
     resources = [
       var.dynamodb_reliability_queue_arn,
+      "${var.dynamodb_reliability_queue_arn}/index/*",
       var.dynamodb_vault_arn,
       "${var.dynamodb_vault_arn}/index/*",
       var.dynamodb_vault_stream_arn,

--- a/lambda-code/submission/src/main.ts
+++ b/lambda-code/submission/src/main.ts
@@ -151,6 +151,7 @@ const saveSubmission = async (
           CreatedAt: timeStamp,
           SecurityAttribute: securityAttribute,
           FormSubmissionHash: formResponsesAsHash,
+          HasFileKeys: fileKeys !== undefined ? 1 : 0,
           ...(fileKeys !== undefined && { FileKeys: JSON.stringify(fileKeys) }),
         },
       })


### PR DESCRIPTION
# Summary | Résumé

Fixes https://github.com/cds-snc/platform-forms-client/issues/5980

- Replaces `FileKeysCreatedAt` Global Secondary Index with `HasFileKeysByCreatedAt` to avoid using the `FileKeys` data field that can become too large ([to be a Primary Key](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Constraints.html#limits-partition-sort-keys)) when people upload a lot of files.