### PR TITLE
fix: Allow internal IDP ECS traffic

### DIFF
--- a/aws/network/security_groups_idp.tf
+++ b/aws/network/security_groups_idp.tf
@@ -16,22 +16,22 @@ resource "aws_security_group_rule" "idp_ecs_egress_internet" {
 }
 
 resource "aws_security_group_rule" "idp_ecs_ingress_internal" {
-  description = "Ingress for internal cluster traffic"
-  type              = "ingress"
-  from_port         = 0
-  to_port           = 65535
-  protocol          = "tcp"
-  security_group_id = aws_security_group.idp_ecs.id
+  description              = "Ingress for internal cluster traffic"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.idp_ecs.id
   source_security_group_id = aws_security_group.idp_ecs.id
 }
 
 resource "aws_security_group_rule" "idp_ecs_egress_internal" {
-  description = "Ingress for internal cluster traffic"
-  type              = "egress"
-  from_port         = 0
-  to_port           = 65535
-  protocol          = "tcp"
-  security_group_id = aws_security_group.idp_ecs.id
+  description              = "Ingress for internal cluster traffic"
+  type                     = "egress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.idp_ecs.id
   source_security_group_id = aws_security_group.idp_ecs.id
 }
 


### PR DESCRIPTION
# Summary | Résumé
Allows tasks to communicate with each other in the same cluster