### PR TITLE
fix: handle recently deleted form when processing submissions

### DIFF
--- a/lambda-code/reliability/src/lib/dataLayer.ts
+++ b/lambda-code/reliability/src/lib/dataLayer.ts
@@ -90,6 +90,30 @@ export async function notifyProcessed(submissionID: string) {
   }
 }
 
+export async function markSubmissionForDeletionIn30days(submissionId: string) {
+  try {
+    return await db.send(
+      new UpdateCommand({
+        TableName: "ReliabilityQueue",
+        Key: {
+          SubmissionID: submissionId,
+        },
+        UpdateExpression: "SET #ttl = :ttl",
+        ExpressionAttributeNames: {
+          "#ttl": "TTL",
+        },
+        ExpressionAttributeValues: {
+          ":ttl": Math.floor(Date.now() / 1000) + 2592000, // expire after 30 days
+        },
+        ReturnValues: "NONE",
+      })
+    );
+  } catch (error) {
+    console.error(error);
+    throw new Error(`Error updating TTL for submission ${submissionId}`);
+  }
+}
+
 const generateRandomString = (length: number = 5) => {
   const letters = "abcdefghijklmnopqrstuvwxyz";
   const characters = letters + "0123456789";

--- a/lambda-code/reliability/src/lib/templates.ts
+++ b/lambda-code/reliability/src/lib/templates.ts
@@ -8,6 +8,7 @@ export type TemplateInfo = {
     emailSubjectEn: string | null;
     emailSubjectFr: string | null;
   };
+  isFormArchived: boolean;
 };
 
 export async function getTemplateInfo(formID: string): Promise<TemplateInfo | null> {
@@ -15,6 +16,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo | nu
     const template = await prisma.template.findUnique({
       where: {
         id: formID,
+        ttl: { not: undefined }, // Because the database package adds a default filter on TTL (if none specified) we want to make sure we can also retrieve archived templates
       },
       select: {
         jsonConfig: true,
@@ -25,6 +27,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo | nu
             emailSubjectFr: true,
           },
         },
+        ttl: true,
       },
     });
 
@@ -35,6 +38,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo | nu
     return {
       formConfig: template.jsonConfig as FormProperties,
       ...(template.deliveryOption && { deliveryOption: template.deliveryOption }),
+      isFormArchived: template.ttl !== null ? true : false,
     };
   } catch (error) {
     console.warn(

--- a/lambda-code/reliability/src/main.ts
+++ b/lambda-code/reliability/src/main.ts
@@ -65,6 +65,8 @@ const messageProcessor = async ({
           msg: "Submission will not be processed because it could not be found in the database or has already been processed.",
         })
       );
+
+      return { status: true, messageId };
     }
 
     if (formID === null || typeof formID === "undefined") {

--- a/lambda-code/reliability/src/main.ts
+++ b/lambda-code/reliability/src/main.ts
@@ -2,7 +2,7 @@ import { Handler, SQSEvent } from "aws-lambda";
 import sendToNotify from "@lib/notifyProcessing.js";
 import sendToVault from "@lib/vaultProcessing.js";
 import { getTemplateInfo } from "@lib/templates.js";
-import { getSubmission } from "@lib/dataLayer.js";
+import { getSubmission, markSubmissionForDeletionIn30days } from "@lib/dataLayer.js";
 import { getAllSubmissionAttachmentScanStatuses } from "@lib/file_scanning.js";
 import { addAllSubmissionAttachmentsChecksums } from "@lib/file_checksum.js";
 
@@ -70,33 +70,42 @@ const messageProcessor = async ({
     }
 
     if (formID === null || typeof formID === "undefined") {
-      console.error(
-        JSON.stringify({
-          level: "error",
-          severity: "2",
-          msg: `Can't process submission because of null or undefined formID.`,
-        })
-      );
-      throw new Error(`Required formID parameter is null or undefined.`);
+      throw new Error(`Form identifier is null or undefined.`);
     }
 
     const templateInfo = await getTemplateInfo(formID);
 
-    if (templateInfo !== null && templateInfo.formConfig !== null) {
-      // Add form config back to submission to be processed
-      formSubmission.form = templateInfo.formConfig;
-      // add delivery option to formsubmission
-      formSubmission.deliveryOption = templateInfo.deliveryOption;
-    } else {
-      console.error(
+    if (templateInfo === null) {
+      throw new Error(`Form ${formID} does not exist in the database.`);
+    }
+
+    if (templateInfo.isFormArchived) {
+      let didSucceedMarkingSubmissionAsProcessed = true;
+
+      try {
+        await markSubmissionForDeletionIn30days(submissionID);
+      } catch (error) {
+        didSucceedMarkingSubmissionAsProcessed = false;
+      }
+
+      // Ack and remove message from queue if the form exist but has been archived
+      console.warn(
         JSON.stringify({
-          level: "error",
-          severity: "2",
-          msg: `No associated form template (ID: ${formID}) exist in the database.`,
+          level: "warn",
+          status: "success",
+          submissionId: submissionID,
+          sendReceipt: sendReceipt,
+          msg: `Submission will not be processed because the associated form ${formID} has been archived. Submission ${didSucceedMarkingSubmissionAsProcessed ? "has been" : "failed to be"} marked for deletion in 30 days.`,
         })
       );
-      throw new Error(`No associated form template (ID: ${formID}) exist in the database.`);
+
+      return { status: true, messageId };
     }
+
+    // Add form config back to submission to be processed
+    formSubmission.form = templateInfo.formConfig;
+    // add delivery option to formsubmission
+    formSubmission.deliveryOption = templateInfo.deliveryOption;
 
     const submissionAttachmentsWithScanStatuses = await getAllSubmissionAttachmentScanStatuses(
       fileKeys
@@ -125,7 +134,6 @@ const messageProcessor = async ({
        form - Complete Form Template
        deliveryOption - (optional) Will be present if user wants to receive form responses by email (`{ emailAddress: string; emailSubjectEn?: string; emailSubjectFr?: string }`)
     */
-
     if (formSubmission.deliveryOption) {
       await sendToNotify(
         submissionID,
@@ -135,7 +143,6 @@ const messageProcessor = async ({
         language,
         createdAt
       );
-      return { status: true, messageId };
     } else {
       await sendToVault(
         submissionID,
@@ -150,8 +157,9 @@ const messageProcessor = async ({
         formSubmissionHash,
         notificationId
       );
-      return { status: true, messageId };
     }
+
+    return { status: true, messageId };
   } catch (error) {
     console.warn(
       JSON.stringify({


### PR DESCRIPTION
# Summary | Résumé

- Puts back an early `return` statement (I missed during review) in the Reliability lambda (was removed in https://github.com/cds-snc/forms-terraform/pull/1158)
- Enhances Reliability lambda to handle submissions being processed after the form was archived. Will flag in Slack so we can act on it (if we want to) as said submission will be deleted 30 days after the detection.
_Root cause behind this change is that we used to process submissions as long as we could find the form in the database (which was the case because a form is entirely deleted 30 days after it was archived) but with the recent introduction of the GC Forms `database` package we broke it due to a default `ttl` filtering being added on every `Template` query in order to return non archived form only._
- Removes a couple of unnecessary `console.warn` logs. The global warning sent by the Reliability lambda is enough as it already provides the reason why something failed in the process.