### PR TITLE
fix: Lmbda workflow build matrix

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -120,6 +120,7 @@ jobs:
       VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
+      max-parallel: 4 # Limits parallel matrix jobs
       matrix:
         image: ${{ fromJSON(needs.generate-lambda-functions-matrix.outputs.lambda-functions-matrix) }}
     steps:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4 # Limits parallel matrix jobs
       matrix:
         image: ${{ fromJSON(needs.detect-lambda-changes.outputs.lambda-to-rebuild) }}
 

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -116,6 +116,7 @@ jobs:
       VERSION: ${{ needs.get-version.outputs.version }}
     strategy:
       fail-fast: false
+      max-parallel: 4 # Limits parallel matrix jobs
       matrix:
         image: ${{ fromJSON(needs.generate-lambda-functions-matrix.outputs.lambda-functions-matrix) }}
     steps:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -105,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4 # Limits parallel matrix jobs
       matrix:
         image: ${{ fromJSON(needs.detect-lambda-changes.outputs.lambda-to-rebuild) }}
     steps:


### PR DESCRIPTION
# Summary | Résumé
With the number of lambdas continuing to grow we are now experiencing errors during the lambda build process as NPM throttles the connection due to too many requests.

This ensures that only 4 lambdas can be build in parallel.