### PR TITLE
fix: Small files less than 100 Bytes are processed

### DIFF
--- a/lambda-code/reliability/src/lib/s3FileInput.ts
+++ b/lambda-code/reliability/src/lib/s3FileInput.ts
@@ -124,6 +124,22 @@ export const getFileTags = async (filePath: string) => {
   }
 };
 
+export const getFileSize = async (filePath: string) => {
+  const response = await s3Client
+    .send(
+      new HeadObjectCommand({
+        Bucket: reliabilityBucketName,
+        Key: filePath,
+      })
+    )
+    .catch((error) => {
+      console.error(error);
+      throw new Error(`Failed to retrieve size for file: ${filePath}`);
+    });
+
+  return Number(response.ContentLength ?? "0");
+};
+
 export const getFileMetaData = async (filePath: string) => {
   const response = await s3Client
     .send(

--- a/lambda-code/reliability/src/lib/vaultProcessing.ts
+++ b/lambda-code/reliability/src/lib/vaultProcessing.ts
@@ -4,7 +4,7 @@ import {} from "./file_scanning.js";
 import { isFileValid } from "./fileValidation.js";
 import {
   copyFilesFromReliabilityToVaultStorage,
-  getFileMetaData,
+  getFileSize,
   getObjectFirst100BytesInReliabilityBucket,
   removeFilesFromReliabilityStorage,
 } from "./s3FileInput.js";
@@ -93,9 +93,7 @@ async function verifyAndFlagMaliciousSubmissionAttachments(
 ): Promise<SubmissionAttachmentInformation[]> {
   return Promise.all(
     submissionAttachmentsWithScanStatuses.map(async (item) => {
-      const fileSize = await getFileMetaData(item.attachmentPath).then((response) =>
-        Number(response.ContentLength ?? "0")
-      );
+      const fileSize = await getFileSize(item.attachmentPath);
 
       if (fileSize < 100) {
         // File size is too small to test and contains no content that can be of value to the end user


### PR DESCRIPTION
# Summary | Résumé
Flag any small files less than 100 Bytes that cannot be Mime Checked as potentially malicious.