### PR TITLE
chore: add new database connection URL secret and use it for the App module where Prisma is implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ All infratructure initialized: Ready for requests
 AWS_PROFILE=development
 DATABASE_URL=postgres://postgres:*********@forms-db-cluster.cluster-************.ca-central-1.rds.amazonaws.com:5432/forms?connect_timeout=60
 REDIS_URL=gcforms-redis-rep-group-001.******.0001.cac1.cache.amazonaws.com:6379
-RELIABILITY_FILE_STORAGE=forms-************-reliability-file-storage
 VAULT_FILE_STORAGE_BUCKET_NAME=forms-************-vault-file-storage
 ```
 

--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -84,7 +84,7 @@ module "gc_forms_code_pipeline" {
   }
 
   build_env_vars_from_secrets = [
-    { key = "DATABASE_URL", secretArn = var.database_url_secret_arn }, # This is required for the database migration script (post build commands)
+    { key = "DATABASE_URL", secretArn = var.database_connection_url_secret_arn }, # This is required for the database migration script (post build commands)
   ]
 
   docker_build_args = [

--- a/aws/app/ecs.tf
+++ b/aws/app/ecs.tf
@@ -28,7 +28,7 @@ locals {
     recaptcha_public                = var.recaptcha_public
     gc_notify_callback_bearer_token = var.notify_callback_bearer_token_secret_arn
     token_secret                    = var.token_secret_arn
-    database_url                    = var.database_url_secret_arn
+    database_url                    = var.database_connection_url_secret_arn
     redis_url                       = var.redis_url
     host_url                        = "https://${var.domains[0]}"
     reliability_file_storage        = var.reliability_file_storage_id

--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "forms_secrets_manager" {
     ]
 
     resources = [
-      var.database_url_secret_arn,
+      var.database_connection_url_secret_arn,
       var.recaptcha_secret_arn,
       var.notify_api_key_secret_arn,
       var.token_secret_arn,

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -8,8 +8,8 @@ variable "codedeploy_termination_wait_time_in_minutes" {
   type        = number
 }
 
-variable "database_url_secret_arn" {
-  description = "Database URL secret version ARN, used by the ECS task"
+variable "database_connection_url_secret_arn" {
+  description = "ARN of the database URL used to connect to Postgres"
   type        = string
 }
 

--- a/aws/lambdas/iam.tf
+++ b/aws/lambdas/iam.tf
@@ -186,7 +186,6 @@ data "aws_iam_policy_document" "lambda_secrets" {
     ]
 
     resources = [
-      var.database_secret_arn,
       var.notify_api_key_secret_arn,
       var.database_url_secret_arn,
     ]

--- a/aws/lambdas/inputs.tf
+++ b/aws/lambdas/inputs.tf
@@ -9,13 +9,8 @@ variable "gc_template_id" {
   type        = string
 }
 
-variable "database_secret_arn" {
-  description = "Database connection secret arn"
-  type        = string
-}
-
 variable "database_url_secret_arn" {
-  description = "Database URL secret version ARN, used by the ECS task"
+  description = "ARN of the database URL used to connect to Postgres. This is the legacy version that should be replaced by `database_connection_url_secret_arn` when possible."
   type        = string
 }
 

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -5,14 +5,14 @@ data "aws_subnet" "private" {
   id       = each.value
 }
 
-output "database_secret_arn" {
-  description = "value"
-  value       = aws_secretsmanager_secret_version.database_secret.arn
+output "database_url_secret_arn" {
+  description = "ARN of the database URL used to connect to Postgres. This is the legacy version that should be replaced by `database_connection_url_secret_arn` when possible."
+  value       = aws_secretsmanager_secret_version.database_url.arn
 }
 
-output "database_url_secret_arn" {
-  description = "value"
-  value       = aws_secretsmanager_secret_version.database_url.arn
+output "database_connection_url_secret_arn" {
+  description = "ARN of the database URL used to connect to Postgres"
+  value       = aws_secretsmanager_secret_version.database_connection_url.arn
 }
 
 output "rds_cluster_arn" {

--- a/aws/rds/secrets.tf
+++ b/aws/rds/secrets.tf
@@ -1,9 +1,12 @@
 #
 # Database secrets
 #
+
+# This secret is legacy and should be removed once `database_connection_url` has fully replaced it
 resource "aws_secretsmanager_secret" "database_url" {
   # checkov:skip=CKV2_AWS_57: Automatic secret rotation not required
   name                    = "server-database-url"
+  description             = "Database URL used to connect to Postgres. This secret can be removed once we have migrated all services to Prisma where `database_connection_url` should be used instead."
   recovery_window_in_days = 0
 }
 
@@ -12,16 +15,16 @@ resource "aws_secretsmanager_secret_version" "database_url" {
   secret_string = "postgres://${var.rds_db_user}:${var.rds_db_password}@${aws_rds_cluster.forms.endpoint}:5432/${var.rds_db_name}"
 }
 
-resource "aws_secretsmanager_secret" "database_secret" {
+resource "aws_secretsmanager_secret" "database_connection_url" {
   # checkov:skip=CKV2_AWS_57: Automatic secret rotation not required
-  name                    = "database-secret"
+  name                    = "database-connection-url"
+  description             = "Database URL used to connect to Postgres. It handles SSL connection (if available) with no certificate verification (default behavior for many drivers)."
   recovery_window_in_days = 0
 }
 
-resource "aws_secretsmanager_secret_version" "database_secret" {
-  depends_on    = [aws_rds_cluster.forms]
-  secret_id     = aws_secretsmanager_secret.database_secret.id
-  secret_string = "{\"dbInstanceIdentifier\": \"${var.rds_name}-cluster\",\"engine\": \"${aws_rds_cluster.forms.engine}\",\"host\": \"${aws_rds_cluster.forms.endpoint}\",\"port\": ${aws_rds_cluster.forms.port},\"resourceId\": \"${aws_rds_cluster.forms.cluster_resource_id}\",\"username\": \"${var.rds_db_user}\",\"password\": \"${var.rds_db_password}\"}"
+resource "aws_secretsmanager_secret_version" "database_connection_url" {
+  secret_id     = aws_secretsmanager_secret.database_connection_url.id
+  secret_string = "postgres://${var.rds_db_user}:${var.rds_db_password}@${aws_rds_cluster.forms.endpoint}:5432/${var.rds_db_name}?sslmode=prefer&uselibpqcompat=true"
 }
 
 resource "aws_secretsmanager_secret" "rds_connector" {

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -71,7 +71,7 @@ dependency "rds" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    database_url_secret_arn = null
+    database_connection_url_secret_arn = "database_connection_url_secret"
   }
 }
 
@@ -191,7 +191,7 @@ inputs = {
 
   redis_url = dependency.redis.outputs.redis_url
 
-  database_url_secret_arn = dependency.rds.outputs.database_url_secret_arn
+  database_connection_url_secret_arn = dependency.rds.outputs.database_connection_url_secret_arn
 
   sqs_reliability_reprocessing_queue_arn = dependency.sqs.outputs.sqs_reliability_reprocessing_queue_arn
   sqs_app_audit_log_queue_arn            = dependency.sqs.outputs.sqs_app_audit_log_queue_arn

--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -52,8 +52,7 @@ dependency "rds" {
   mock_outputs = {
     rds_cluster_arn         = null
     rds_db_name             = null
-    database_secret_arn     = null
-    database_url_secret_arn = null
+    database_url_secret_arn = "database_url_secret"
   }
 }
 
@@ -239,7 +238,6 @@ inputs = {
 
   rds_cluster_arn         = dependency.rds.outputs.rds_cluster_arn
   rds_db_name             = dependency.rds.outputs.rds_db_name
-  database_secret_arn     = dependency.rds.outputs.database_secret_arn
   database_url_secret_arn = dependency.rds.outputs.database_url_secret_arn
 
   redis_port = dependency.redis.outputs.redis_port

--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -101,8 +101,8 @@ fi
 t=$SECONDS
 printf "${greenColor}All infratructure initialized in %d minutes\nReady for requests${reset}\n" "$((t / 60 - 1440 * (t / 86400)))"
 
-DB_SECRET_ARN=$(aws secretsmanager list-secrets --filter Key="name",Values="server-database-url" --query "SecretList[0].ARN" --output text)
+DB_SECRET_ARN=$(aws secretsmanager list-secrets --filter Key="name",Values="database-connection-url" --query "SecretList[0].ARN" --output text)
 DATABASE_URL=$(aws secretsmanager get-secret-value --secret-id $DB_SECRET_ARN --query "SecretString" --output text)
 REDIS_URL=$(aws elasticache describe-cache-clusters --show-cache-node-info --query "CacheClusters[0].CacheNodes[0].Endpoint.Address" --output text)
 VAULT_FILE_STORAGE_BUCKET_NAME="forms-${AWS_ACCOUNT_ID}-vault-file-storage"
-printf "${greenColor}=> Please copy the following to your app .env file:${reset}\nAWS_PROFILE=${AWS_PROFILE}\nDATABASE_URL=${DATABASE_URL}?connect_timeout=30&pool_timeout=30\nREDIS_URL=${REDIS_URL}:6379\nVAULT_FILE_STORAGE_BUCKET_NAME=${VAULT_FILE_STORAGE_BUCKET_NAME}\n"
+printf "${greenColor}=> Please copy the following to your app .env file:${reset}\nAWS_PROFILE=${AWS_PROFILE}\nDATABASE_URL=${DATABASE_URL}&connect_timeout=30&pool_timeout=30\nREDIS_URL=${REDIS_URL}:6379\nVAULT_FILE_STORAGE_BUCKET_NAME=${VAULT_FILE_STORAGE_BUCKET_NAME}\n"

--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -104,6 +104,5 @@ printf "${greenColor}All infratructure initialized in %d minutes\nReady for requ
 DB_SECRET_ARN=$(aws secretsmanager list-secrets --filter Key="name",Values="server-database-url" --query "SecretList[0].ARN" --output text)
 DATABASE_URL=$(aws secretsmanager get-secret-value --secret-id $DB_SECRET_ARN --query "SecretString" --output text)
 REDIS_URL=$(aws elasticache describe-cache-clusters --show-cache-node-info --query "CacheClusters[0].CacheNodes[0].Endpoint.Address" --output text)
-RELIABILITY_FILE_STORAGE="forms-${AWS_ACCOUNT_ID}-reliability-file-storage"
 VAULT_FILE_STORAGE_BUCKET_NAME="forms-${AWS_ACCOUNT_ID}-vault-file-storage"
-printf "${greenColor}=> Please copy the following to your app .env file:${reset}\nAWS_PROFILE=${AWS_PROFILE}\nDATABASE_URL=${DATABASE_URL}?connect_timeout=30&pool_timeout=30\nREDIS_URL=${REDIS_URL}:6379\nRELIABILITY_FILE_STORAGE=${RELIABILITY_FILE_STORAGE}\nVAULT_FILE_STORAGE_BUCKET_NAME=${VAULT_FILE_STORAGE_BUCKET_NAME}\n"
+printf "${greenColor}=> Please copy the following to your app .env file:${reset}\nAWS_PROFILE=${AWS_PROFILE}\nDATABASE_URL=${DATABASE_URL}?connect_timeout=30&pool_timeout=30\nREDIS_URL=${REDIS_URL}:6379\nVAULT_FILE_STORAGE_BUCKET_NAME=${VAULT_FILE_STORAGE_BUCKET_NAME}\n"


### PR DESCRIPTION
# Summary | Résumé

Context: this is part of the work we are doing for the [Prisma package isolation](https://github.com/cds-snc/platform-forms-client/issues/6731)

- Removes unused environment variable from `build_dev_env.sh` output
- Adds new `database-connection-url` secret that provides a connection URL compatible with both Prisma 6 and 7
- Replaces legacy `server-database-url` with new `database-connection-url` secret in the GC Forms App ECS task definition
- Deletes unused `database-secret` secret

Note: the legacy `server-database-url` secret can be deleted once we have migrated all of our services (Lambdas + API) to the new Prisma package