### PR TITLE
chore: add new database connection URL as env var for the API service

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -30,6 +30,10 @@ locals {
     {
       name      = "FRESHDESK_API_KEY"
       valueFrom = var.freshdesk_api_key_secret_arn
+    },
+    {
+      name      = "DATABASE_URL"
+      valueFrom = var.database_connection_url_secret_arn
     }
   ]
 }
@@ -169,7 +173,8 @@ data "aws_iam_policy_document" "api_ecs_secrets_manager" {
 
     resources = [
       var.zitadel_application_key_secret_arn,
-      var.freshdesk_api_key_secret_arn
+      var.freshdesk_api_key_secret_arn,
+      var.database_connection_url_secret_arn
     ]
   }
 }

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -75,6 +75,12 @@ variable "rds_connection_url_secret_arn" {
   type        = string
   sensitive   = true
 }
+
+variable "database_connection_url_secret_arn" {
+  description = "ARN of the database URL used to connect to Postgres"
+  type        = string
+}
+
 variable "sqs_api_audit_log_queue_arn" {
   description = "SQS audit log queue ARN"
   type        = string

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -101,7 +101,8 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    database_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:${local.aws_account_id}:secret:database_url"
+    database_url_secret_arn            = "arn:aws:secretsmanager:ca-central-1:${local.aws_account_id}:secret:database_url"
+    database_connection_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:${local.aws_account_id}:secret:database-connection-url"
   }
 }
 
@@ -153,7 +154,8 @@ inputs = {
 
   freshdesk_api_key_secret_arn = dependency.secrets.outputs.freshdesk_api_key_secret_arn
 
-  rds_connection_url_secret_arn = dependency.rds.outputs.database_url_secret_arn
+  rds_connection_url_secret_arn      = dependency.rds.outputs.database_url_secret_arn
+  database_connection_url_secret_arn = dependency.rds.outputs.database_connection_url_secret_arn
 
   sqs_api_audit_log_queue_arn = dependency.sqs.outputs.sqs_api_audit_log_queue_arn
 


### PR DESCRIPTION
# Summary | Résumé

Context: https://github.com/cds-snc/platform-forms-client/issues/6731

- Adds new database connection URL as env var for the API service (in order to integrate Prisma into the API code)

Note: I kept the permission for the API ECS task to access the previous secret so that we can release the infra with no impact on the API. Will remove in https://github.com/cds-snc/forms-terraform/pull/1312