### PR TITLE
fix: set log type to FLOW instead of ALERT for the forms flow log group

### DIFF
--- a/aws/network/firewall.tf
+++ b/aws/network/firewall.tf
@@ -93,7 +93,7 @@ resource "aws_networkfirewall_logging_configuration" "forms_flow" {
         logGroup = aws_cloudwatch_log_group.forms_flow.name
       }
       log_destination_type = "CloudWatchLogs"
-      log_type             = "ALERT"
+      log_type             = "FLOW"
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

- Fixes log type for the forms flow log group