### PR TITLE
fix: remove the use of JSON.stringify in console logs when formatting errors from external services

### DIFF
--- a/lambda-code/reliability/src/lib/dataLayer.ts
+++ b/lambda-code/reliability/src/lib/dataLayer.ts
@@ -54,7 +54,7 @@ export async function removeSubmission(submissionID: string) {
 
     return await db.send(new DeleteCommand(DBParams));
   } catch (error) {
-    console.error(JSON.stringify(error));
+    console.error(error);
     throw new Error(`Error removing submission ${submissionID} from ReliabilityQueue table`);
   }
 }
@@ -85,7 +85,7 @@ export async function notifyProcessed(submissionID: string) {
 
     return await db.send(new UpdateCommand(DBParams));
   } catch (error) {
-    console.error(JSON.stringify(error));
+    console.error(error);
     throw new Error(`Error updating Notify TTL for submission ${submissionID}`);
   }
 }
@@ -190,7 +190,7 @@ export async function saveToVault(
         });
       } else {
         // Not a duplication error, something else has gone wrong
-        console.error(JSON.stringify(error));
+        console.error(error);
         throw new Error(
           `Error saving submission to vault for submission ID ${submissionID} / FormID: ${formID}`
         );

--- a/lambda-code/reliability/src/lib/s3FileInput.ts
+++ b/lambda-code/reliability/src/lib/s3FileInput.ts
@@ -47,7 +47,7 @@ async function getObject(bucket: string, key: string) {
       );
 
       // Log full error to console, it will not be sent to Slack
-      console.error(JSON.stringify(error));
+      console.error(error);
 
       return reject(error);
     }
@@ -62,7 +62,7 @@ export async function retrieveFilesFromReliabilityStorage(filePaths: string[]) {
     });
     return await Promise.all(files);
   } catch (error) {
-    console.error(JSON.stringify(error));
+    console.error(error);
     throw new Error(`Failed to retrieve files from reliability storage: ${filePaths.toString()}`);
   }
 }
@@ -79,7 +79,7 @@ export async function copyFilesFromReliabilityToVaultStorage(filePaths: string[]
       await s3Client.send(new CopyObjectCommand(commandInput));
     }
   } catch (error) {
-    console.error(JSON.stringify(error));
+    console.error(error);
     throw new Error(
       `Failed to copy files from reliability storage to vault storage: ${filePaths.toString()}`
     );
@@ -97,7 +97,7 @@ export async function removeFilesFromReliabilityStorage(filePaths: string[]) {
       await s3Client.send(new DeleteObjectCommand(commandInput));
     }
   } catch (error) {
-    console.log(JSON.stringify(error));
+    console.log(error);
     throw new Error(`Failed to remove files from reliability storage: ${filePaths.toString()}`);
   }
 }
@@ -118,7 +118,7 @@ export const getFileMetaData = async (filePath: string) => {
 
     return metadata;
   } catch (error) {
-    console.error(JSON.stringify(error));
+    console.error(error);
     throw new Error(`Failed to retrieve metadata for file: ${filePath}`);
   }
 };

--- a/lambda-code/reliability/src/main.ts
+++ b/lambda-code/reliability/src/main.ts
@@ -139,7 +139,7 @@ export const handler: Handler = async (event: SQSEvent) => {
     );
 
     // Log full error to console, it will not be sent to Slack
-    console.warn(JSON.stringify(error));
+    console.warn(error);
 
     throw new Error(JSON.stringify({ status: "failed" }));
   }


### PR DESCRIPTION
# Summary | Résumé

Context: we recently experienced a problem in Staging where an error from the AWS SDK was not able to be JSON stringified because of its complex structure. This led us to not being able to read the real error that happened during processing in the Reliability Lambda function.

- Removes the use of JSON.stringify in console logs when formatting errors from external services