### PR TITLE
fix: rework source path encoding when copying file between S3 buckets

### DIFF
--- a/lambda-code/reliability/src/lib/s3FileInput.ts
+++ b/lambda-code/reliability/src/lib/s3FileInput.ts
@@ -78,12 +78,14 @@ export async function retrieveFilesFromReliabilityStorage(filePaths: string[]) {
 export async function copyFilesFromReliabilityToVaultStorage(filePaths: string[]) {
   try {
     for (const filePath of filePaths) {
+      const lastSlashIndex = filePath.lastIndexOf("/");
+      const filePathMinusFileName = filePath.slice(0, lastSlashIndex);
+      const fileName = filePath.slice(lastSlashIndex + 1);
+
       await s3Client.send(
         new CopyObjectCommand({
           Bucket: vaultBucketName,
-          CopySource: [reliabilityBucketName, filePath.split("/").map(encodeURIComponent)]
-            .flat()
-            .join("/"),
+          CopySource: `${reliabilityBucketName}/${filePathMinusFileName}/${encodeURIComponent(fileName)}`,
           Key: filePath,
         })
       );

--- a/lambda-code/reliability/src/lib/s3FileInput.ts
+++ b/lambda-code/reliability/src/lib/s3FileInput.ts
@@ -78,13 +78,15 @@ export async function retrieveFilesFromReliabilityStorage(filePaths: string[]) {
 export async function copyFilesFromReliabilityToVaultStorage(filePaths: string[]) {
   try {
     for (const filePath of filePaths) {
-      const commandInput = {
-        Bucket: vaultBucketName,
-        CopySource: encodeURI(`${reliabilityBucketName}/${filePath}`),
-        Key: filePath,
-      };
-
-      await s3Client.send(new CopyObjectCommand(commandInput));
+      await s3Client.send(
+        new CopyObjectCommand({
+          Bucket: vaultBucketName,
+          CopySource: [reliabilityBucketName, filePath.split("/").map(encodeURIComponent)]
+            .flat()
+            .join("/"),
+          Key: filePath,
+        })
+      );
     }
   } catch (error) {
     console.error(error);

--- a/lambda-code/response-archiver/src/main.ts
+++ b/lambda-code/response-archiver/src/main.ts
@@ -169,15 +169,14 @@ async function archiveFileAttachments(
 ): Promise<void> {
   try {
     const copyObjectRequests = fileAttachments.map((attachment) => {
+      const lastSlashIndex = attachment.path.lastIndexOf("/");
+      const filePathMinusFileName = attachment.path.slice(0, lastSlashIndex);
+      const fileName = attachment.path.slice(lastSlashIndex + 1);
+
       return s3Client.send(
         new CopyObjectCommand({
           Bucket: ARCHIVING_S3_BUCKET,
-          CopySource: [
-            VAULT_FILE_STORAGE_S3_BUCKET,
-            attachment.path.split("/").map(encodeURIComponent),
-          ]
-            .flat()
-            .join("/"),
+          CopySource: `${VAULT_FILE_STORAGE_S3_BUCKET}/${filePathMinusFileName}/${encodeURIComponent(fileName)}`,
           Key: `${new Date()
             .toISOString()
             .slice(0, 10)}/${formId}/${submissionId}/${submissionId}_${attachment.name}`,

--- a/lambda-code/response-archiver/src/main.ts
+++ b/lambda-code/response-archiver/src/main.ts
@@ -169,16 +169,18 @@ async function archiveFileAttachments(
 ): Promise<void> {
   try {
     const copyObjectRequests = fileAttachments.map((attachment) => {
-      const fromUri = `${attachment.path}`;
-      const toUri = `${new Date()
-        .toISOString()
-        .slice(0, 10)}/${formId}/${submissionId}/${submissionId}_${attachment.name}`;
-
       return s3Client.send(
         new CopyObjectCommand({
           Bucket: ARCHIVING_S3_BUCKET,
-          CopySource: encodeURI(`${VAULT_FILE_STORAGE_S3_BUCKET}/${fromUri}`),
-          Key: toUri,
+          CopySource: [
+            VAULT_FILE_STORAGE_S3_BUCKET,
+            attachment.path.split("/").map(encodeURIComponent),
+          ]
+            .flat()
+            .join("/"),
+          Key: `${new Date()
+            .toISOString()
+            .slice(0, 10)}/${formId}/${submissionId}/${submissionId}_${attachment.name}`,
         })
       );
     });


### PR DESCRIPTION
# Summary | Résumé

- Reworks encoding of `CopySource` value when copying objects between S3 buckets

Note: I was not sure if this solution would work in case a file name contained a `/` but I tested it and for some reason, even though they appear to be accepted if we look at https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines, S3 automatically replaces `/` with `:`. This kind of makes sense because S3 uses `/` to organize objects by "folders" but I have not found anything mentioning this in their documentation.
Because we use the generated signed URL data to identify an S3 object within the actual submission data we don't have anything else to handle because the auto renaming of `/` in `:` will happen behind the scenes.

# Tests

- Using a form that has file input components, try submitting files that have special characters in their names like "+", "-", "/"