### PR TITLE
Fix: Add cors to retrieve vault files

### DIFF
--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -155,6 +155,17 @@ resource "aws_s3_bucket_public_access_block" "vault_file_storage" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_cors_configuration" "vault_file_storage" {
+  bucket = aws_s3_bucket.vault_file_storage.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+}
+
 #
 # Archive Storage
 #


### PR DESCRIPTION
# Summary | Résumé
Add CORS configuration to S3 vault storage so a browser can initiate the connection of a signed url.