### PR TITLE
chore: add formId to Md5 checksum error message

### DIFF
--- a/lambda-code/submission/src/lib/fileUpload.ts
+++ b/lambda-code/submission/src/lib/fileUpload.ts
@@ -124,7 +124,7 @@ const extractFileInputs = (originalObject: Record<string, unknown>) => {
 
 const generateSignedUrl = async (key: string, contentMD5: string) => {
   if (!contentMD5) {
-    throw new Error(`Content MD5 checksum is required to generate signed URL. key: ${key}`);
+    throw new Error(`Content MD5 checksum is required to generate signed URL. $_key: ${key}`);
   }
 
   const base64ContentMD5 = Buffer.from(contentMD5, "hex").toString("base64");

--- a/lambda-code/submission/src/lib/fileUpload.ts
+++ b/lambda-code/submission/src/lib/fileUpload.ts
@@ -56,6 +56,7 @@ export function findAttachedFileReferencesInSubmissionResponses(
 
 export async function generateFileAccessKeysAndUploadURLs(
   submissionId: string,
+  formId: string,
   fileReferences: FileReference[],
   fileChecksums: Record<string, string>
 ): Promise<{ fileAccessKeys: string[]; fileUploadURLs: Record<string, PresignedPost> }> {
@@ -68,7 +69,7 @@ export async function generateFileAccessKeysAndUploadURLs(
       const fileAccessKey = `${keyStartingPath}/${fileReference.id}/${fileReference.name}`;
       const contentMD5 = fileChecksums?.[fileReference.id];
 
-      const fileUploadURL = await generateSignedUrl(fileAccessKey, contentMD5);
+      const fileUploadURL = await generateSignedUrl(fileAccessKey, contentMD5, formId);
       return { id: fileReference.id, fileAccessKey, fileUploadURL };
     })
   );
@@ -122,9 +123,9 @@ const extractFileInputs = (originalObject: Record<string, unknown>) => {
   return fileInputList;
 };
 
-const generateSignedUrl = async (key: string, contentMD5: string) => {
+const generateSignedUrl = async (key: string, contentMD5: string, formId: string) => {
   if (!contentMD5) {
-    throw new Error(`Content MD5 checksum is required to generate signed URL. $_key: ${key}`);
+    throw new Error(`Content MD5 checksum is required to generate signed URL. formId: ${formId}, key: ${key}`);
   }
 
   const base64ContentMD5 = Buffer.from(contentMD5, "hex").toString("base64");

--- a/lambda-code/submission/src/lib/fileUpload.ts
+++ b/lambda-code/submission/src/lib/fileUpload.ts
@@ -56,7 +56,6 @@ export function findAttachedFileReferencesInSubmissionResponses(
 
 export async function generateFileAccessKeysAndUploadURLs(
   submissionId: string,
-  formId: string,
   fileReferences: FileReference[],
   fileChecksums: Record<string, string>
 ): Promise<{ fileAccessKeys: string[]; fileUploadURLs: Record<string, PresignedPost> }> {
@@ -69,7 +68,7 @@ export async function generateFileAccessKeysAndUploadURLs(
       const fileAccessKey = `${keyStartingPath}/${fileReference.id}/${fileReference.name}`;
       const contentMD5 = fileChecksums?.[fileReference.id];
 
-      const fileUploadURL = await generateSignedUrl(fileAccessKey, contentMD5, formId);
+      const fileUploadURL = await generateSignedUrl(fileAccessKey, contentMD5);
       return { id: fileReference.id, fileAccessKey, fileUploadURL };
     })
   );
@@ -123,9 +122,9 @@ const extractFileInputs = (originalObject: Record<string, unknown>) => {
   return fileInputList;
 };
 
-const generateSignedUrl = async (key: string, contentMD5: string, formId: string) => {
+const generateSignedUrl = async (key: string, contentMD5: string) => {
   if (!contentMD5) {
-    throw new Error(`Content MD5 checksum is required to generate signed URL. formId: ${formId}, key: ${key}`);
+    throw new Error(`Content MD5 checksum is required to generate signed URL. key: ${key}`);
   }
 
   const base64ContentMD5 = Buffer.from(contentMD5, "hex").toString("base64");

--- a/lambda-code/submission/src/main.ts
+++ b/lambda-code/submission/src/main.ts
@@ -51,7 +51,6 @@ export const handler: Handler = async (submission: AnyObject) => {
 
       const { fileAccessKeys, fileUploadURLs } = await generateFileAccessKeysAndUploadURLs(
         submissionId,
-        submission.formID,
         attachedFileReferences,
         fileChecksums
       );
@@ -93,8 +92,8 @@ export const handler: Handler = async (submission: AnyObject) => {
         severity: "1", // this will trigger an alert to on-call team
         status: "failed",
         submissionId: submissionId,
+        formId: submission.formID ?? "n/a",
         msg: (error as Error).message,
-        details: JSON.stringify(error),
       })
     );
 

--- a/lambda-code/submission/src/main.ts
+++ b/lambda-code/submission/src/main.ts
@@ -51,6 +51,7 @@ export const handler: Handler = async (submission: AnyObject) => {
 
       const { fileAccessKeys, fileUploadURLs } = await generateFileAccessKeysAndUploadURLs(
         submissionId,
+        submission.formID,
         attachedFileReferences,
         fileChecksums
       );


### PR DESCRIPTION
# Summary | Résumé

This PR adds the formId to the Md5 checksum error message to help speed up on call trouble shooting.