### PR TITLE
chore: add missing lifecycle block about image_uri in Notification lambda configuration

### DIFF
--- a/aws/lambdas/notification.tf
+++ b/aws/lambdas/notification.tf
@@ -31,6 +31,10 @@ resource "aws_lambda_function" "notification" {
   tracing_config {
     mode = "Active"
   }
+
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
 }
 
 resource "aws_cloudwatch_log_group" "notification" {


### PR DESCRIPTION
# Summary | Résumé

- Adds missing `lifecycle` block to Notification lambda configuration in order to prevent Terrafrom from changing the `image_uri` resource property (which is handled by the deployment Github action)