### PR TITLE
addes codestart endpoint

### DIFF
--- a/aws/network/vpc_endpoints.tf
+++ b/aws/network/vpc_endpoints.tf
@@ -164,6 +164,17 @@ resource "aws_vpc_endpoint" "ssm" {
   subnet_ids = aws_subnet.forms_private.*.id
 }
 
+resource "aws_vpc_endpoint" "codestar" {
+  vpc_id              = aws_vpc.forms.id
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.${var.region}.codestar-connections.api"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+  subnet_ids = aws_subnet.forms_private.*.id
+}
+
 
 resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id            = aws_vpc.forms.id


### PR DESCRIPTION
# Summary | Résumé
Adds a codestar connection vpc endpoint so that traffic does not need to traverse the firewall onto the internet.
<img width="490" height="480" alt="Screenshot 2026-04-21 at 9 13 18 AM" src="https://github.com/user-attachments/assets/1dccf953-ab2a-40ec-abaa-a834bc7f8dd1" />
