### PR TITLE
chore: limit to 10 the number of concurrent audit logs lambda running at a time

### DIFF
--- a/aws/lambdas/audit_log.tf
+++ b/aws/lambdas/audit_log.tf
@@ -11,6 +11,9 @@ resource "aws_lambda_function" "audit_logs" {
   timeout       = 60
   memory_size   = 256
 
+  # Limit number of concurrent instances running at a time to fight against DynamoDB's API rate limiting when there is a spike in numbers of audit logs to process
+  reserved_concurrent_executions = 10
+
   lifecycle {
     ignore_changes = [image_uri]
   }


### PR DESCRIPTION
# Summary | Résumé

- Limits to 10 the number of concurrent audit logs lambda running at a time