### PR TITLE
chore: update waf ip block version

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -668,7 +668,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_maintenance_mode_uri_paths" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=7341e0355a0a346574828da97863af2f552d05ed" # v10.4.6
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=10bb6f8d05df94698a93aa016618fd1ab22b8b2c" # v10.7.0
 
   service_name                     = "forms_app"
   athena_database_name             = "access_logs"


### PR DESCRIPTION
# Summary | Résumé
Update Dynamic WAF IP Block to latest version that ignores GC IP addresses