### PR TITLE
chore: delete IdP RDS Proxy

### DIFF
--- a/.github/module-filter.yml
+++ b/.github/module-filter.yml
@@ -91,3 +91,7 @@ sqs:
   - *common
   - "aws/sqs/**"
   - "env/cloud/sqs/**"
+pr_review:
+  - *common
+  - "aws/pr_review/**"
+  - "env/cloud/pr_review/**"

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -47,8 +47,6 @@ env:
   TF_VAR_zitadel_admin_password: ${{ secrets.PRODUCTION_ZITADEL_ADMIN_PASSWORD }}
   TF_VAR_zitadel_admin_username: ${{ secrets.PRODUCTION_ZITADEL_ADMIN_USERNAME }}
   TF_VAR_zitadel_database_name: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_NAME }}
-  TF_VAR_zitadel_database_user_password: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_USER_PASSWORD }}
-  TF_VAR_zitadel_database_user_username: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.PRODUCTION_ZITADEL_SECRET_KEY }}
   # API END TO END TEST
   TF_VAR_idp_project_identifier: "284778202772022819"

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -54,8 +54,6 @@ env:
   TF_VAR_zitadel_admin_password: ${{ secrets.STAGING_ZITADEL_ADMIN_PASSWORD }}
   TF_VAR_zitadel_admin_username: ${{ secrets.STAGING_ZITADEL_ADMIN_USERNAME }}
   TF_VAR_zitadel_database_name: ${{ secrets.STAGING_ZITADEL_DATABASE_NAME }}
-  TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
-  TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
   TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -46,8 +46,6 @@ env:
   TF_VAR_zitadel_admin_password: ${{ secrets.STAGING_ZITADEL_ADMIN_PASSWORD }}
   TF_VAR_zitadel_admin_username: ${{ secrets.STAGING_ZITADEL_ADMIN_USERNAME }}
   TF_VAR_zitadel_database_name: ${{ secrets.STAGING_ZITADEL_DATABASE_NAME }}
-  TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
-  TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
   TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -49,8 +49,6 @@ env:
   TF_VAR_zitadel_admin_password: ${{ secrets.PRODUCTION_ZITADEL_ADMIN_PASSWORD }}
   TF_VAR_zitadel_admin_username: ${{ secrets.PRODUCTION_ZITADEL_ADMIN_USERNAME }}
   TF_VAR_zitadel_database_name: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_NAME }}
-  TF_VAR_zitadel_database_user_password: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_USER_PASSWORD }}
-  TF_VAR_zitadel_database_user_username: ${{ secrets.PRODUCTION_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.PRODUCTION_ZITADEL_SECRET_KEY }}
   # API END TO END TEST
   TF_VAR_idp_project_identifier: "284778202772022819"

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -56,8 +56,6 @@ env:
   TF_VAR_zitadel_admin_password: ${{ secrets.STAGING_ZITADEL_ADMIN_PASSWORD }}
   TF_VAR_zitadel_admin_username: ${{ secrets.STAGING_ZITADEL_ADMIN_USERNAME }}
   TF_VAR_zitadel_database_name: ${{ secrets.STAGING_ZITADEL_DATABASE_NAME }}
-  TF_VAR_zitadel_database_user_password: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_PASSWORD }}
-  TF_VAR_zitadel_database_user_username: ${{ secrets.STAGING_ZITADEL_DATABASE_USER_USERNAME }}
   TF_VAR_zitadel_secret_key: ${{ secrets.STAGING_ZITADEL_SECRET_KEY }}
   # ECR
   TF_VAR_aws_development_accounts: ${{ vars.AWS_DEVELOPMENT_ACCOUNTS }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -359,17 +359,18 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
-      - name: Terragrunt plan load_testing
-        if: steps.filter.outputs.load_testing == 'true'
+      - name: Terragrunt plan glue
+        if: steps.filter.outputs.glue == 'true'
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:
-          directory: "env/cloud/load_testing"
+          directory: "env/cloud/glue"
           comment-delete: "true"
-          comment-title: "Staging: load_testing"
+          comment-title: "Staging: glue"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
       - name: Terragrunt plan pr_review
+        if: steps.filter.outputs.pr_review == 'true'
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:
           directory: "env/cloud/pr_review"
@@ -378,12 +379,12 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
-      - name: Terragrunt plan glue
-        if: steps.filter.outputs.glue == 'true'
+      - name: Terragrunt plan load_testing
+        if: steps.filter.outputs.load_testing == 'true'
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:
-          directory: "env/cloud/glue"
+          directory: "env/cloud/load_testing"
           comment-delete: "true"
-          comment-title: "Staging: glue"
+          comment-title: "Staging: load_testing"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"

--- a/aws/idp/ecs.tf
+++ b/aws/idp/ecs.tf
@@ -15,14 +15,6 @@ locals {
       "valueFrom" = aws_ssm_parameter.zitadel_database_host.arn
     },
     {
-      "name"      = "ZITADEL_DATABASE_POSTGRES_USER_USERNAME"
-      "valueFrom" = aws_ssm_parameter.zitadel_database_user_username.arn
-    },
-    {
-      "name"      = "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD"
-      "valueFrom" = aws_ssm_parameter.zitadel_database_user_password.arn
-    },
-    {
       "name"      = "ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME"
       "valueFrom" = aws_ssm_parameter.idp_database_cluster_admin_username.arn
     },
@@ -109,8 +101,6 @@ data "aws_iam_policy_document" "ecs_task_ssm_parameters" {
       aws_ssm_parameter.zitadel_admin_password.arn,
       aws_ssm_parameter.zitadel_database_host.arn,
       aws_ssm_parameter.zitadel_database_name.arn,
-      aws_ssm_parameter.zitadel_database_user_username.arn,
-      aws_ssm_parameter.zitadel_database_user_password.arn,
       aws_ssm_parameter.zitadel_secret_key.arn
     ]
   }

--- a/aws/idp/inputs.tf
+++ b/aws/idp/inputs.tf
@@ -78,18 +78,6 @@ variable "zitadel_database_name" {
   sensitive   = true
 }
 
-variable "zitadel_database_user_password" {
-  description = "The Zitadel database user password."
-  type        = string
-  sensitive   = true
-}
-
-variable "zitadel_database_user_username" {
-  description = "The Zitadel database user username."
-  type        = string
-  sensitive   = true
-}
-
 variable "zitadel_image_ecr_url" {
   description = "The Zitadel Docker image ECR repository URL."
   type        = string

--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -13,9 +13,9 @@ module "idp_database" {
   serverless_min_capacity = var.idp_database_min_acu
   serverless_max_capacity = var.idp_database_max_acu
 
-  username               = var.idp_database_cluster_admin_username
-  password               = var.idp_database_cluster_admin_password
-  proxy_secret_auth_arns = [aws_secretsmanager_secret.zidatel_database_proxy_auth.arn]
+  username  = var.idp_database_cluster_admin_username
+  password  = var.idp_database_cluster_admin_password
+  use_proxy = false
 
   backup_retention_period      = 14
   preferred_backup_window      = "02:00-04:00"
@@ -49,7 +49,7 @@ resource "aws_ssm_parameter" "zitadel_database_host" {
   # checkov:skip=CKV_AWS_337: Default SSM service key encryption is acceptable
   name  = "zitadel_database_host"
   type  = "SecureString"
-  value = module.idp_database.proxy_endpoint
+  value = module.idp_database.rds_cluster_endpoint
   tags  = local.common_tags
 }
 
@@ -59,34 +59,4 @@ resource "aws_ssm_parameter" "zitadel_database_name" {
   type  = "SecureString"
   value = var.zitadel_database_name
   tags  = local.common_tags
-}
-
-resource "aws_ssm_parameter" "zitadel_database_user_username" {
-  # checkov:skip=CKV_AWS_337: Default SSM service key encryption is acceptable
-  name  = "zitadel_database_user_username"
-  type  = "SecureString"
-  value = var.zitadel_database_user_username
-  tags  = local.common_tags
-}
-
-resource "aws_ssm_parameter" "zitadel_database_user_password" {
-  # checkov:skip=CKV_AWS_337: Default SSM service key encryption is acceptable
-  name  = "zitadel_database_user_password"
-  type  = "SecureString"
-  value = var.zitadel_database_user_password
-  tags  = local.common_tags
-}
-
-resource "aws_secretsmanager_secret" "zidatel_database_proxy_auth" {
-  # checkov:skip=CKV2_AWS_57: automated rotation is not applicable to this secret
-  name = "zidatel_database_proxy_auth"
-  tags = local.common_tags
-}
-
-resource "aws_secretsmanager_secret_version" "zidatel_database_proxy_auth" {
-  secret_id = aws_secretsmanager_secret.zidatel_database_proxy_auth.id
-  secret_string = jsonencode({
-    username = var.zitadel_database_user_username,
-    password = var.zitadel_database_user_password
-  })
 }


### PR DESCRIPTION
# Summary | Résumé

- Adds `pr_review` to the list of filtered modules so that we don't have to run Terraform plan on it when nothing has changed in that module
- Deletes IdP AWS RDS Proxy as it causes problems with recent versions of Zitadel (now that it includes Riverqueue as a dependency)