### PR TITLE
add ecs endpoint

### DIFF
--- a/aws/network/vpc_endpoints.tf
+++ b/aws/network/vpc_endpoints.tf
@@ -175,6 +175,16 @@ resource "aws_vpc_endpoint" "codestar" {
   subnet_ids = aws_subnet.forms_private.*.id
 }
 
+resource "aws_vpc_endpoint" "ecs" {
+  vpc_id              = aws_vpc.forms.id
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.${var.region}.ecs"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+  subnet_ids = aws_subnet.forms_private.*.id
+}
 
 resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id            = aws_vpc.forms.id


### PR DESCRIPTION
# Summary | Résumé
creates and ECS endpoint to ensure that traffic destined for the ECS controller remains within the VPC and does not traverse the firewall.
<img width="396" height="451" alt="Screenshot 2026-04-21 at 9 25 12 AM" src="https://github.com/user-attachments/assets/052c8032-d3f5-40af-b33f-ab7cb1513654" />
