### PR TITLE
fix: Allow OIDC login for Zitadel

### DIFF
--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -1,6 +1,7 @@
 locals {
   excluded_common_rules = [
-    "EC2MetaDataSSRF_BODY" # Rule is blocking IdP OIDC app creation
+    "EC2MetaDataSSRF_BODY", # Rule is blocking IdP OIDC app creation
+    "EC2MetaDataSSRF_QUERYARGUMENTS" # Rule is blocking IdP OIDC login
   ]
 }
 

--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -246,51 +246,6 @@ resource "aws_wafv2_web_acl" "idp" {
     sampled_requests_enabled   = true
   }
 
-  # Label match rule
-  # Blocks requests that trigger `AWSManagedRulesCommonRuleSet.EC2MetaDataSSRF_Body` except those creating an OIDC app
-  rule {
-    name     = "Label_EC2MetaDataSSRF_BODY"
-    priority = 60
-
-    action {
-      block {}
-    }
-
-    statement {
-      and_statement {
-        statement {
-          label_match_statement {
-            scope = "LABEL"
-            key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Body"
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "CONTAINS"
-                search_string         = "/addoidcapp"
-                text_transformation {
-                  type     = "LOWERCASE"
-                  priority = 0
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "Label_EC2MetaDataSSRF_BODY"
-      sampled_requests_enabled   = true
-    }
-  }
-
   rule {
     name     = "BlockedIPv4"
     priority = 70


### PR DESCRIPTION
# Summary | Résumé
AWS WAF Common rules were blocking various admin management functionality through the interface as well as blocking attempts at leveraging OIDC login for Zitadel.