### PR TITLE
chore: add ssm vpc endpoint

### DIFF
--- a/aws/network/vpc_endpoints.tf
+++ b/aws/network/vpc_endpoints.tf
@@ -153,6 +153,17 @@ resource "aws_vpc_endpoint" "xray" {
   subnet_ids = aws_subnet.forms_private.*.id
 }
 
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.forms.id
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.${var.region}.ssm"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+  subnet_ids = aws_subnet.forms_private.*.id
+}
+
 
 resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id            = aws_vpc.forms.id


### PR DESCRIPTION
# Summary | Résumé
Adds an SSM vpc endpoint to ensure the traffic stays within the VPC.  With the new firewall we have seen that the ECS traffic is calling out over the internet.