### PR TITLE
chore: set ECS platform version to 1.4.0 to prepare for the switch to AWS CodeDeploy

### DIFF
--- a/aws/api/ecs.tf
+++ b/aws/api/ecs.tf
@@ -39,7 +39,7 @@ locals {
 }
 
 module "api_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=825c15a16d794bd878e0d11555c0abe6f481f29e" # v10.10.2
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=b78d45257e74dab02c8f100d0023aebfee417720" # v11.3.0
 
   create_cluster = false
   cluster_name   = var.ecs_cluster_name
@@ -51,6 +51,8 @@ module "api_ecs" {
   # This gives precedence to the `cds-snc/forms-api` repo's CI/CD task deployments
   # and prevents the Terraform from undoing deployments.
   service_use_latest_task_def = true
+
+  platform_version = "1.4.0"
 
   # Scaling
   enable_autoscaling       = true


### PR DESCRIPTION
# Summary | Résumé

- Upgrades CDS ECS Terraform module to version `11.3.0` to support upcoming AWS CodeDeploy integration
- Updates ECS configuration to set `platform_version` to `1.4.0` instead of `LATEST` (by default) to avoid Terraform deployment failure when introducing AWS CodeDeploy later on. This is due to AWS automatically modifying this property when the deployment controller is set to `CODE_DEPLOY`.

Note: this needs to be merged and deployed to Production before https://github.com/cds-snc/forms-terraform/pull/1333 gets in to avoid getting Terraform apply errors like the one I mentioned earlier but also because we have introduced new changes in the CDS ECS Terraform module which requires an existing resource to be moved to a new one.