### PR TITLE
chore: enable Terraform S3 native-state locking

### DIFF
--- a/env/root.hcl
+++ b/env/root.hcl
@@ -24,12 +24,12 @@ generate "backend_remote_state" {
   contents  = <<EOF
 terraform {
   backend "s3" {
+    region         = "ca-central-1"
     encrypt        = true
     use_path_style = true
     bucket         = "forms-${local.env == "development" ? local.account_id : local.env}-tfstate"
-    dynamodb_table = "tfstate-lock"
-    region         = "ca-central-1"
     key            = "${path_relative_to_include("root")}/terraform.tfstate"
+    use_lockfile   = true
   }
 }
 EOF

--- a/local_dev_files/build_dev_env.sh
+++ b/local_dev_files/build_dev_env.sh
@@ -34,26 +34,11 @@ else
     --region ca-central-1 \
     --create-bucket-configuration LocationConstraint=ca-central-1 \
     >/dev/null
+
   # encrypt the bucket
   aws s3api put-bucket-encryption \
     --bucket forms-${AWS_ACCOUNT_ID}-tfstate \
     --server-side-encryption-configuration "{\"Rules\": [{\"ApplyServerSideEncryptionByDefault\":{\"SSEAlgorithm\": \"AES256\"}}]}" \
-    >/dev/null
-fi
-
-if aws dynamodb list-tables | grep -q "tfstate-lock"; then
-  printf "${yellowColor}=> Terraform Lock DynamoDB table exists...${reset}\n"
-else
-  printf "${yellowColor}=> Detected fresh AWS account instance.  Setting up Terraform Lock table...${reset}\n"
-
-  fresh_instance=true
-
-  # create DynamoDB table for Terraform state locking
-  aws dynamodb create-table \
-    --table-name tfstate-lock \
-    --attribute-definitions AttributeName=LockID,AttributeType=S \
-    --key-schema AttributeName=LockID,KeyType=HASH \
-    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
     >/dev/null
 fi
 

--- a/local_dev_files/refresh_dev_state.sh
+++ b/local_dev_files/refresh_dev_state.sh
@@ -19,8 +19,6 @@ tfswitch 1.15.6
 
 export TG_PROVIDER_CACHE=1
 
-
-
 if aws s3api list-buckets | grep -q "forms-${AWS_ACCOUNT_ID}-tfstate"; then
   printf "${greenColor}=> Terraform State Bucket exists...${reset}\n"
 else  
@@ -29,19 +27,11 @@ else
   exit 0
 fi
 
-if aws dynamodb list-tables | grep -q "tfstate-lock"; then
-  printf "${greenColor}=> Terraform Lock DynamoDB table exists...${reset}\n"
-else
-  printf "${yellowColor}=> Terrafrom Lock tables do not exist.  Broken install need to be fixed manually.${reset}\n"
-  exit 0
-fi
-
 printf "${yellowColor}=> Clearing local files...${reset}\n"
 for dir in $basedir/env/cloud/*/; do
   rm -rf "${dir}.terragrunt-cache"
   rm -f "${dir}.terraform.lock.hcl"
 done
-
 
 if [ -z "$MODULE_NAME" ]; then
   printf "${greenColor}=> Refreshing All Terragrunt Modules${reset}\n"
@@ -69,8 +59,4 @@ else
   exit 0
 fi
 
-# Print out the time it took to initialize the infrastructure
-
-
 printf "${greenColor} State refreshed"
-


### PR DESCRIPTION
# Summary | Résumé

Context: https://medium.com/@mohamed.mourad/terraform-state-locking-migrating-from-dynamodb-to-native-s3-locking-2a49ef2668ac

- Migrates Terraform state locking from DynamoDB to S3

# Manual steps once ready to merge (will have to be done in Production as well)
- Enable versioning on Terraform S3 bucket (done in Staging)
- Delete legacy `production` sub directory inside Terraform S3 bucket. Only `cloud` folder is being used (done in Staging)
- Add `ssc_cbrid` tag on Terraform related resources (S3) (done in Staging)
- Delete DynamoDB `tfstate-lock` table entries related to forms infra modules once new S3 state locking solution is released