### PR TITLE
fix: spelling of var to vars

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -47,7 +47,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
-  TF_VAR_zitadel_client_id: ${{var.STAGING_ZITADEL_CLIENT_ID}}
+  TF_VAR_zitadel_client_id: ${{vars.STAGING_ZITADEL_CLIENT_ID}}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}
   # IdP
   TF_VAR_idp_database_cluster_admin_username: ${{ secrets.STAGING_IDP_DATABASE_CLUSTER_ADMIN_USERNAME }}

--- a/.github/workflows/terragrunt-plan-all-staging.yml
+++ b/.github/workflows/terragrunt-plan-all-staging.yml
@@ -39,7 +39,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
-  TF_VAR_zitadel_client_id: ${{var.STAGING_ZITADEL_CLIENT_ID}}
+  TF_VAR_zitadel_client_id: ${{vars.STAGING_ZITADEL_CLIENT_ID}}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}
   # IdP
   TF_VAR_idp_database_cluster_admin_username: ${{ secrets.STAGING_IDP_DATABASE_CLUSTER_ADMIN_USERNAME }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -49,7 +49,7 @@ env:
   TF_VAR_email_address_support: ${{ vars.STAGING_SUPPORT_EMAIL }}
   TF_VAR_load_testing_zitadel_app_private_key: ${{ secrets.STAGING_ZITADEL_APPLICATION_KEY }}
   TF_VAR_zitadel_administration_key: ${{ secrets.STAGING_ZITADEL_ADMINISTRATION_KEY }}
-  TF_VAR_zitadel_client_id: ${{var.STAGING_ZITADEL_CLIENT_ID}}
+  TF_VAR_zitadel_client_id: ${{vars.STAGING_ZITADEL_CLIENT_ID}}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.STAGING_HCAPTCHA_SITE_VERIFY_KEY }}
   # IdP
   TF_VAR_idp_database_cluster_admin_username: ${{ secrets.STAGING_IDP_DATABASE_CLUSTER_ADMIN_USERNAME }}


### PR DESCRIPTION
# Summary | Résumé
fixes reference in github workflow files from "var" to "vars"