### PR TITLE
chore: enable AWS CodePipeline in production for the GC Forms web app

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -40,6 +40,8 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.PRODUCTION_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
   TF_VAR_zitadel_administration_key: ${{ secrets.PRODUCTION_ZITADEL_ADMINISTRATION_KEY }}
+  TF_VAR_zitadel_project_id: ${{ vars.PRODUCTION_ZITADEL_PROJECT_ID }}
+  TF_VAR_hcaptcha_site_key: ${{ vars.PRODUCTION_HCAPTCHA_SITE_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.PRODUCTION_HCAPTCHA_SITE_VERIFY_KEY }}
   TF_VAR_security_txt_content: ${{ vars.SECURITY_TXT_ALPHA_CANADA_CA }}
   # IdP
@@ -116,7 +118,8 @@ jobs:
         run: terragrunt run --non-interactive -- apply -auto-approve
 
   build-tag-push-lambda-images:
-    needs: [get-version, generate-lambda-functions-matrix, terragrunt-apply-ecr-only]
+    needs:
+      [get-version, generate-lambda-functions-matrix, terragrunt-apply-ecr-only]
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.get-version.outputs.version }}
@@ -281,7 +284,12 @@ jobs:
         run: terragrunt run --non-interactive -- apply -auto-approve
 
   update-lambda-function-image:
-    needs: [get-version, generate-lambda-functions-matrix, terragrunt-apply-all-modules]
+    needs:
+      [
+        get-version,
+        generate-lambda-functions-matrix,
+        terragrunt-apply-all-modules,
+      ]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -42,6 +42,8 @@ env:
   TF_VAR_email_address_contact_us: ${{ vars.PRODUCTION_CONTACT_US_EMAIL }}
   TF_VAR_email_address_support: ${{ vars.PRODUCTION_SUPPORT_EMAIL }}
   TF_VAR_zitadel_administration_key: ${{ secrets.PRODUCTION_ZITADEL_ADMINISTRATION_KEY }}
+  TF_VAR_zitadel_project_id: ${{ vars.PRODUCTION_ZITADEL_PROJECT_ID }}
+  TF_VAR_hcaptcha_site_key: ${{ vars.PRODUCTION_HCAPTCHA_SITE_KEY }}
   TF_VAR_hcaptcha_site_verify_key: ${{ secrets.PRODUCTION_HCAPTCHA_SITE_VERIFY_KEY }}
   TF_VAR_security_txt_content: ${{ vars.SECURITY_TXT_ALPHA_CANADA_CA }}
   # IdP

--- a/aws/alarms/cloudwatch_app.tf
+++ b/aws/alarms/cloudwatch_app.tf
@@ -205,40 +205,6 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_route53_warn" {
 }
 
 #
-# Code Deploy events
-# We can delete the following resources once we stop using Github actions to deploy our applications (migrate to the new code_pipeline module)
-#
-resource "aws_cloudwatch_event_target" "codedeploy_sns" {
-  target_id = "CodeDeploy_SNS"
-  rule      = aws_cloudwatch_event_rule.codedeploy_sns.name
-  arn       = var.sns_topic_alert_warning_arn
-
-  input_transformer {
-    input_paths = {
-      "status"       = "$.detail.state"
-      "deploymentID" = "$.detail.deploymentId"
-    }
-    input_template = "\"End User Forms - CloudDeploy has registered a <status> for deployment: <deploymentID>\""
-  }
-}
-
-resource "aws_cloudwatch_event_rule" "codedeploy_sns" {
-  name        = "alert-on-codedeploy-status"
-  description = "Alert if CodeDeploy succeeds or fails during deployment"
-  event_pattern = jsonencode({
-    source      = ["aws.codedeploy"],
-    detail-type = ["CodeDeploy Deployment State-change Notification"],
-    detail = {
-      state = [
-        "START",
-        "SUCCESS",
-        "FAILURE"
-      ]
-    }
-  })
-}
-
-#
 # Code Pipeline events
 #
 

--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -5,7 +5,6 @@ module "gc_forms_code_pipeline" {
   private_subnet_ids             = var.private_subnet_ids
   app_name                       = "gc-forms-web-app"
   github_repo_name               = "cds-snc/platform-forms-client"
-  app_ecr_name                   = var.ecr_form_viewer_repository_name
   app_ecr_url                    = var.ecr_repository_url_form_viewer
   ecs_cluster_name               = aws_ecs_cluster.forms.name
   ecs_service_name               = aws_ecs_service.form_viewer.name

--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -42,3 +42,70 @@ module "gc_forms_code_pipeline" {
 
   depends_on = [aws_ecs_service.form_viewer, aws_ecs_cluster.forms, aws_ecs_task_definition.form_viewer]
 }
+
+# Following moved blocks can be removed once https://github.com/cds-snc/forms-terraform/pull/1295 has been merged
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_codebuild_project.ecs_render
+  to   = module.gc_forms_code_pipeline.aws_codebuild_project.ecs_render
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_codedeploy_app.this
+  to   = module.gc_forms_code_pipeline.aws_codedeploy_app.this
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_codedeploy_deployment_group.this
+  to   = module.gc_forms_code_pipeline.aws_codedeploy_deployment_group.this
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_codepipeline.this
+  to   = module.gc_forms_code_pipeline.aws_codepipeline.this
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_codestarconnections_connection.this
+  to   = module.gc_forms_code_pipeline.aws_codestarconnections_connection.this
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_iam_role.this
+  to   = module.gc_forms_code_pipeline.aws_iam_role.this
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_iam_role_policy.codepipeline_policy
+  to   = module.gc_forms_code_pipeline.aws_iam_role_policy.codepipeline_policy
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_iam_role_policy_attachment.AWSCodeDeployRole
+  to   = module.gc_forms_code_pipeline.aws_iam_role_policy_attachment.AWSCodeDeployRole
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_iam_role_policy_attachment.AWSCodeDeployRoleForECS
+  to   = module.gc_forms_code_pipeline.aws_iam_role_policy_attachment.AWSCodeDeployRoleForECS
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_s3_bucket.codepipeline_bucket
+  to   = module.gc_forms_code_pipeline.aws_s3_bucket.codepipeline_bucket
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_s3_bucket_ownership_controls.codepipeline_bucket
+  to   = module.gc_forms_code_pipeline.aws_s3_bucket_ownership_controls.codepipeline_bucket
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_s3_bucket_public_access_block.codepipeline_bucket
+  to   = module.gc_forms_code_pipeline.aws_s3_bucket_public_access_block.codepipeline_bucket
+}
+
+moved {
+  from = module.gc_forms_code_pipeline[0].aws_s3_bucket_server_side_encryption_configuration.codepipeline_bucket
+  to   = module.gc_forms_code_pipeline.aws_s3_bucket_server_side_encryption_configuration.codepipeline_bucket
+}

--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -1,67 +1,4 @@
-#
-# Only use Blue/Gree deployment with CodeDeploy in Production while we test the new full deployment pipeline in Staging using our code_pipeline module.
-#
-resource "aws_codedeploy_app" "app" {
-  count = var.env == "production" ? 1 : 0
-
-  compute_platform = "ECS"
-  name             = "AppECS-${aws_ecs_cluster.forms.name}-${aws_ecs_service.form_viewer.name}"
-}
-
-resource "aws_codedeploy_deployment_group" "app" {
-  count = var.env == "production" ? 1 : 0
-
-  app_name               = aws_codedeploy_app.app[0].name
-  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
-  deployment_group_name  = "DgpECS-${aws_ecs_cluster.forms.name}-${aws_ecs_service.form_viewer.name}"
-  service_role_arn       = aws_iam_role.codedeploy.arn
-
-  auto_rollback_configuration {
-    enabled = true
-    events  = ["DEPLOYMENT_FAILURE"]
-  }
-
-  blue_green_deployment_config {
-    deployment_ready_option {
-      action_on_timeout = var.codedeploy_manual_deploy_enabled ? "STOP_DEPLOYMENT" : "CONTINUE_DEPLOYMENT"
-    }
-
-    terminate_blue_instances_on_deployment_success {
-      action                           = "TERMINATE"
-      termination_wait_time_in_minutes = var.codedeploy_termination_wait_time_in_minutes
-    }
-  }
-
-  deployment_style {
-    deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type   = "BLUE_GREEN"
-  }
-
-  ecs_service {
-    cluster_name = aws_ecs_cluster.forms.name
-    service_name = aws_ecs_service.form_viewer.name
-  }
-
-  load_balancer_info {
-    target_group_pair_info {
-      prod_traffic_route {
-        listener_arns = [var.lb_https_listener_arn]
-      }
-
-      target_group {
-        name = var.lb_target_group_1_name
-      }
-
-      target_group {
-        name = var.lb_target_group_2_name
-      }
-    }
-  }
-}
-
 module "gc_forms_code_pipeline" {
-  count = var.env == "production" ? 0 : 1
-
   source                         = "../modules/code_pipeline"
   vpc_id                         = var.vpc_id
   code_build_security_group_id   = var.code_build_security_group_id
@@ -84,7 +21,7 @@ module "gc_forms_code_pipeline" {
   }
 
   build_env_vars_from_secrets = [
-    { key = "DATABASE_URL", secretArn = var.database_connection_url_secret_arn }, # This is required for the database migration script (post build commands)
+    { key = "DATABASE_URL", secretArn = var.database_connection_url_secret_arn }, # This is required by the @gcforms/database package to run database migrations
   ]
 
   docker_build_args = [
@@ -92,7 +29,7 @@ module "gc_forms_code_pipeline" {
     { key = "COGNITO_APP_CLIENT_ID", value = var.cognito_client_id },
     { key = "COGNITO_USER_POOL_ID", value = var.cognito_user_pool_id },
     { key = "HCAPTCHA_SITE_KEY", value = var.hcaptcha_site_key },
-    { key = "NEXT_DEPLOYMENT_ID", value = var.env == "production" ? "$GIT_TAG" : "$GIT_COMMIT_ID" },
+    { key = "NEXT_DEPLOYMENT_ID", value = "$NEXT_DEPLOYMENT_ID" }, # $NEXT_DEPLOYMENT_ID is declared in the actual CodePipeline module definition (see aws/modules/code_pipeline/codebuild.tf)
     { key = "ZITADEL_URL", value = "https://auth.${var.domains[0]}" },
     { key = "ZITADEL_PROJECT_ID", value = var.zitadel_project_id }
   ]

--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -1,4 +1,5 @@
 module "gc_forms_code_pipeline" {
+  region                         = var.region
   source                         = "../modules/code_pipeline"
   vpc_id                         = var.vpc_id
   code_build_security_group_id   = var.code_build_security_group_id

--- a/aws/app/inputs.tf
+++ b/aws/app/inputs.tf
@@ -43,11 +43,6 @@ variable "ecs_form_viewer_name" {
   type        = string
 }
 
-variable "ecr_form_viewer_repository_name" {
-  description = "ECR repository name for the form viewer ECS task's Docker image"
-  type        = string
-}
-
 variable "ecr_repository_url_form_viewer" {
   description = "ECR repository URL for the ECS task's Docker image"
   type        = string

--- a/aws/ecr/outputs.tf
+++ b/aws/ecr/outputs.tf
@@ -1,8 +1,3 @@
-output "ecr_form_viewer_repository_name" {
-  description = "Name of the Form viewer ECR repository"
-  value       = aws_ecr_repository.viewer_repository.name
-}
-
 output "ecr_repository_url_form_viewer" {
   description = "URL of the Form viewer ECR repository"
   value       = aws_ecr_repository.viewer_repository.repository_url

--- a/aws/idp/code_pipeline.tf
+++ b/aws/idp/code_pipeline.tf
@@ -6,7 +6,6 @@ module "user_portal_code_pipeline" {
   private_subnet_ids             = var.private_subnet_ids
   app_name                       = "idp-user-portal"
   github_repo_name               = "cds-snc/platform-unified-accounts-user-portal"
-  app_ecr_name                   = "idp/user_portal"
   app_ecr_url                    = var.idp_login_ecr_url
   ecs_cluster_name               = aws_ecs_cluster.idp.name
   ecs_service_name               = aws_ecs_service.user_portal[0].name

--- a/aws/idp/code_pipeline.tf
+++ b/aws/idp/code_pipeline.tf
@@ -1,5 +1,6 @@
 module "user_portal_code_pipeline" {
   count                          = var.env == "production" ? 0 : 1
+  region                         = var.region
   source                         = "../modules/code_pipeline"
   vpc_id                         = var.vpc_id
   code_build_security_group_id   = var.code_build_security_group_id

--- a/aws/modules/code_pipeline/codebuild.tf
+++ b/aws/modules/code_pipeline/codebuild.tf
@@ -54,7 +54,7 @@ locals {
     "export GIT_TAG=$(git tag --points-at $GIT_COMMIT_ID | head -n 1)", # Check if a GIT_TAG exist. This would mean that CodePipeline was triggered by a Production release
     "export RELEASE_IDENTIFIER=$${GIT_TAG:-$GIT_COMMIT_ID}",            # Create RELEASE_IDENTIFIER which will be used by the rest of the deployment pipeline to either reference a Git tag (production) or commit identifier (staging)
     "export NEXT_DEPLOYMENT_ID=$${RELEASE_IDENTIFIER//./-}",            # This is used in aws/app/code_pipeline.tf. We should be able to delete it once we get rid of Rainbow deployments (context: https://github.com/cds-snc/platform-forms-client/pull/6908)
-    "aws ecr get-login-password --region ca-central-1 | docker login --username AWS --password-stdin ${var.app_ecr_url}",
+    "aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${var.app_ecr_url}",
     "docker build -t base ${local.docker_build_args} .",
     "docker tag base ${var.app_ecr_url}:latest && docker push ${var.app_ecr_url}:latest",
     "docker tag base ${var.app_ecr_url}:$RELEASE_IDENTIFIER && docker push ${var.app_ecr_url}:$RELEASE_IDENTIFIER"

--- a/aws/modules/code_pipeline/codebuild.tf
+++ b/aws/modules/code_pipeline/codebuild.tf
@@ -51,19 +51,18 @@ locals {
   docker_build_args = join(" ", [for instance in var.docker_build_args : "--build-arg ${instance.key}=${instance.value}"])
 
   base_build_commands = [
-    "export GIT_TAG=$(git tag --points-at $GIT_COMMIT_ID)",
+    "export GIT_TAG=$(git tag --points-at $GIT_COMMIT_ID | head -n 1)", # Check if a GIT_TAG exist. This would mean that CodePipeline was triggered by a Production release
+    "export RELEASE_IDENTIFIER=$${GIT_TAG:-$GIT_COMMIT_ID}",            # Create RELEASE_IDENTIFIER which will be used by the rest of the deployment pipeline to either reference a Git tag (production) or commit identifier (staging)
+    "export NEXT_DEPLOYMENT_ID=$${RELEASE_IDENTIFIER//./-}",            # This is used in aws/app/code_pipeline.tf. We should be able to delete it once we get rid of Rainbow deployments (context: https://github.com/cds-snc/platform-forms-client/pull/6908)
     "aws ecr get-login-password --region ca-central-1 | docker login --username AWS --password-stdin ${var.app_ecr_url}",
     "docker build -t base ${local.docker_build_args} .",
-    "docker tag base ${var.app_ecr_url}:latest",
-    "docker push ${var.app_ecr_url}:latest",
-    "docker tag base ${var.app_ecr_url}:$GIT_COMMIT_ID",
-    "docker push ${var.app_ecr_url}:$GIT_COMMIT_ID",
-    "if [[ -n \"$GIT_TAG\" ]]; then docker tag base ${var.app_ecr_url}:$GIT_TAG && docker push ${var.app_ecr_url}:$GIT_TAG; fi"
+    "docker tag base ${var.app_ecr_url}:latest && docker push ${var.app_ecr_url}:latest",
+    "docker tag base ${var.app_ecr_url}:$RELEASE_IDENTIFIER && docker push ${var.app_ecr_url}:$RELEASE_IDENTIFIER"
   ]
 
   base_post_build_commands = [
     "printf \"$APPSPEC\" > appspec.yaml",
-    "aws ecs describe-task-definition --task-definition ${var.task_definition_family} --query taskDefinition | jq --arg gitCommit \"$GIT_COMMIT_ID\" '.taskDefinitionArn |= \"${data.aws_ecs_task_definition.this.arn_without_revision}\" | .containerDefinitions |= map(select(.name == \"${var.app_container_name}\").image |= \"${var.app_ecr_url}:\" + $gitCommit)' > task_definition.json"
+    "aws ecs describe-task-definition --task-definition ${var.task_definition_family} --query taskDefinition | jq --arg releaseIdentifier \"$RELEASE_IDENTIFIER\" '.taskDefinitionArn |= \"${data.aws_ecs_task_definition.this.arn_without_revision}\" | .containerDefinitions |= map(select(.name == \"${var.app_container_name}\").image |= \"${var.app_ecr_url}:\" + $releaseIdentifier)' > task_definition.json"
   ]
 
   post_build_commands = concat(local.base_post_build_commands, var.custom_post_build_commands)

--- a/aws/modules/code_pipeline/inputs.tf
+++ b/aws/modules/code_pipeline/inputs.tf
@@ -24,11 +24,6 @@ variable "github_repo_name" {
   type        = string
 }
 
-variable "app_ecr_name" {
-  description = "ECR repository name for the app"
-  type        = string
-}
-
 variable "app_ecr_url" {
   description = "ECR repository url for the app"
   type        = string

--- a/aws/modules/code_pipeline/inputs.tf
+++ b/aws/modules/code_pipeline/inputs.tf
@@ -1,3 +1,7 @@
+variable "region" {
+  description = "The current AWS region"
+  type        = string
+}
 
 variable "private_subnet_ids" {
   description = "The list of private subnet IDs used by the RDS cluster to"

--- a/aws/modules/code_pipeline/s3.tf
+++ b/aws/modules/code_pipeline/s3.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "codepipeline_bucket" {
   # checkov:skip=CKV_AWS_21: Versioning not required
   # checkov:skip=CKV2_AWS_62: Event notifications not required
   # checkov:skip=CKV2_AWS_61: Lifecycle configuration not required
-  bucket        = "${var.app_name}-pipeline"
+  bucket        = "${var.app_name}-${local.account_id}-pipeline"
   force_destroy = true
 }
 

--- a/aws/oidc_roles/iam_policies.tf
+++ b/aws/oidc_roles/iam_policies.tf
@@ -121,13 +121,6 @@ resource "aws_iam_policy" "forms_api_release" {
   policy = data.aws_iam_policy_document.ecr_push_image[0].json
 }
 
-resource "aws_iam_policy" "platform_forms_client_release" {
-  count  = var.env == "production" ? 1 : 0
-  name   = local.platform_forms_client_release
-  path   = "/"
-  policy = data.aws_iam_policy_document.ecr_push_image[0].json
-}
-
 data "aws_iam_policy_document" "ecr_push_image" {
   count = var.env == "production" ? 1 : 0
 

--- a/aws/oidc_roles/iam_roles.tf
+++ b/aws/oidc_roles/iam_roles.tf
@@ -1,7 +1,6 @@
 locals {
   forms_api_release                   = "forms-api-release"
   platform_forms_client_pr_review_env = "platform-forms-client-pr-review-env"
-  platform_forms_client_release       = "platform-forms-client-release"
 }
 
 # 
@@ -32,11 +31,6 @@ module "github_workflow_roles" {
       name      = local.platform_forms_client_pr_review_env
       repo_name = "platform-forms-client"
       claim     = "pull_request"
-    },
-    {
-      name      = local.platform_forms_client_release
-      repo_name = "platform-forms-client"
-      claim     = "ref:refs/tags/v*"
     }
   ]
 
@@ -60,14 +54,6 @@ resource "aws_iam_role_policy_attachment" "platform_forms_client_pr_review_env" 
   count      = var.env == "staging" ? 1 : 0
   role       = local.platform_forms_client_pr_review_env
   policy_arn = aws_iam_policy.platform_forms_client_pr_review_env[0].arn
-
-  depends_on = [module.github_workflow_roles]
-}
-
-resource "aws_iam_role_policy_attachment" "platform_forms_client_release" {
-  count      = var.env == "production" ? 1 : 0
-  role       = local.platform_forms_client_release
-  policy_arn = aws_iam_policy.platform_forms_client_release[0].arn
 
   depends_on = [module.github_workflow_roles]
 }

--- a/env/cloud/app/terragrunt.hcl
+++ b/env/cloud/app/terragrunt.hcl
@@ -25,7 +25,6 @@ dependency "ecr" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    ecr_form_viewer_repository_name = "form_viewer_development"
     ecr_repository_url_form_viewer  = "${local.aws_account_id}.dkr.ecr.ca-central-1.amazonaws.com/form_viewer_development"
   }
 }
@@ -171,7 +170,6 @@ inputs = {
   dynamodb_app_audit_logs_arn    = dependency.dynamodb.outputs.dynamodb_app_audit_logs_arn
   dynamodb_api_audit_logs_arn    = dependency.dynamodb.outputs.dynamodb_api_audit_logs_arn
 
-  ecr_form_viewer_repository_name = dependency.ecr.outputs.ecr_form_viewer_repository_name
   ecr_repository_url_form_viewer  = dependency.ecr.outputs.ecr_repository_url_form_viewer
 
   kms_key_cloudwatch_arn = dependency.kms.outputs.kms_key_cloudwatch_arn


### PR DESCRIPTION
# Summary | Résumé

- Adds the AWS account ID back to the AWS CodePipeline S3 bucket name to avoid naming conflicts (since S3 bucket names are globally unique)
- Enables AWS CodePipeline in our Production environment
- Removes the old AWS CodeDeploy code that was used by Github actions to handle release process
- Removes unused `app_ecr_name` input from `code_pipeline` module