### PR TITLE
chore: remove unused terragrunt input (forgot to remove it in previous commit)

### DIFF
--- a/env/cloud/lambdas/terragrunt.hcl
+++ b/env/cloud/lambdas/terragrunt.hcl
@@ -209,7 +209,6 @@ inputs = {
   ecs_iam_role_arn                         = local.env == "development" ? null : dependency.app.outputs.ecs_iam_role_arn
   ecs_iam_forms_secrets_manager_policy_arn = dependency.app.outputs.ecs_iam_forms_secrets_manager_policy_arn
   ecs_iam_forms_kms_policy_arn             = dependency.app.outputs.ecs_iam_forms_kms_policy_arn
-  ecs_iam_forms_s3_policy_arn              = dependency.app.outputs.ecs_iam_forms_s3_policy_arn
   ecs_iam_forms_dynamodb_policy_arn        = dependency.app.outputs.ecs_iam_forms_dynamodb_policy_arn
   ecs_iam_forms_audit_logs_arn             = dependency.app.outputs.ecs_iam_forms_audit_logs_policy_arn
   ecs_iam_forms_sqs_policy_arn             = dependency.app.outputs.ecs_iam_forms_sqs_policy_arn


### PR DESCRIPTION
# Summary | Résumé

- Removes unused terragrunt input (forgot to remove it in previous PR)