### PR TITLE
chore: update AWS CodeBuild to leverage new GC Forms database (Prisma) package

### DIFF
--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -34,10 +34,10 @@ module "gc_forms_code_pipeline" {
     { key = "ZITADEL_PROJECT_ID", value = var.zitadel_project_id }
   ]
 
+  # Run database migration process
   custom_post_build_commands = [
-    "yarn install",
-    "yarn prisma:generate",
-    "yarn prisma:deploy",
+    "yarn workspaces focus @gcforms/database",
+    "yarn db:prod"
   ]
 
   depends_on = [aws_ecs_service.form_viewer, aws_ecs_cluster.forms, aws_ecs_task_definition.form_viewer]


### PR DESCRIPTION
# Summary | Résumé

Context: https://github.com/cds-snc/platform-forms-client/issues/6731

- Updates GC Forms web app AWS CodeBuild step to run database migration through the new `@gcforms/database` package