### PR TITLE
chore: remove unused environment variable in Notification lambda

### DIFF
--- a/aws/lambdas/notification.tf
+++ b/aws/lambdas/notification.tf
@@ -20,7 +20,6 @@ resource "aws_lambda_function" "notification" {
       REGION                           = var.region
       DYNAMODB_NOTIFICATION_TABLE_NAME = var.dynamodb_notification_table_name
       NOTIFY_API_KEY                   = var.notify_api_key_secret_arn
-      TEMPLATE_ID                      = var.gc_template_id
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

- Removes unused `TEMPLATE_ID` environment variable in Notification lambda