### PR TITLE
chore: ugprade Aurora ProtgreSQL engine version to 16.11 to match what is now running in Staging and Production

### DIFF
--- a/aws/idp/rds.tf
+++ b/aws/idp/rds.tf
@@ -7,7 +7,7 @@ module "idp_database" {
 
   database_name           = var.zitadel_database_name
   engine                  = "aurora-postgresql"
-  engine_version          = "16.8"
+  engine_version          = "16.11"
   instances               = 1 # TODO: increase for prod loads
   instance_class          = "db.serverless"
   serverless_min_capacity = var.idp_database_min_acu


### PR DESCRIPTION
# Summary | Résumé

Context: there was an AWS automated maintenance that upgraded the engine version

- Upgrades Aurora ProtgreSQL engine version to 16.11 to match what is now running in Staging and Production