### PR TITLE
chore: fix emoji selection when processing CloudWatch alarm in order to send a message on Slack

### DIFF
--- a/lambda-code/notify-slack/src/main.ts
+++ b/lambda-code/notify-slack/src/main.ts
@@ -14,7 +14,7 @@ export const handler: Handler = async (event: any) => {
       await notifyGcFormsTeam({
         group: "Unknown Event",
         message: JSON.stringify(event, null, 2),
-        level: "info",
+        level: "warn",
         severity: "", // Not applicable here. Will disappear once we rework the `notify-slack` Lambda function
       });
     }
@@ -180,7 +180,7 @@ const handleSnsEventFromCloudWatchAlarm = async (message: string) => {
   await notifyGcFormsTeam({
     group: "CloudWatch Alarm Event",
     message,
-    level: "", // Not applicable here. Will disappear once we rework the `notify-slack` Lambda function
+    level: severity, // Assigning severity to level here will allow for the right Slack Emoji to be selected when a message is posted
     severity,
   });
 };

--- a/lambda-code/notify-slack/tests/notify-slack.test.ts
+++ b/lambda-code/notify-slack/tests/notify-slack.test.ts
@@ -166,7 +166,7 @@ describe("handler", () => {
     expect(sendToSlackMock).toHaveBeenCalledWith(
       "CloudWatch Alarm Event",
       'Alarm Status now OK - test "newstatevalue":"ok"',
-      ""
+      "alarm_reset"
     );
     expect(sendToOpsGenieMock).toBeCalledTimes(0);
   });


### PR DESCRIPTION
# Summary | Résumé

- Fixes an issue with Emoji selection when a message is posted on Slack after the `notify-slack` Lambda code processed a CloudWatch alarm event