### PR TITLE
fix: load test bug related to compatibility between invokust and locust

### DIFF
--- a/lambda-code/load-testing/.gitignore
+++ b/lambda-code/load-testing/.gitignore
@@ -1,1 +1,2 @@
+.venv/
 test_configuration.json

--- a/lambda-code/load-testing/Dockerfile
+++ b/lambda-code/load-testing/Dockerfile
@@ -4,6 +4,7 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 COPY main.py .
+COPY custom_create_settings.py .
 COPY tests ./tests
 
 CMD ["main.handler"]

--- a/lambda-code/load-testing/Dockerfile
+++ b/lambda-code/load-testing/Dockerfile
@@ -1,4 +1,5 @@
-FROM amazon/aws-lambda-python:3.13@sha256:01b4aadb2181e2aa473dd7eb8a125de366cbcf77e6aa75cc2b3b719775da49b4
+# Due to some incompatibility between Locust and Python3.13 we are forced to use 3.12 (see https://github.com/locustio/locust/issues/3050)
+FROM amazon/aws-lambda-python:3.12@sha256:1965397387bae8db437d907cbb8e17b490edc8912b9ecab6abd394649bd25c1f
 
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt

--- a/lambda-code/load-testing/Makefile
+++ b/lambda-code/load-testing/Makefile
@@ -2,7 +2,7 @@ fmt:
 	black .
 
 install:
-	python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
+	python3.12 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
 
 .PHONY: \
 	fmt \

--- a/lambda-code/load-testing/Makefile
+++ b/lambda-code/load-testing/Makefile
@@ -2,7 +2,7 @@ fmt:
 	black .
 
 install:
-	pip3 install --user -r requirements.txt
+	python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
 
 .PHONY: \
 	fmt \

--- a/lambda-code/load-testing/custom_create_settings.py
+++ b/lambda-code/load-testing/custom_create_settings.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from locust.main import load_locustfile
+
+
+def create_settings(
+    from_environment=False,
+    locustfile=None,
+    classes=None,
+    host=None,
+    num_users=None,
+    spawn_rate=None,
+    reset_stats=False,
+    run_time="3m",
+    loglevel="INFO",
+):
+    """
+    Returns a settings object to configure the locust load test.
+
+    Arguments
+
+        from_environment: get settings from environment variables
+        locustfile: locustfile to use for loadtest
+        classes: locust classes to use for load test
+        host: host for load testing
+        num_users: number of users to simulate in load test
+        spawn_rate: number of users per second to start
+        reset_stats: Whether to reset stats after all users are hatched
+        run_time: The length of time to run the test for. Cannot exceed the duration limit set by lambda
+
+    If from_environment is set to True then this function will attempt to set
+    the attributes from environment variables. The environment variables are
+    named LOCUST_ + attribute name in upper case.
+    """
+
+    settings = type("", (), {})()
+
+    settings.from_environment = from_environment
+    settings.locustfile = locustfile
+
+    # parameters needed to create the locust Environment object
+    settings.classes = classes
+    settings.host = host
+    settings.tags = None
+    settings.exclude_tags = None
+    settings.reset_stats = reset_stats
+    settings.step_load = False
+    settings.stop_timeout = None
+
+    # parameters to configure test
+    settings.num_users = num_users
+    settings.run_time = run_time
+    settings.spawn_rate = spawn_rate
+
+    if from_environment:
+        for attribute in [
+            "locustfile",
+            "classes",
+            "host",
+            "run_time",
+            "num_users",
+            "spawn_rate",
+            "loglevel",
+        ]:
+            var_name = "LOCUST_{0}".format(attribute.upper())
+            var_value = os.environ.get(var_name)
+            if var_value:
+                setattr(settings, attribute, var_value)
+
+    if settings.locustfile is None and settings.classes is None:
+        raise Exception("One of locustfile or classes must be specified")
+
+    if settings.locustfile and settings.classes:
+        raise Exception("Only one of locustfile or classes can be specified")
+
+    if settings.locustfile:
+        classes, shape_class = load_locustfile(settings.locustfile)
+        settings.classes = [classes[n] for n in classes]
+    else:
+        if isinstance(settings.classes, str):
+            settings.classes = settings.classes.split(",")
+            for idx, val in enumerate(settings.classes):
+                # This needs fixing
+                settings.classes[idx] = eval(val)
+
+    for attribute in ["classes", "host", "num_users", "spawn_rate"]:
+        val = getattr(settings, attribute, None)
+        if not val:
+            raise Exception(
+                "configuration error, attribute not set: {0}".format(attribute)
+            )
+
+        if isinstance(val, str) and val.isdigit():
+            setattr(settings, attribute, int(val))
+
+    return settings

--- a/lambda-code/load-testing/main.py
+++ b/lambda-code/load-testing/main.py
@@ -5,6 +5,7 @@ import boto3
 import json
 
 from invokust.aws_lambda import get_lambda_runtime_info
+from custom_create_settings import create_settings
 
 logging.basicConfig(level=logging.INFO)
 
@@ -47,7 +48,7 @@ def handler(event: dict[str, any], context=None):
         with open("/tmp/test_configuration.json", "w") as file:
             json.dump(test_configuration, file)
 
-        loadtest = invokust.LocustLoadTest(invokust.create_settings(**event))
+        loadtest = invokust.LocustLoadTest(create_settings(**event))
         loadtest.run()
     except Exception as e:
         logging.error("Exception running locust tests {0}".format(repr(e)))

--- a/lambda-code/load-testing/requirements.txt
+++ b/lambda-code/load-testing/requirements.txt
@@ -3,6 +3,6 @@ boto3==1.35.39
 cryptography==44.0.1
 httpx[http2]==0.27.2
 invokust==0.77
-locust==2.31.7
+locust==2.39.1
 PyJWT==2.9.0
 pydantic==2.11.7

--- a/lambda-code/load-testing/tests/behaviours/api.py
+++ b/lambda-code/load-testing/tests/behaviours/api.py
@@ -21,12 +21,19 @@ from utils.sequential_task_set_with_failure import SequentialTaskSetWithFailure
 class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
     def __init__(self, parent: HttpUser) -> None:
         super().__init__(parent)
-        test_configuration = load_test_configuration()
+        self.test_configuration = load_test_configuration()
+        self.idp_project_id = get_idp_project_id()
+        self.idp_url = get_idp_url_from_target_host(self.parent.host)
+        self.api_url = get_api_url_from_target_host(self.parent.host)
+        self.headers = None
+
+    def on_start(self) -> None:
         random_test_form = (
-            test_configuration.get_test_form_based_on_thread_id()
-            if test_configuration.assignTestFormBasedOnThreadId
-            else test_configuration.get_random_test_form()
+            self.test_configuration.get_test_form_based_on_thread_id()
+            if self.test_configuration.assignTestFormBasedOnThreadId
+            else self.test_configuration.get_random_test_form()
         )
+
         self.form_id = random_test_form.id
 
         if random_test_form.apiKey is None:
@@ -34,12 +41,6 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
 
         self.form_private_key = random_test_form.apiKey
 
-        self.idp_project_id = get_idp_project_id()
-        self.idp_url = get_idp_url_from_target_host(self.parent.host)
-        self.api_url = get_api_url_from_target_host(self.parent.host)
-        self.headers = None
-
-    def on_start(self) -> None:
         jwt_form = JwtGenerator.generate(self.idp_url, self.form_private_key)
 
         data = {
@@ -49,7 +50,11 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
         }
 
         response = self.request_with_failure_check(
-            "post", f"{self.idp_url}/oauth/v2/token", 200, data=data
+            method="post",
+            url=f"{self.idp_url}/oauth/v2/token",
+            expected_status_code=200,
+            request_tracking_name="oauth/v2/token",
+            data=data,
         )
 
         self.headers = {
@@ -57,45 +62,37 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
             "Content-Type": "application/json",
         }
 
+        self.request_with_failure_check(
+            method="get",
+            url=f"{self.api_url}/forms/{self.form_id}/template",
+            expected_status_code=200,
+            request_tracking_name="/forms/template",
+            headers=self.headers,
+        )
+
     @task
     def get_new_submissions(self) -> None:
         form_new_submissions = self.request_with_failure_check(
-            "get",
-            f"{self.api_url}/forms/{self.form_id}/submission/new",
-            200,
+            method="get",
+            url=f"{self.api_url}/forms/{self.form_id}/submission/new",
+            expected_status_code=200,
+            request_tracking_name="/forms/submission/new",
             headers=self.headers,
-            name=f"/forms/submission/new",
         )
-
-        self.get_form_template()
 
         while form_new_submissions:
             new_submission = form_new_submissions.pop(0)
             new_submission_name = new_submission["name"]
             submission = self.get_submission_by_name(new_submission_name)
-
-            if "attachments" in submission:
-                for attachment in submission["attachments"]:
-                    self.download_submission_attachment(attachment["downloadLink"])
-
             self.confirm_submission(new_submission_name, submission["confirmationCode"])
-
-    def get_form_template(self) -> None:
-        self.request_with_failure_check(
-            "get",
-            f"{self.api_url}/forms/{self.form_id}/template",
-            200,
-            headers=self.headers,
-            name=f"/forms/template",
-        )
 
     def get_submission_by_name(self, submission_name: str) -> dict:
         response = self.request_with_failure_check(
-            "get",
-            f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}",
-            200,
+            method="get",
+            url=f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}",
+            expected_status_code=200,
+            request_tracking_name="/forms/submission/retrieve",
             headers=self.headers,
-            name=f"/forms/submission/retrieve",
         )
 
         encrypted_submission = EncryptedFormSubmission.from_json(response)
@@ -107,14 +104,9 @@ class RetrieveResponseBehaviour(SequentialTaskSetWithFailure):
 
     def confirm_submission(self, submission_name: str, confirmation_code: str) -> None:
         self.request_with_failure_check(
-            "put",
-            f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}/confirm/{confirmation_code}",
-            200,
+            method="put",
+            url=f"{self.api_url}/forms/{self.form_id}/submission/{submission_name}/confirm/{confirmation_code}",
+            expected_status_code=200,
+            request_tracking_name="/forms/submission/confirm",
             headers=self.headers,
-            name=f"/forms/submission/confirm",
-        )
-
-    def download_submission_attachment(self, download_link: str) -> None:
-        self.request_with_failure_check(
-            "get", download_link, 200, name="submission-attachment-download"
         )

--- a/lambda-code/load-testing/tests/utils/sequential_task_set_with_failure.py
+++ b/lambda-code/load-testing/tests/utils/sequential_task_set_with_failure.py
@@ -8,12 +8,21 @@ class SequentialTaskSetWithFailure(SequentialTaskSet):
         super().__init__(parent)
 
     def request_with_failure_check(
-        self, method: str, url: str, status_code: int, **kwargs: Dict[str, Any]
+        self,
+        method: str,
+        url: str,
+        expected_status_code: int,
+        request_tracking_name: str | None = None,
+        **kwargs: Dict[str, Any],
     ) -> dict:
-        kwargs["catch_response"] = True
-
-        with self.client.request(method, url, **kwargs) as response:
-            if response.status_code != status_code:
+        with self.client.request(
+            method,
+            url,
+            name=request_tracking_name or url,
+            catch_response=True,
+            **kwargs,
+        ) as response:
+            if response.status_code != expected_status_code:
                 response.failure(
                     f"Request failed: {response.status_code} {response.text}"
                 )


### PR DESCRIPTION
# Summary | Résumé

- Upgrades Locust to version 2.39.1
- Forces use of Python 3.12 in load test project
- Revises use of `HttpSession` from Locust
- Removes submission attachments download process from API test scenario