### PR TITLE
chore: upgrade WAF IP Blocklist and Athena access logs modules to version 11.2.2

### DIFF
--- a/aws/alarms/athena.tf
+++ b/aws/alarms/athena.tf
@@ -2,7 +2,7 @@
 # Create Athena queries to view the WAF and load balancer access logs
 #
 module "athena" {
-  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=64b19ecfc23025718cd687e24b7115777fd09666" # v10.2.1
+  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=77d83b2f20f6722384cc1bb5d75978d6a6ccff0f" # v11.2.2
 
   athena_bucket_name = module.athena_bucket.s3_bucket_id
 

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -793,7 +793,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_maintenance_mode_uri_paths" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=f3a43458a64fa67459fde4cf5d62cae3e81bc910" # v10.11.4
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=77d83b2f20f6722384cc1bb5d75978d6a6ccff0f" # v11.2.2
 
   service_name                     = "forms_app"
   athena_database_name             = "access_logs"


### PR DESCRIPTION
# Summary | Résumé

- Upgrades `waf_ip_blocklist` module to its latest version 11.2.2
- Upgrades `athena_access_logs` module to its latest version 11.2.2