### PR TITLE
fix: DLQ alarms should use name of queue instead of ARN

### DIFF
--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -107,10 +107,10 @@ resource "aws_cloudwatch_metric_alarm" "ELB_healthy_hosts" {
 
 locals {
   map_of_sqs_dead_letter_queues = {
-    reliability   = var.sqs_reliability_deadletter_queue_arn,
-    app_audit_log = var.sqs_app_audit_log_deadletter_queue_arn,
-    api_audit_log = var.sqs_api_audit_log_deadletter_queue_arn,
-    file_upload   = var.sqs_file_upload_deadletter_queue_arn
+    reliability   = var.sqs_reliability_deadletter_queue_name,
+    app_audit_log = var.sqs_app_audit_log_deadletter_queue_name,
+    api_audit_log = var.sqs_api_audit_log_deadletter_queue_name,
+    file_upload   = var.sqs_file_upload_deadletter_queue_name
   }
 }
 

--- a/aws/alarms/inputs.tf
+++ b/aws/alarms/inputs.tf
@@ -211,23 +211,23 @@ variable "rds_idp_cpu_maxiumum" {
 
 }
 
-variable "sqs_reliability_deadletter_queue_arn" {
-  description = "ARN of the Reliability queue's SQS Dead Letter Queue"
+variable "sqs_reliability_deadletter_queue_name" {
+  description = "Name of the Reliability queue's SQS Dead Letter Queue"
   type        = string
 }
 
-variable "sqs_app_audit_log_deadletter_queue_arn" {
-  description = "ARN of the Audit Log queue's SQS Dead Letter Queue"
+variable "sqs_app_audit_log_deadletter_queue_name" {
+  description = "Name of the Audit Log queue's SQS Dead Letter Queue"
   type        = string
 }
 
-variable "sqs_api_audit_log_deadletter_queue_arn" {
-  description = "ARN of the API Audit Log queue's SQS Dead Letter Queue"
+variable "sqs_api_audit_log_deadletter_queue_name" {
+  description = "Name of the API Audit Log queue's SQS Dead Letter Queue"
   type        = string
 }
 
-variable "sqs_file_upload_deadletter_queue_arn" {
-  description = "File upload dead-letter queue ARN"
+variable "sqs_file_upload_deadletter_queue_name" {
+  description = "Name of the File upload queue's SQS Dead Letter Queue"
   type        = string
 }
 

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -23,8 +23,8 @@ output "sqs_reliability_reprocessing_queue_id" {
   value       = aws_sqs_queue.reliability_reprocessing_queue.id
 }
 
-output "sqs_reliability_deadletter_queue_arn" {
-  description = "Reliability queue's dead-letter queue ARN"
+output "sqs_reliability_deadletter_queue_name" {
+  description = "Reliability queue's dead-letter queue name"
   value       = aws_sqs_queue.reliability_deadletter_queue.name
 }
 
@@ -48,14 +48,14 @@ output "sqs_api_audit_log_queue_id" {
   value       = aws_sqs_queue.api_audit_log_queue.id
 }
 
-output "sqs_app_audit_log_deadletter_queue_arn" {
-  description = "Audit Log queues dead-letter queue ARN"
-  value       = aws_sqs_queue.audit_log_deadletter_queue.arn
+output "sqs_app_audit_log_deadletter_queue_name" {
+  description = "Audit Log queues dead-letter queue name"
+  value       = aws_sqs_queue.audit_log_deadletter_queue.name
 }
 
-output "sqs_api_audit_log_deadletter_queue_arn" {
-  description = "API Audit Log queues dead-letter queue ARN"
-  value       = aws_sqs_queue.api_audit_log_deadletter_queue.arn
+output "sqs_api_audit_log_deadletter_queue_name" {
+  description = "API Audit Log queues dead-letter queue name"
+  value       = aws_sqs_queue.api_audit_log_deadletter_queue.name
 }
 
 output "sqs_file_upload_queue_arn" {
@@ -68,7 +68,7 @@ output "sqs_file_upload_queue_id" {
   value       = aws_sqs_queue.file_upload_queue.id
 }
 
-output "sqs_file_upload_deadletter_queue_arn" {
-  description = "File upload dead-letter queue ARN"
-  value       = aws_sqs_queue.file_upload_deadletter_queue.arn
+output "sqs_file_upload_deadletter_queue_name" {
+  description = "File upload dead-letter queue name"
+  value       = aws_sqs_queue.file_upload_deadletter_queue.name
 }

--- a/env/cloud/alarms/terragrunt.hcl
+++ b/env/cloud/alarms/terragrunt.hcl
@@ -68,10 +68,10 @@ dependency "sqs" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    sqs_reliability_deadletter_queue_arn   = "arn:aws:sqs:ca-central-1:${local.aws_account_id}:reliability_deadletter_queue.fifo"
-    sqs_app_audit_log_deadletter_queue_arn = "arn:aws:sqs:ca-central-1:${local.aws_account_id}:audit_log_deadletter_queue"
-    sqs_api_audit_log_deadletter_queue_arn = "arn:aws:sqs:ca-central-1:${local.aws_account_id}:api_audit_log_deadletter_queue"
-    sqs_file_upload_deadletter_queue_arn   = "arn:aws:sqs:ca-central-1:${local.aws_account_id}:file_upload_deadletter_queue"
+    sqs_reliability_deadletter_queue_name   = "reliability_deadletter_queue"
+    sqs_app_audit_log_deadletter_queue_name = "audit_log_deadletter_queue"
+    sqs_api_audit_log_deadletter_queue_name = "api_audit_log_deadletter_queue"
+    sqs_file_upload_deadletter_queue_name   = "file_upload_deadletter_queue"
   }
 }
 
@@ -204,10 +204,10 @@ inputs = {
   unhealthy_host_count_for_target_group_1_alarm_arn = dependency.load_balancer.outputs.unhealthy_host_count_for_target_group_1_alarm_arn
   unhealthy_host_count_for_target_group_2_alarm_arn = dependency.load_balancer.outputs.unhealthy_host_count_for_target_group_2_alarm_arn
 
-  sqs_reliability_deadletter_queue_arn   = dependency.sqs.outputs.sqs_reliability_deadletter_queue_arn
-  sqs_app_audit_log_deadletter_queue_arn = dependency.sqs.outputs.sqs_app_audit_log_deadletter_queue_arn
-  sqs_api_audit_log_deadletter_queue_arn = dependency.sqs.outputs.sqs_api_audit_log_deadletter_queue_arn
-  sqs_file_upload_deadletter_queue_arn   = dependency.sqs.outputs.sqs_file_upload_deadletter_queue_arn
+  sqs_reliability_deadletter_queue_name   = dependency.sqs.outputs.sqs_reliability_deadletter_queue_name
+  sqs_app_audit_log_deadletter_queue_name = dependency.sqs.outputs.sqs_app_audit_log_deadletter_queue_name
+  sqs_api_audit_log_deadletter_queue_name = dependency.sqs.outputs.sqs_api_audit_log_deadletter_queue_name
+  sqs_file_upload_deadletter_queue_name   = dependency.sqs.outputs.sqs_file_upload_deadletter_queue_name
 
   ecs_cloudwatch_log_group_name = dependency.app.outputs.ecs_cloudwatch_log_group_name
   ecs_cluster_name              = dependency.app.outputs.ecs_cluster_name


### PR DESCRIPTION
# Summary | Résumé

- Fixes DLQ alarm configuration due to misleading example 😅 (resource name was ARN but actual value pointed at name)