### PR TITLE
chore: remove legacy code deploy IAM role

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -230,31 +230,6 @@ data "aws_iam_policy_document" "forms_audit_logs" {
 }
 
 #
-# IAM - Codedeploy
-#
-resource "aws_iam_role" "codedeploy" {
-  name               = "codedeploy"
-  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_codedeploy.json
-  path               = "/"
-}
-
-data "aws_iam_policy_document" "assume_role_policy_codedeploy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["codedeploy.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "codedeploy" {
-  role       = aws_iam_role.codedeploy.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
-}
-
-#
 # IAM cognito
 #
 


### PR DESCRIPTION
# Summary | Résumé

- Removes legacy AWS CodeDeploy IAM role (it is now replaced by the one created within the GC Forms CodePipeline module)