### PR TITLE
chore: limit to 5 the number of concurrent audit logs lambda running at a time

### DIFF
--- a/aws/lambdas/audit_log.tf
+++ b/aws/lambdas/audit_log.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "audit_logs" {
   memory_size   = 256
 
   # Limit number of concurrent instances running at a time to fight against DynamoDB's API rate limiting when there is a spike in numbers of audit logs to process
-  reserved_concurrent_executions = 10
+  reserved_concurrent_executions = 5
 
   lifecycle {
     ignore_changes = [image_uri]


### PR DESCRIPTION
# Summary | Résumé

- Decreases number of concurrent audit logs lambda running at a time to 5 (instead of 10)