### PR TITLE
chore: increase Nagware lambda max memory size to 512 MB

### DIFF
--- a/aws/lambdas/nagware.tf
+++ b/aws/lambdas/nagware.tf
@@ -8,6 +8,7 @@ resource "aws_lambda_function" "nagware" {
   package_type  = "Image"
   role          = aws_iam_role.lambda.arn
   timeout       = 900
+  memory_size   = 512
 
   // Even in development mode this lambda should be attached to the VPC in order to connecto the DB
   vpc_config {


### PR DESCRIPTION
# Summary | Résumé

- Increases max memory size for Nagware lambda from 128 to 512 MB