### PR TITLE
chore: add db:generate command to AWS CodeBuild for the GC Forms web app

### DIFF
--- a/aws/app/code_pipeline.tf
+++ b/aws/app/code_pipeline.tf
@@ -37,6 +37,7 @@ module "gc_forms_code_pipeline" {
   # Run database migration process
   custom_post_build_commands = [
     "yarn workspaces focus @gcforms/database",
+    "yarn db:generate",
     "yarn db:prod"
   ]
 

--- a/aws/modules/code_pipeline/codebuild.tf
+++ b/aws/modules/code_pipeline/codebuild.tf
@@ -16,7 +16,7 @@ resource "aws_codebuild_project" "ecs_render" {
 
   environment {
     compute_type                = var.build_compute_type == "large" ? "BUILD_GENERAL1_MEDIUM" : "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true


### PR DESCRIPTION
# Summary | Résumé

- Adds `yarn db:generate` command to AWS CodeBuild for the GC Forms web app