### PR TITLE
fix: Reliability Queue can handle new response date format

### DIFF
--- a/lambda-code/reliability/src/lib/dataLayer.ts
+++ b/lambda-code/reliability/src/lib/dataLayer.ts
@@ -371,10 +371,7 @@ function handleFormattedDateResponse(
 ) {
   if (response !== undefined && response !== null && response !== "") {
     collector.push(
-      `**${title}**${String.fromCharCode(13)}${getFormattedDateFromObject(
-        dateFormat,
-        JSON.parse(String(response))
-      )}`
+      `**${title}**${String.fromCharCode(13)}${getFormattedDateFromObject(dateFormat, response)}`
     );
     return;
   }

--- a/lambda-code/reliability/src/lib/utils.ts
+++ b/lambda-code/reliability/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { DateFormat, DateObject } from "./types.js";
+import { DateFormat, DateObject, Response } from "./types.js";
 
 /**
  * Utility function to use when rendering a formatted date string
@@ -9,7 +9,7 @@ import { DateFormat, DateObject } from "./types.js";
  */
 export const getFormattedDateFromObject = (
   dateFormat: DateFormat = "YYYY-MM-DD",
-  dateObject: DateObject
+  dateObject: Response
 ): string => {
   // If an invalid date format is provided, use the default format
   if (!isValidDateFormat(dateFormat)) {
@@ -75,9 +75,9 @@ export const isValidDateObject = (obj: unknown): obj is DateObject => {
     "YYYY" in obj &&
     "MM" in obj &&
     "DD" in obj &&
-    typeof obj.YYYY === "number" &&
-    typeof obj.MM === "number" &&
-    typeof obj.DD === "number"
+    typeof obj["YYYY"] === "number" &&
+    typeof obj["MM"] === "number" &&
+    typeof obj["DD"] === "number"
   );
 };
 


### PR DESCRIPTION
# Summary | Résumé
Treats the formatted date response as an object instead of a string in the Notify email creation path.