### PR TITLE
chore: add HTTP 429 to WAF IP Blocklist skip list

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -801,7 +801,7 @@ module "waf_ip_blocklist" {
   athena_query_source_bucket       = var.cbs_satellite_bucket_name
   athena_workgroup_name            = "primary"
   waf_rule_ids_skip                = ["BlockLargeRequests", "RateLimitersRuleGroup", "BlockedIPv4"]
-  lb_status_code_skip              = ["404"]
+  lb_status_code_skip              = ["404", "429"]
   athena_lb_table_name             = "lb_logs"
   query_lb                         = true
   query_waf                        = false


### PR DESCRIPTION
# Summary | Résumé

Context: while using the API to download and confirm responses on multiple forms being flagged by the Nagware I noticed that I had been blocklisted because of all the HTTP 429 returned by the rate limiter.

- Adds HTTP 429 to skip list of WAF IP Blocklist