### PR TITLE
fix: handle non existing submission when getting file upload events from S3 for a submission that was already processed

### DIFF
--- a/lambda-code/file-upload-processor/src/lib/utils.ts
+++ b/lambda-code/file-upload-processor/src/lib/utils.ts
@@ -23,7 +23,7 @@ export const extractSubmissionIdFromObjectKey = (objectKey: string) => {
   return decodeURIComponent(objectKey.replace(/\+/g, " ")).split("/", 4)[2];
 };
 
-export const retrieveSubmission = async (submissionId: string): Promise<Submission> => {
+export const retrieveSubmission = async (submissionId: string): Promise<Submission | undefined> => {
   return dynamodb
     .send(
       new GetCommand({
@@ -36,13 +36,18 @@ export const retrieveSubmission = async (submissionId: string): Promise<Submissi
     )
     .then((result) => {
       if (result.Item === undefined) {
-        throw new Error(`Failed to retrieve submission ${submissionId}`);
+        return undefined;
       }
 
       return {
         sendReceipt: result.Item.SendReceipt,
         ...(result.Item.FileKeys && { fileKeys: JSON.parse(result.Item.FileKeys) }),
       } as Submission;
+    })
+    .catch((error) => {
+      throw new Error(
+        `Failed to retrieve submission ${submissionId}. Reason: ${(error as Error).message}`
+      );
     });
 };
 

--- a/lambda-code/file-upload-processor/src/main.ts
+++ b/lambda-code/file-upload-processor/src/main.ts
@@ -65,12 +65,20 @@ async function requestSubmissionProcessingWhenAllFilesAreAvailable(
       try {
         const submission = await retrieveSubmission(submissionId);
 
-        // If there are no files to verify or the submission has already been processed (sendReceipt != unknown) return early
         if (
+          submission === undefined ||
           submission.sendReceipt !== "unknown" ||
           submission.fileKeys === undefined ||
           submission.fileKeys.length === 0
         ) {
+          console.info(
+            JSON.stringify({
+              level: "info",
+              message:
+                "Skipping processing of file attachments because submission either does not exist or has already been processed or has no attached files",
+              submission: submission ?? "undefined",
+            })
+          );
           return;
         }
 


### PR DESCRIPTION
# Summary | Résumé

- Handles non existing submission when getting file upload events from S3 for a submission that was already processed