### PR TITLE
fix: deployment of aws_s3_bucket_notification Terraform resource breaks Guard Duty integration

### DIFF
--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -67,8 +67,11 @@ resource "aws_s3_bucket_public_access_block" "reliability_file_storage" {
 # The policy is in the S3 module because adding it to the SQS module would cause a circular dependency.
 
 resource "aws_s3_bucket_notification" "file_upload" {
-  bucket      = aws_s3_bucket.reliability_file_storage.id
-  eventbridge = false
+  bucket = aws_s3_bucket.reliability_file_storage.id
+
+  # [IMPORTANT] We need to keep this enabled as it would break the integration with AWS Guard Duty
+  # which relies on notifications being published to EventBridge in order to trigger scanning
+  eventbridge = true
 
   queue {
     queue_arn = var.sqs_file_upload_arn


### PR DESCRIPTION
# Summary | Résumé

- Fixes a weird problem where deploying the `aws_s3_bucket_notification` Terraform resource breaks the AWS Guard Duty integration.

Here is the Terraform output for the last commit that was deployed to Staging:
```
18:25:45.352 STDOUT terraform: Terraform used the selected providers to generate the following execution
18:25:45.352 STDOUT terraform: plan. Resource actions are indicated with the following symbols:
18:25:45.352 STDOUT terraform:   ~ update in-place
18:25:45.352 STDOUT terraform: Terraform will perform the following actions:
18:25:45.352 STDOUT terraform:   # aws_s3_bucket_notification.file_upload will be updated in-place
18:25:45.353 STDOUT terraform:   ~ resource "aws_s3_bucket_notification" "file_upload" {
18:25:45.353 STDOUT terraform:       ~ eventbridge = true -> false
18:25:45.353 STDOUT terraform:         id          = "forms-staging-reliability-file-storage"
18:25:45.353 STDOUT terraform:         # (2 unchanged attributes hidden)
18:25:45.353 STDOUT terraform:         # (1 unchanged block hidden)
18:25:45.353 STDOUT terraform:     }
18:25:45.353 STDOUT terraform: Plan: 0 to add, 1 to change, 0 to destroy.
```