### PR TITLE
chore: delete legacy server-database-url secret

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -70,7 +70,6 @@ module "api_ecs" {
     data.aws_iam_policy_document.api_ecs_kms_vault.json,
     data.aws_iam_policy_document.api_ecs_dynamodb_vault.json,
     data.aws_iam_policy_document.api_ecs_s3_vault.json,
-    data.aws_iam_policy_document.api_ecs_secrets_manager_runtime.json,
     data.aws_iam_policy_document.api_sqs.json
   ]
 
@@ -145,20 +144,6 @@ data "aws_iam_policy_document" "api_ecs_s3_vault" {
     resources = [
       var.s3_vault_file_storage_arn,
       "${var.s3_vault_file_storage_arn}/*"
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "api_ecs_secrets_manager_runtime" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "secretsmanager:GetSecretValue",
-    ]
-
-    resources = [
-      var.rds_connection_url_secret_arn
     ]
   }
 }

--- a/aws/api/inputs.tf
+++ b/aws/api/inputs.tf
@@ -70,12 +70,6 @@ variable "freshdesk_api_key_secret_arn" {
   sensitive   = true
 }
 
-variable "rds_connection_url_secret_arn" {
-  description = "The RDS connection URL secret used by the ECS task"
-  type        = string
-  sensitive   = true
-}
-
 variable "database_connection_url_secret_arn" {
   description = "ARN of the database URL used to connect to Postgres"
   type        = string

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -5,11 +5,6 @@ data "aws_subnet" "private" {
   id       = each.value
 }
 
-output "database_url_secret_arn" {
-  description = "ARN of the database URL used to connect to Postgres. This is the legacy version that should be replaced by `database_connection_url_secret_arn` when possible."
-  value       = aws_secretsmanager_secret_version.database_url.arn
-}
-
 output "database_connection_url_secret_arn" {
   description = "ARN of the database URL used to connect to Postgres"
   value       = aws_secretsmanager_secret_version.database_connection_url.arn

--- a/aws/rds/secrets.tf
+++ b/aws/rds/secrets.tf
@@ -2,19 +2,6 @@
 # Database secrets
 #
 
-# This secret is legacy and should be removed once `database_connection_url` has fully replaced it
-resource "aws_secretsmanager_secret" "database_url" {
-  # checkov:skip=CKV2_AWS_57: Automatic secret rotation not required
-  name                    = "server-database-url"
-  description             = "Database URL used to connect to Postgres. This secret can be removed once we have migrated all services to Prisma where `database_connection_url` should be used instead."
-  recovery_window_in_days = 0
-}
-
-resource "aws_secretsmanager_secret_version" "database_url" {
-  secret_id     = aws_secretsmanager_secret.database_url.id
-  secret_string = "postgres://${var.rds_db_user}:${var.rds_db_password}@${aws_rds_cluster.forms.endpoint}:5432/${var.rds_db_name}"
-}
-
 resource "aws_secretsmanager_secret" "database_connection_url" {
   # checkov:skip=CKV2_AWS_57: Automatic secret rotation not required
   name                    = "database-connection-url"

--- a/env/cloud/api/terragrunt.hcl
+++ b/env/cloud/api/terragrunt.hcl
@@ -101,7 +101,6 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    database_url_secret_arn            = "arn:aws:secretsmanager:ca-central-1:${local.aws_account_id}:secret:database_url"
     database_connection_url_secret_arn = "arn:aws:secretsmanager:ca-central-1:${local.aws_account_id}:secret:database-connection-url"
   }
 }
@@ -154,7 +153,6 @@ inputs = {
 
   freshdesk_api_key_secret_arn = dependency.secrets.outputs.freshdesk_api_key_secret_arn
 
-  rds_connection_url_secret_arn      = dependency.rds.outputs.database_url_secret_arn
   database_connection_url_secret_arn = dependency.rds.outputs.database_connection_url_secret_arn
 
   sqs_api_audit_log_queue_arn = dependency.sqs.outputs.sqs_api_audit_log_queue_arn


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/6731

- Deletes legacy `server-database-url` secret and its references