### PR TITLE
fix: handle archived forms in Nagware lambda

### DIFF
--- a/lambda-code/nagware/src/lib/templates.ts
+++ b/lambda-code/nagware/src/lib/templates.ts
@@ -8,6 +8,7 @@ export type TemplateInfo = {
     email: string;
   }[];
   isPublished: boolean;
+  isFormArchived: boolean;
 };
 
 export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
@@ -15,6 +16,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
     const template = await prisma.template.findUnique({
       where: {
         id: formID,
+        ttl: { not: undefined }, // Because the database package adds a default filter on TTL (if none specified) we want to make sure we can also retrieve archived templates
       },
       select: {
         name: true,
@@ -26,6 +28,7 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
             email: true,
           },
         },
+        ttl: true,
       },
     });
 
@@ -38,7 +41,12 @@ export async function getTemplateInfo(formID: string): Promise<TemplateInfo> {
     // Note we use || instead of ?? to allow for empty strings
     const formName = template.name || `${formProperties.titleEn} - ${formProperties.titleFr}`;
 
-    return { formName, owners: template.users, isPublished: template.isPublished };
+    return {
+      formName,
+      owners: template.users,
+      isPublished: template.isPublished,
+      isFormArchived: template.ttl !== null ? true : false,
+    };
   } catch (error) {
     console.error(
       JSON.stringify({

--- a/lambda-code/nagware/src/main.ts
+++ b/lambda-code/nagware/src/main.ts
@@ -77,21 +77,32 @@ async function nagOrDelete(
       const templateInfo = await getTemplateInfo(formResponse.formID);
 
       if (templateInfo.isPublished) {
-        if (notificationSettings.shouldSendEmail) {
-          for (const owner of templateInfo.owners) {
-            await notifyFormOwner(formResponse.formID, templateInfo.formName, owner.email);
+        if (templateInfo.isFormArchived === false) {
+          // Only send Nagware emails is form is published and not archived
+          if (notificationSettings.shouldSendEmail) {
+            for (const owner of templateInfo.owners) {
+              await notifyFormOwner(formResponse.formID, templateInfo.formName, owner.email);
+            }
           }
-        }
 
-        logNagwareDetection(
-          {
-            formTimestamp: formResponse.createdAt,
-            formId: formResponse.formID,
-            formName: templateInfo.formName,
-            owners: templateInfo.owners,
-          },
-          notificationSettings.shouldSendSlackNotification
-        );
+          logNagwareDetection(
+            {
+              formTimestamp: formResponse.createdAt,
+              formId: formResponse.formID,
+              formName: templateInfo.formName,
+              owners: templateInfo.owners,
+            },
+            notificationSettings.shouldSendSlackNotification
+          );
+        } else {
+          // If a form is published but also archived we should let the team know about it so that they can act on it (either investigate a possible issue with the app/infra flow or delete orphan submissions)
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              msg: `Nagware detected submission(s) on a form (${formResponse.formID}) that is published but archived.`,
+            })
+          );
+        }
       } else {
         // Delete form response if form is not published and older than 28 days
         await deleteOldTestResponses(formResponse.formID);


### PR DESCRIPTION
# Summary | Résumé

Context: currently investigating/working on errors like https://gcdigital.slack.com/archives/C05G766KW49/p1784196115894829

- Adds support for archived forms in Nagware lambda. If we detect a published but archived form we will send a message on Slack to let the team investigate and decide whether "orphan" submissions should be deleted. This is not something that should happen anymore now that we have implemented https://github.com/cds-snc/forms-terraform/pull/1400