### PR TITLE
fix: ignore or on dynamic blocks until we have multiple domains

### DIFF
--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -220,7 +220,7 @@ variable "cognito_client_id" {
 
 variable "zitadel_client_id" {
   description = "Zitadel Client ID for GCforms"
-  type = string
+  type        = string
 }
 
 variable "cognito_endpoint_url" {

--- a/aws/idp/waf.tf
+++ b/aws/idp/waf.tf
@@ -82,29 +82,30 @@ resource "aws_wafv2_web_acl" "idp" {
 
     statement {
       not_statement {
-        statement {
-          or_statement {
-            dynamic "statement" {
-              for_each = local.idp_domains
-              content {
-                byte_match_statement {
-                  positional_constraint = "EXACTLY"
-                  field_to_match {
-                    single_header {
-                      name = "host"
-                    }
-                  }
-                  search_string = statement.value
-                  text_transformation {
-                    priority = 1
-                    type     = "COMPRESS_WHITE_SPACE"
-                  }
-                  text_transformation {
-                    priority = 1
-                    type     = "LOWERCASE"
-                  }
+        // statement {
+        // The OR statement is commented out until we have more then one domain to check against
+        // or_statement {
+        dynamic "statement" {
+          for_each = local.idp_domains
+          content {
+            byte_match_statement {
+              positional_constraint = "EXACTLY"
+              field_to_match {
+                single_header {
+                  name = "host"
                 }
               }
+              search_string = statement.value
+              text_transformation {
+                priority = 1
+                type     = "COMPRESS_WHITE_SPACE"
+              }
+              text_transformation {
+                priority = 1
+                type     = "LOWERCASE"
+              }
+              //        }
+              //        }
             }
           }
         }

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -28,27 +28,28 @@ resource "aws_wafv2_rule_group" "rate_limiters_group" {
         aggregate_key_type = "IP"
         scope_down_statement {
           not_statement {
-            statement {
-              or_statement {
-                dynamic "statement" {
-                  for_each = local.api_domains
-                  content {
-                    byte_match_statement {
-                      positional_constraint = "EXACTLY"
-                      field_to_match {
-                        single_header {
-                          name = "host"
-                        }
-                      }
-                      search_string = statement.value
-                      text_transformation {
-                        priority = 1
-                        type     = "LOWERCASE"
-                      }
+            // statement {
+            // The OR statement is commented out until we have more then one domain to check against
+            // or_statement {
+            dynamic "statement" {
+              for_each = local.api_domains
+              content {
+                byte_match_statement {
+                  positional_constraint = "EXACTLY"
+                  field_to_match {
+                    single_header {
+                      name = "host"
                     }
+                  }
+                  search_string = statement.value
+                  text_transformation {
+                    priority = 1
+                    type     = "LOWERCASE"
                   }
                 }
               }
+              //    }
+              //     }
             }
           }
         }
@@ -109,26 +110,27 @@ resource "aws_wafv2_web_acl" "forms_acl" {
 
     statement {
       and_statement {
-        statement {
-          or_statement {
-            dynamic "statement" {
-              for_each = local.api_domains
-              content {
-                byte_match_statement {
-                  positional_constraint = "EXACTLY"
-                  field_to_match {
-                    single_header {
-                      name = "host"
-                    }
-                  }
-                  search_string = statement.value
-                  text_transformation {
-                    priority = 1
-                    type     = "LOWERCASE"
-                  }
+        // statement {
+        // The OR statement is commented out until we have more then one domain to check against
+        // or_statement {
+        dynamic "statement" {
+          for_each = local.api_domains
+          content {
+            byte_match_statement {
+              positional_constraint = "EXACTLY"
+              field_to_match {
+                single_header {
+                  name = "host"
                 }
               }
+              search_string = statement.value
+              text_transformation {
+                priority = 1
+                type     = "LOWERCASE"
+              }
             }
+            //      }
+            //      }
           }
         }
         statement {
@@ -429,26 +431,27 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     */
     statement {
       and_statement {
-        statement {
-          or_statement {
-            dynamic "statement" {
-              for_each = local.api_domains
-              content {
-                byte_match_statement {
-                  positional_constraint = "EXACTLY"
-                  field_to_match {
-                    single_header {
-                      name = "host"
-                    }
-                  }
-                  search_string = statement.value
-                  text_transformation {
-                    priority = 1
-                    type     = "LOWERCASE"
-                  }
+        // statement {
+        // The OR statement is commented out until we have more then one domain to check against
+        // or_statement {
+        dynamic "statement" {
+          for_each = local.api_domains
+          content {
+            byte_match_statement {
+              positional_constraint = "EXACTLY"
+              field_to_match {
+                single_header {
+                  name = "host"
                 }
               }
+              search_string = statement.value
+              text_transformation {
+                priority = 1
+                type     = "LOWERCASE"
+              }
             }
+            //    }
+            //  }
           }
         }
         statement {


### PR DESCRIPTION
# Summary | Résumé

WAF rules were failing because an ignore block requires multiple statements but only one was being created because only one domain is currently in use.