### PR TITLE
fix: IDP cluster name reference

### DIFF
--- a/aws/idp/ecs_idp.tf
+++ b/aws/idp/ecs_idp.tf
@@ -49,7 +49,7 @@ module "idp_ecs" {
   source = "github.com/cds-snc/terraform-modules//ecs?ref=825c15a16d794bd878e0d11555c0abe6f481f29e" # v10.10.2
 
   create_cluster = false
-  cluster_name   = "idp"
+  cluster_name   = aws_ecs_cluster.idp.name
   service_name   = "zitadel"
   container_name = "zitadel"
   task_cpu       = 1024

--- a/aws/idp/ecs_login.tf
+++ b/aws/idp/ecs_login.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "user_portal" {
 resource "aws_ecs_service" "user_portal" {
   count                = var.env == "production" ? 0 : 1
   name                 = "user_portal"
-  cluster              = aws_ecs_cluster.idp.id
+  cluster              = aws_ecs_cluster.idp.name
   task_definition      = aws_ecs_task_definition.user_portal.arn
   launch_type          = "FARGATE"
   platform_version     = "1.4.0"


### PR DESCRIPTION
# Summary | Résumé
Was referencing wrong idp cluster name for Zitadel service after creation of new cluster.