### PR TITLE
chore: delete legacy StatusCreatedAt Vault GSI

### DIFF
--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -57,12 +57,6 @@ resource "aws_dynamodb_global_secondary_index" "reliability_queue_has_file_keys_
   }
 }
 
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.reliability_queue_has_file_keys_by_created_at
-  id = "${aws_dynamodb_table.reliability_queue.name},HasFileKeysByCreatedAt"
-}
-
 resource "aws_dynamodb_table" "vault" {
   # checkov:skip=CKV_AWS_28: 'point in time recovery' is set to true for staging and production
   name                        = "Vault"
@@ -100,34 +94,6 @@ resource "aws_dynamodb_table" "vault" {
   lifecycle {
     ignore_changes = [global_secondary_index]
   }
-}
-
-resource "aws_dynamodb_global_secondary_index" "vault_status_created_at" {
-  index_name = "StatusCreatedAt"
-  table_name = aws_dynamodb_table.vault.name
-
-  key_schema {
-    attribute_name = "FormID"
-    attribute_type = "S"
-    key_type       = "HASH"
-  }
-
-  key_schema {
-    attribute_name = "Status#CreatedAt"
-    attribute_type = "S"
-    key_type       = "RANGE"
-  }
-
-  projection {
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["CreatedAt", "Name"]
-  }
-}
-
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.vault_status_created_at
-  id = "${aws_dynamodb_table.vault.name},StatusCreatedAt"
 }
 
 resource "aws_dynamodb_global_secondary_index" "vault_status_created_at_v2" {
@@ -217,12 +183,6 @@ resource "aws_dynamodb_global_secondary_index" "audit_logs_user_by_time" {
   }
 }
 
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.audit_logs_user_by_time
-  id = "${aws_dynamodb_table.audit_logs.name},UserByTime"
-}
-
 resource "aws_dynamodb_global_secondary_index" "audit_logs_status_by_timestamp" {
   index_name = "StatusByTimestamp"
   table_name = aws_dynamodb_table.audit_logs.name
@@ -244,12 +204,6 @@ resource "aws_dynamodb_global_secondary_index" "audit_logs_status_by_timestamp" 
   }
 }
 
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.audit_logs_status_by_timestamp
-  id = "${aws_dynamodb_table.audit_logs.name},StatusByTimestamp"
-}
-
 resource "aws_dynamodb_global_secondary_index" "audit_logs_subject_by_timestamp" {
   index_name = "SubjectByTimestamp"
   table_name = aws_dynamodb_table.audit_logs.name
@@ -269,12 +223,6 @@ resource "aws_dynamodb_global_secondary_index" "audit_logs_subject_by_timestamp"
   projection {
     projection_type = "KEYS_ONLY"
   }
-}
-
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.audit_logs_subject_by_timestamp
-  id = "${aws_dynamodb_table.audit_logs.name},SubjectByTimestamp"
 }
 
 resource "aws_dynamodb_table" "api_audit_logs" {
@@ -342,12 +290,6 @@ resource "aws_dynamodb_global_secondary_index" "api_audit_logs_user_by_time" {
   }
 }
 
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.api_audit_logs_user_by_time
-  id = "${aws_dynamodb_table.api_audit_logs.name},UserByTime"
-}
-
 resource "aws_dynamodb_global_secondary_index" "api_audit_logs_status_by_timestamp" {
   index_name = "StatusByTimestamp"
   table_name = aws_dynamodb_table.api_audit_logs.name
@@ -369,12 +311,6 @@ resource "aws_dynamodb_global_secondary_index" "api_audit_logs_status_by_timesta
   }
 }
 
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.api_audit_logs_status_by_timestamp
-  id = "${aws_dynamodb_table.api_audit_logs.name},StatusByTimestamp"
-}
-
 resource "aws_dynamodb_global_secondary_index" "api_audit_logs_subject_by_timestamp" {
   index_name = "SubjectByTimestamp"
   table_name = aws_dynamodb_table.api_audit_logs.name
@@ -394,10 +330,4 @@ resource "aws_dynamodb_global_secondary_index" "api_audit_logs_subject_by_timest
   projection {
     projection_type = "KEYS_ONLY"
   }
-}
-
-# Should be deleted once this code has been applied to both Staging and Production
-import {
-  to = aws_dynamodb_global_secondary_index.api_audit_logs_subject_by_timestamp
-  id = "${aws_dynamodb_table.api_audit_logs.name},SubjectByTimestamp"
 }


### PR DESCRIPTION
# This can only be merged once we have released both the Web App and the API with the new index in use. This implies that the infra was also previously released so that the new index exists in Production

# Summary | Résumé

- Deletes legacy `StatusCreatedAt` Vault GSI
- Deletes Terraform import blocks for the DynamoDB GSI migration to standalone resource