### PR TITLE
fix: Add vpc gateway endpoints to public routes

### DIFF
--- a/aws/network/development_env/network.tf
+++ b/aws/network/development_env/network.tf
@@ -11,6 +11,8 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "forms" {
+  # checkov:skip=CKV2_AWS_12: False positive.  The default security group is modified in `security_groups_app.tf`
+  # checkov:skip=CKV2_AWS_11: This is a development environment, no need to VPC flow logging
   cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = true
 

--- a/aws/network/development_env/network.tf
+++ b/aws/network/development_env/network.tf
@@ -1,15 +1,16 @@
 #
 # VPC:
 # Defines the network and subnets for the Forms service
-# Provides no internet access
 #
+locals {
+  subnetCount = 2
+}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }
 
 resource "aws_vpc" "forms" {
-  # checkov:skip=CKV2_AWS_12: False positive.  The default security group is modified in `security_groups_app.tf`
-  # checkov:skip=CKV2_AWS_11: This is a development environment, no need to VPC flow logging
   cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = true
 
@@ -18,13 +19,13 @@ resource "aws_vpc" "forms" {
   }
 }
 
-
 #
 # Subnets:
-# 3 private subnets
+# public, private subnets
 #
+
 resource "aws_subnet" "forms_private" {
-  count = 3
+  count = local.subnetCount
 
   vpc_id            = aws_vpc.forms.id
   cidr_block        = cidrsubnet(var.vpc_cidr_block, 4, count.index)
@@ -36,12 +37,11 @@ resource "aws_subnet" "forms_private" {
   }
 }
 
-# We need to create the resource as a dummy output
 resource "aws_subnet" "forms_public" {
-  count = 0
+  count = local.subnetCount
 
   vpc_id            = aws_vpc.forms.id
-  cidr_block        = cidrsubnet(var.vpc_cidr_block, 4, count.index + 3)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 4, count.index + local.subnetCount)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -49,7 +49,6 @@ resource "aws_subnet" "forms_public" {
     Access = "public"
   }
 }
-
 data "aws_subnets" "ecr_endpoint_available" {
   filter {
     name   = "vpc-id"
@@ -81,6 +80,9 @@ data "aws_subnets" "lambda_endpoint_available" {
   }
   depends_on = [aws_subnet.forms_private]
 }
+#
+# Local DNS Namespace
+#
 
 resource "aws_service_discovery_private_dns_namespace" "ecs_local" {
   name        = "ecs.local"

--- a/aws/network/firewall.tf
+++ b/aws/network/firewall.tf
@@ -7,11 +7,12 @@ locals {
 resource "aws_networkfirewall_firewall" "forms" {
   #checkov:skip=CKV_AWS_345: AWS Managed Key is enough encryption for this use case
 
-  name                = "GCForms"
-  description         = "Firewall limiting outbound traffic.  WAF handles inbound"
-  delete_protection   = true
-  vpc_id              = aws_vpc.forms.id
-  firewall_policy_arn = aws_networkfirewall_firewall_policy.forms.arn
+  name                   = "GCForms"
+  description            = "Firewall limiting outbound traffic.  WAF handles inbound"
+  delete_protection      = true
+  vpc_id                 = aws_vpc.forms.id
+  firewall_policy_arn    = aws_networkfirewall_firewall_policy.forms.arn
+  enabled_analysis_types = ["HTTP_HOST", "TLS_SNI"]
   dynamic "subnet_mapping" {
     for_each = aws_subnet.firewall.*.id
     content {
@@ -43,7 +44,7 @@ resource "aws_networkfirewall_firewall_policy" "forms" {
     }
 
     stateful_rule_group_reference {
-      priority = 1
+      priority     = 1
       resource_arn = aws_networkfirewall_rule_group.suricata_rules.arn
     }
 
@@ -56,16 +57,16 @@ resource "aws_networkfirewall_rule_group" "suricata_rules" {
   name        = "GCForms"
   description = "Only allow web traffic and deny everything else"
   type        = "STATEFUL"
-rule_group {
-  stateful_rule_options {
-    rule_order = "STRICT_ORDER"
+  rule_group {
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+    rules_source {
+      rules_string = file("./firewall_rules/suricata.rules")
+    }
   }
-  rules_source {
-    rules_string = file("./firewall_rules/suricata.rules")
-  }
-}
 
- 
+
 
 }
 

--- a/aws/network/vpc_endpoints.tf
+++ b/aws/network/vpc_endpoints.tf
@@ -158,7 +158,7 @@ resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id            = aws_vpc.forms.id
   vpc_endpoint_type = "Gateway"
   service_name      = "com.amazonaws.${var.region}.dynamodb"
-  route_table_ids   = [aws_vpc.forms.main_route_table_id]
+  route_table_ids   = aws_route_table.forms_public_subnet.*.id
 
 
 }
@@ -167,5 +167,5 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id            = aws_vpc.forms.id
   vpc_endpoint_type = "Gateway"
   service_name      = "com.amazonaws.${var.region}.s3"
-  route_table_ids   = [aws_vpc.forms.main_route_table_id]
+  route_table_ids   = aws_route_table.forms_public_subnet.*.id
 }


### PR DESCRIPTION
# Summary | Résumé
Adds the routing to the VPC Endpoint gateways for S3 and DynamoDB in the public subnet route table. They were previously in the "main" routing table which is no longer referenced by the private and public subnets.