### PR TITLE
chore: upgrade aurora-postgresql to 16.8 for the IdP module

### DIFF
--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -7,7 +7,7 @@ module "idp_database" {
 
   database_name           = var.zitadel_database_name
   engine                  = "aurora-postgresql"
-  engine_version          = "16.6"
+  engine_version          = "16.8"
   instances               = 1 # TODO: increase for prod loads
   instance_class          = "db.serverless"
   serverless_min_capacity = var.idp_database_min_acu


### PR DESCRIPTION
# Summary | Résumé

- Upgrades aurora-postgresql to 16.8 for the IdP module